### PR TITLE
integration with nvim-completion-manager, use callback style.  #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ More recordings at <https://github.com/autozimu/images/tree/master/LanguageClien
 # Features
 
 - Non-blocking asynchronous calls.
-- [Sensible completion](https://github.com/autozimu/images/tree/master/LanguageClient-neovim#completion). Integrated with [deoplete](https://github.com/Shougo/deoplete.nvim).
+- [Sensible completion](https://github.com/autozimu/images/tree/master/LanguageClient-neovim#completion).
+  Integrated with [deoplete](https://github.com/Shougo/deoplete.nvim) 
+  or [nvim-completion-manager](https://github.com/roxma/nvim-completion-manager).
 - [Realtime diagnostics/compiler/lint message.](https://github.com/autozimu/images/tree/master/LanguageClient-neovim#diagnostics)
 - [Rename.](https://github.com/autozimu/images/tree/master/LanguageClient-neovim#rename)
 - [Get identifer info.](https://github.com/autozimu/images/tree/master/LanguageClient-neovim#hover)

--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -611,7 +611,7 @@ call fzf#run(fzf#wrap({{
         return items
 
     # this method is called by nvim-completion-manager framework
-    @neovim.function("LanguageClient_completionManager_refresh")
+    @neovim.function("LanguageClient_completionManager_refresh",sync=False)
     def completionManager_refresh(self, args) -> None:
         if not self.alive():
             return


### PR DESCRIPTION
Tested on my machine using [PHP language server](https://github.com/felixfbecker/php-language-server)

```vim
let g:LanguageClient_serverCommands = {
    \ 'php': ['php', 'path/to/language/server/base/vendor/felixfbecker/language-server/bin/php-language-server.php'],
    \ }
```