### PR TITLE
Add newline after each result from hover

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -457,7 +457,7 @@ class LanguageClient:
         value = ""
         if isinstance(contents, list):
             for markedString in contents:
-                value += self.markedStringToString(markedString)
+                value += self.markedStringToString(markedString) + "\n"
         else:
             value += self.markedStringToString(contents)
         self.asyncEcho(value)


### PR DESCRIPTION
When I hover a rust function that has documentation, such as the `nth` method from `Iterator`, the text shows up as:

```
An interface for dealing with iterators.https://doc.rust-lang.org/nightly/core/iter/iterator/Iterator.t.html#nth.vfn (&mut self, n: usize) -> Option<Self::Item>
```

There are no newlines so the text is hard to read. This PR just adds newlines to turn the example into:

```
An interface for dealing with iterators.
https://doc.rust-lang.org/nightly/core/iter/iterator/Iterator.t.html#nth.v
fn (&mut self, n: usize) -> Option<Self::Item>
```