### PR TITLE
Remove last param from setqflist and setloclist because it's unused

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -973,11 +973,9 @@ call fzf#run(fzf#wrap({{
         self.asyncCommand(cmd)
 
         if self.diagnosticsList == "quickfix":
-            self.nvim.funcs.setqflist(
-                qflist, "r", "LanguageClient-diagnostics")
+            self.nvim.funcs.setqflist(qflist, "r")
         elif self.diagnosticsList == "location":
-            self.nvim.funcs.setloclist(
-                0, qflist, "r", "LanguageClient-diagnostics")
+            self.nvim.funcs.setloclist(0, qflist, "r")
 
     @neovim.autocmd("CursorMoved", pattern="*", eval="line('.')")
     def handleCursorMoved(self, line) -> None:


### PR DESCRIPTION
I'm not sure if it's the same with the python binding
According to vim documentation last param for setqflist and setloclist is a Dictionary so current value is invalid

http://vimdoc.sourceforge.net/htmldoc/eval.html#setqflist()
