### PR TITLE
Fix LOG filepath for Windows

### DIFF
--- a/rplugin/python3/LanguageClient/logger.py
+++ b/rplugin/python3/LanguageClient/logger.py
@@ -1,7 +1,9 @@
 import logging
+import os
 
 logger = logging.getLogger("LanguageClient")
-fileHandler = logging.FileHandler(filename="/tmp/LanguageClient.log")
+filename = os.environ['TMP'] + "/LanguageClient.log"
+fileHandler = logging.FileHandler(filename)
 fileHandler.setFormatter(
     logging.Formatter(
         "%(asctime)s %(levelname)-8s %(message)s",

--- a/rplugin/python3/LanguageClient/logger.py
+++ b/rplugin/python3/LanguageClient/logger.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 logger = logging.getLogger("LanguageClient")
-filename = os.environ['TMP'] + "/LanguageClient.log"
+filename = os.getenv('TMP', '/tmp') + "/LanguageClient.log"
 fileHandler = logging.FileHandler(filename)
 fileHandler.setFormatter(
     logging.Formatter(

--- a/rplugin/python3/LanguageClient/wrapper.sh
+++ b/rplugin/python3/LanguageClient/wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Tee server stdio into log file.
 
-LOG=/tmp/LanguageClient.log
+LOG="$TMP/LanguageClient.log"
 
 # tee -a $LOG | RUST_LOG=rls rustup run nightly rls 2>>$LOG | tee -a $LOG
 

--- a/rplugin/python3/LanguageClient/wrapper.sh
+++ b/rplugin/python3/LanguageClient/wrapper.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # Tee server stdio into log file.
 
+if test -z "$TMP"; then
+    TMP=/tmp
+fi
+
 LOG="$TMP/LanguageClient.log"
 
 # tee -a $LOG | RUST_LOG=rls rustup run nightly rls 2>>$LOG | tee -a $LOG


### PR DESCRIPTION
Swap `/tmp` with `$TMP` environment variable because it is set in `cmd.exe`.
This fixes #87 for me because I can run `:UpdateRemotePlugins` with no errors and update `rplugin.vim`.