### PR TITLE
Insert use function

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -12,6 +12,13 @@ function! LanguageClient#FZFSinkWorkspaceSymbol(line) abort
     call LanguageClient_FZFSinkWorkspaceSymbol(a:line)
 endfunction
 
+function! LanguageClient#InsertUse(line) abort
+    let save_cursor = getcurpos()
+    let l:lnumber = search("namespace")
+    call append(l:lnumber + 1, "use " . a:line . ";")
+    call setpos('.', save_cursor)
+endfunction
+
 function! LanguageClient#complete(findstart, base) abort
     if a:findstart
         let l:line = getline('.')

--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -63,6 +63,7 @@ class LanguageClient:
         self.diagnostics = {}
         self.lastLine = -1
         self.hlsid = None
+        self.insertUseName = ""
         self.signs = []
         self.serverCommands = {}
         self.changeThreshold = 0
@@ -589,6 +590,30 @@ call fzf#run(fzf#wrap({{
         line = splitted[0]
         character = splitted[1]
         self.asyncCommand("normal! {}G{}|".format(line, character))
+
+    @neovim.function('LanguageClient_insert_use')
+    @args()
+    def insert_use(self, languageId: str = None, name: str = None) -> None:
+        if not name:
+            name = ""
+
+        self.insertUseName = name;
+
+        cbs = [self.handleInsertUseResponse,
+               self.handleError]
+
+        return self.rpc[languageId].call('workspace/symbol', {
+            "query": name
+        }, cbs)
+
+    def handleInsertUseResponse(self, symbols: list) -> None:
+        symbols = [symbol for symbol in symbols if symbol["kind"] == 5]
+        symbols = [symbol for symbol in symbols if symbol["name"] == self.insertUseName]
+        source = []
+        for sb in symbols:
+            name = sb["containerName"] + "\\" + sb["name"]
+            source.append(name)
+        self.fzf(source, "LanguageClient#InsertUse")
 
     @neovim.function('LanguageClient_workspace_symbol')
     @args()


### PR DESCRIPTION
This PR adds a "insert use" function and can be used to add a use statement for the word (class short name) under the cursor (selecting from FZF):

```
nnoremap <silent><Leader>u :call LanguageClient_insert_use({"name": expand('<cword>')})<CR>
```

This is pretty crude (i'm not a Python developer and only looked at nvim today) and not sure if this is a valid feature for this library, or indeed if there is a better way to do this already.

So feel free to close if it's inappropriate, otherwise willing to do more work on it.