### PR TITLE
[Suggestion] Batch textDocument_didChange 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags
+__pycache__

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![rename](https://raw.github.com/autozimu/images/master/LanguageClient-neovim/rename.gif)
 
-More recordings at <https://github.com/autozimu/images/tree/master/LanguageClient-neovim>.
+More recordings at [Updates, screenshots & GIFs](https://github.com/autozimu/LanguageClient-neovim/issues/35).
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) support for [neovim](https://github.com/neovim/neovim).
 
-![rename](https://raw.github.com/autozimu/images/master/LanguageClient-neovim/rename.gif)
+![rename](https://cloud.githubusercontent.com/assets/1453551/24251636/2e73a1cc-0fb1-11e7-8a5e-3332e6a5f424.gif)
 
 More recordings at [Updates, screenshots & GIFs](https://github.com/autozimu/LanguageClient-neovim/issues/35).
 

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -90,6 +90,17 @@ Whether to keep sign column open even if there is no diagnostics.
 
 Default: 1
 
+2.4 g:LanguageClient_changeThrottle      *g:LanguageClient_changeThrottle*
+
+Interval in seconds during which textDocument_didChange is suppressed. For exmaple: >
+
+    let g:LanguageClient_changeThrottle = 0.5
+
+This will make LanguageClient pause 0.5 second to send text changes to
+server after one textDocument_didChange is sent.
+
+Default: 0. No throttling.
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 

--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -51,7 +51,7 @@ class LanguageClient:
         type(self)._instance = self
         self.serverCommands = nvim.eval(
                 "get(g:, 'LanguageClient_serverCommands', {})")
-        self.skip_threshold = 0
+        self.changeThreshold = 0
 
     def asyncCommand(self, cmds: str) -> None:
         self.nvim.async_call(self.nvim.command, cmds)
@@ -184,7 +184,7 @@ class LanguageClient:
     @neovim.command('LanguageClientStart')
     def start(self) -> None:
         languageId, = self.getArgs(["languageId"], [], {})
-        self.skip_threshold = float(self.nvim.eval(
+        self.changeThreshold = float(self.nvim.eval(
                 "get(g:, 'LanguageClient_changeThreshold', 0)"))
         if self.alive(languageId, False):
             self.asyncEcho("Language client has already started.")
@@ -628,7 +628,7 @@ call fzf#run(fzf#wrap({{
         uri = pathToURI(self.nvim.current.buffer.name)
         if uri and uri in self.textDocuments:
             text_doc = self.textDocuments[uri]
-            if text_doc.skip_change(self.skip_threshold):
+            if text_doc.skip_change(self.changeThreshold):
                 return
         self.textDocument_didChange()
 
@@ -637,7 +637,7 @@ call fzf#run(fzf#wrap({{
         uri = pathToURI(self.nvim.current.buffer.name)
         if uri and uri in self.textDocuments:
             text_doc = self.textDocuments[uri]
-            if text_doc.skip_change(self.skip_threshold):
+            if text_doc.skip_change(self.changeThreshold):
                 return
         self.textDocument_didChange()
 
@@ -920,7 +920,7 @@ call fzf#run(fzf#wrap({{
             cbs: List = None) -> None:
         logger.info("Begin textDocument/codeAction")
 
-        # self.sync_doc(uri)
+        self.sync_doc(uri)
         if cbs is None:
             cbs = [self.handleTextDocumentCodeActionResponse,
                    self.handleError]

--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -49,9 +49,9 @@ class LanguageClient:
         self.hlsid = None
         self.signid = 0
         type(self)._instance = self
-        self.serverCommands = self.nvim.eval(
+        self.serverCommands = nvim.eval(
                 "get(g:, 'LanguageClient_serverCommands', {})")
-        self.skip_threshold = 0.5
+        self.skip_threshold = 0
 
     def asyncCommand(self, cmds: str) -> None:
         self.nvim.async_call(self.nvim.command, cmds)
@@ -184,6 +184,8 @@ class LanguageClient:
     @neovim.command('LanguageClientStart')
     def start(self) -> None:
         languageId, = self.getArgs(["languageId"], [], {})
+        self.skip_threshold = float(self.nvim.eval(
+                "get(g:, 'LanguageClient_changeThreshold', 0)"))
         if self.alive(languageId, False):
             self.asyncEcho("Language client has already started.")
             return

--- a/rplugin/python3/LanguageClient/LanguageClient_test.py
+++ b/rplugin/python3/LanguageClient/LanguageClient_test.py
@@ -103,6 +103,8 @@ def test_textDocument_didChange(nvim):
     assert nvim.current.window.cursor == [12, 3]
     nvim.command("edit! {}".format(MAINRS_PATH))
 
+def test_textDocument_throttleChange(nvim):
+    pass
 
 def test_textDocument_didClose(nvim):
     nvim.funcs.LanguageClient_textDocument_didClose()

--- a/rplugin/python3/LanguageClient/TextDocumentItem.py
+++ b/rplugin/python3/LanguageClient/TextDocumentItem.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Tuple  # noqa: F401
+import time
 
 
 class TextDocumentItem:
@@ -7,6 +8,8 @@ class TextDocumentItem:
         self.languageId = languageId
         self.version = 1
         self.text = text
+        self.last_update = time.time()
+        self.dirty = True
 
     def incVersion(self) -> int:
         self.version += 1
@@ -19,3 +22,13 @@ class TextDocumentItem:
             })
         self.text = newText
         return (self.incVersion(), changes)
+
+    def skip_change(self, threshold: int = 0.5):
+        if time.time() - self.last_update < threshold:
+            self.dirty = True
+            return True
+        self.last_update = time.time()
+        return False
+
+    def commit_change(self):
+        self.dirty = False


### PR DESCRIPTION
Language Server Protocol implies reading (or writing) is single threaded.

So when frequent text change take places, server must read all textDocument_didChanges, even if most of them are stale. The same applies to client writing. 

If we can throttle the frequency, server performance, especially completion, will improve. We need also implement a guard flag to refresh document before sending completion/definition requests.

We can also implement incremental `contentChange` item instead of full text reload, but that's another story.

This pull request just illustrates the idea. Feel free to close it. Also, naming convention is arguable.