### PR TITLE
Fix TypeError

### DIFF
--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -146,10 +146,11 @@ def getCommandUpdateSigns(signs: List[Sign], nextSigns: List[Sign]) -> str:
 
 def convertVimCommandArgsToKwargs(args: List[str]) -> Dict:
     kwargs = {}
-    for arg in args:
-        argarr = arg.split("=")
-        if len(argarr) != 2:
-            logger.warn("Parse vim command arg failed: " + arg)
-            continue
-        kwargs[argarr[0]] = argarr[1]
+    if args:
+      for arg in args:
+          argarr = arg.split("=")
+          if len(argarr) != 2:
+              logger.warn("Parse vim command arg failed: " + arg)
+              continue
+          kwargs[argarr[0]] = argarr[1]
     return kwargs


### PR DESCRIPTION
I had following error on opening rust file.

```
error caught in async handler '/Users/pocari/.cache/dein/repos/github.com/autozimu/LanguageClient-neovim/rplugin/python3/LanguageClient:autocmd:BufReadPost:* []'
Traceback (most recent call last):
  File "/Users/pocari/.cache/dein/repos/github.com/autozimu/LanguageClient-neovim/rplugin/python3/LanguageClient/LanguageClient.py", line 352, in handleBufReadPost
    self.start(warn=False)
  File "/Users/pocari/.cache/dein/repos/github.com/autozimu/LanguageClient-neovim/rplugin/python3/LanguageClient/LanguageClient.py", line 283, in start
    kwargs = convertVimCommandArgsToKwargs(args)
  File "/Users/pocari/.cache/dein/repos/github.com/autozimu/LanguageClient-neovim/rplugin/python3/LanguageClient/util.py", line 149, in convertVimCommandArgsToKwargs
    for arg in args:
TypeError: 'NoneType' object is not iterable
```
