### PR TITLE
Consider `&endofline` when sending buffer text to server

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -70,6 +70,12 @@ class LanguageClient:
         self.autoStart = self.nvim.vars.get(
             "LanguageClient_autoStart", False)
 
+    def currentBufferText(self) -> str:
+        text = str.join("\n", self.nvim.current.buffer)
+        if self.nvim.current.buffer.options['endofline']:
+            text += "\n"
+        return text
+
     def asyncCommand(self, cmds: str) -> None:
         self.nvim.async_call(self.nvim.command, cmds)
 
@@ -351,7 +357,7 @@ class LanguageClient:
 
         logger.info("textDocument/didOpen")
 
-        text = str.join("\n", self.nvim.current.buffer)
+        text = self.currentBufferText()
 
         textDocumentItem = TextDocumentItem(uri, languageId, text)
         self.textDocuments[uri] = textDocumentItem
@@ -744,7 +750,7 @@ call fzf#run(fzf#wrap({{
             return
         if uri not in self.textDocuments:
             self.textDocument_didOpen()
-        newText = str.join("\n", self.nvim.current.buffer)
+        newText = self.currentBufferText()
         text_doc = self.textDocuments[uri]
         if newText == text_doc.text:
             return


### PR DESCRIPTION
In the POSIX standard, the newline character is a line terminator rather than a line separator. This means that the last line ends with a newline character. Windows treats the newline characters as line separators, so there is nothing after the last line.

Prior to this commit, LanguageClient was sending to the language server the buffer's using the line separation scheme. As far as the language server was concerned, the document did not end with a new line. This was especially a problem for Python, which was emitting warning number 292 - "no newline at end of file". Adding a newline - as the linter suggests - was fixing the problem inside Vim with LanguageClient, but when you would run the linter externally on the file you'd get warning number 391 - "blank line at end of file".

Vim is using the `&endofline` option(`:help 'endofline'`) to decide whether or not to put a newline character after the last line. This commit uses this option to send to the language server the same text Vim would have written to the disk, in order to create a consistency between the language server and external linters.
