### PR TITLE
ncm source: $ is no longer needed in cm_refresh_patterns.

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -328,7 +328,7 @@ class LanguageClient:
 
         trigger_patterns = []
         for c in completionProvider.get("triggerCharacters", []):
-            trigger_patterns.append(re.escape(c) + '$')
+            trigger_patterns.append(re.escape(c))
 
         try:
             self.nvim.call('cm#register_source', dict(


### PR DESCRIPTION
Hi,

I'm fixing https://github.com/roxma/nvim-completion-manager/issues/100, due to a breaking chage I made weeks ago.

This PR avoids side effect after that issue is fiexed.

