### PR TITLE
fix #52, roughly convert markdown to plain string

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -409,7 +409,8 @@ class LanguageClient:
 
     def markedStringToString(self, s: Any) -> str:
         if isinstance(s, str):
-            return s
+            # rougly convert markdown to plain text
+            return re.sub(r'\\([\\`*_{}[\]()#+\-.!])', r'\1', s)
         else:
             return s["value"]
 


### PR DESCRIPTION
Because vim cannot support full html of course, so roughly removing markdown escape is enough, I think.

https://github.com/Microsoft/vscode/blob/d4504b92f466a2882931513fde34a610170557d6/src/vs/base/common/htmlContent.ts#L74-L79