### PR TITLE
fix deoplete get_complete_position

### DIFF
--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -30,6 +30,11 @@ class Source(Base):
         self.__results = {}
         self.__errors = {}
 
+    def get_complete_position(self, context):
+        m = re.search('(?:' + context['keyword_patterns'] + ')*$',
+                      context['input'])
+        return m.start() if m else -1
+
     def handleCompletionResult(self, items, contextid):
         self.__results[contextid] = items
 


### PR DESCRIPTION
deoplete requires get_complete_position with input_pattern
Compared to previous implementation, `keyword_pattern` is used.

	Note: If the source set the attribute, it must define
	|deoplete-source-attribute-get_complete_position| attribute.

This fixes no popup when user input `xxx.`