### PR TITLE
Log the Exception preventing completion from registering

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -301,8 +301,8 @@ class LanguageClient:
                 abbreviation='',
                 cm_refresh='LanguageClient_completionManager_refresh'))
             logger.info("register completion manager source ok.")
-        except Exception:
-            logger.warn("register completion manager source failed.")
+        except Exception as ex:
+            logger.warn("register completion manager source failed. Error: " + repr(ex))
 
     @neovim.autocmd("BufReadPost", pattern="*")
     def handleBufReadPost(self):


### PR DESCRIPTION
If something has failed,
it is nice to know as much as possible about why it has failed.

So lets log that exception for why the completion manager can't register.