### PR TITLE
Remove get_complete_pos

### DIFF
--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -29,13 +29,6 @@ class Source(Base):
         self.__results = {}
         self.__errors = {}
 
-    def get_complete_position(self, context):
-        m = re.search('\w*$', context['input'])
-        if m:
-            return m.start()
-        else:
-            return -1
-
     def handleCompletionResult(self, items, contextid):
         self.__results[contextid] = items
 


### PR DESCRIPTION
`get_complete_pos` isn't necessary for Source. In file like HTML or Lisp, `\w` does not count `-` dash character as keyword pattern.

Indeed, deoplete provides a better default method in which complete position is computed via `&l:iskeyword`.