### PR TITLE
util: Fix traverseUp infinite recursion

### DIFF
--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -56,7 +56,7 @@ def getRootPath(filepath: str, languageId: str) -> str:
 def traverseUp(folder: str, stop) -> str:
     if stop(folder):
         return folder
-    elif folder == "/":
+    elif folder == "/" or folder == "":
         return None
     else:
         return traverseUp(os.path.dirname(folder), stop)

--- a/rplugin/python3/LanguageClient/util_test.py
+++ b/rplugin/python3/LanguageClient/util_test.py
@@ -9,6 +9,7 @@ from . Sign import Sign
 def test_getRootPath():
     assert (getRootPath(joinPath("tests/sample-rs/src/main.rs"), "rust") ==
             joinPath("tests/sample-rs"))
+    assert (getRootPath("does/not/exists", "") == "does/not")
 
 
 def test_pathToURI():


### PR DESCRIPTION
If the folder does not exists and is given as a relative path, the LanguageClient crashes due to an infinite recursion as
os.path.dirname returns ''.

I noticed that accidentally when re-editing a file from the command history without noticing I was was in a different WD 😕 

```bash
$ vim abcdef/x.py
[...]
error caught while executing async callback:                                                                                                                                                                                       
RecursionError('maximum recursion depth exceeded',)                                                                                                                                                                                
Traceback (most recent call last):                                                                                                                                                                                                 
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/LanguageClient.py", line 357, in handleBufReadPost                                                                                        
    self.start(warn=False)                                                                                                                                                                                                         
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/LanguageClient.py", line 289, in start                                                                                                    
    self.initialize(rootPath=rootPath, languageId=languageId)                                                                                                                                                                      
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/LanguageClient.py", line 32, in wrappedf                                                                                                  
    return f(*fullargs)                                                                                                                                                                                                            
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/LanguageClient.py", line 304, in initialize                                                                                               
    rootPath = getRootPath(self.nvim.current.buffer.name, languageId)                                                                                                                                                              
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/util.py", line 45, in getRootPath                                                                                                         
    lambda folder: (                                                                                                                                                                                                               
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/util.py", line 62, in traverseUp                                                                                                          
    return traverseUp(os.path.dirname(folder), stop)                                                                                                                                                                               
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/util.py", line 62, in traverseUp                                                                                                          
    return traverseUp(os.path.dirname(folder), stop)                                                                                                                                                                               
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/util.py", line 62, in traverseUp                                                                                                          
    return traverseUp(os.path.dirname(folder), stop)                                                                                                                                                                               
  [Previous line repeated 967 more times]                                                                                                                                                                                          
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/util.py", line 57, in traverseUp                                                                                                          
    if stop(folder):                                                                                                                                                                                                               
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/util.py", line 46, in <lambda>                                                                                                            
    os.path.exists(os.path.join(folder, ".git")) or                                                                                                                                                                                
  File "/usr/lib/python3.6/posixpath.py", line 79, in join                                                                                                                                                                         
    sep = _get_sep(a)                                                                                                                                                                                                              
RecursionError: maximum recursion depth exceeded                                                                                                                                                                                   
                                                                                                                                                                                                                                   
the call was requested at                                                                                                                                                                                                          
  File "/usr/lib/python3.6/site-packages/neovim/api/nvim.py", line 171, in filter_notification_cb                                                                                                                                  
    notification_cb(name, args)                                                                                                                                                                                                    
  File "/usr/lib/python3.6/site-packages/neovim/plugin/host.py", line 108, in _on_notification                                                                                                                                     
    handler(*args)                                                                                                                                                                                                                 
  File "/usr/lib/python3.6/site-packages/neovim/plugin/host.py", line 70, in _wrap_function                                                                                                                                        
    return fn(*args)                                                                                                                                                                                                               
  File "/home/otilmans/.vim/plugged/LanguageClient-neovim/rplugin/python3/LanguageClient/LanguageClient.py", line 364, in handleVimEnter                                                                                           
    self.nvim.async_call(self.handleBufReadPost)
```