### PR TITLE
Use tempfile lib for log file

### DIFF
--- a/rplugin/python3/LanguageClient/logger.py
+++ b/rplugin/python3/LanguageClient/logger.py
@@ -1,7 +1,12 @@
 import logging
+import tempfile
 
 logger = logging.getLogger("LanguageClient")
-fileHandler = logging.FileHandler(filename="/tmp/LanguageClient.log")
+with tempfile.NamedTemporaryFile(
+        prefix="LanguageClient-",
+        suffix=".log", delete=False) as tmp:
+    tmpname = tmp.name
+fileHandler = logging.FileHandler(filename=tmpname)
 fileHandler.setFormatter(
     logging.Formatter(
         "%(asctime)s %(levelname)-8s %(message)s",


### PR DESCRIPTION
The fixed name for the log file causes issues with multiple users.  The
tempfile library will create temporary files that don't conflict.