### PR TITLE
completion: add snippet support for nvim-completion-manager

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -36,16 +36,27 @@ def args(warn=True):
 
 
 def convert_lsp_completion_item_to_vim_style(item):
+    insertText = item.get('insertText', "") or ""
+    label = item['label']
+    insertTextFormat = item.get('insertTextFormat', 1)
+
     e = {}
     e['icase'] = 1
     # insertText:
     # A string that should be inserted a document when selecting
     # this completion. When `falsy` the label is used.
-    e['word'] = item.get('insertText', "") or item['label']
-    e['abbr'] = item['label']
+    e['word'] = insertText or label
+    e['abbr'] = label
     e['dup'] = 1
     e['menu'] = item.get('detail', "")
     e['info'] = item.get('documentation', "")
+
+    # snippet injection is supported by nvim-completion-manager
+    if insertTextFormat == 2:
+        # some snippet engine may not support multi word expansion
+        e['word'] = label.split(' ')[0]
+        e['snippet'] = insertText
+
     return e
 
 

--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -53,8 +53,7 @@ def convert_lsp_completion_item_to_vim_style(item):
 
     # snippet injection is supported by nvim-completion-manager
     if insertTextFormat == 2:
-        # some snippet engine may not support multi word expansion
-        e['word'] = label.split(' ')[0]
+        e['word'] = label
         e['snippet'] = insertText
 
     return e


### PR DESCRIPTION
As per https://github.com/neovim/neovim/issues/5522#issuecomment-326200846

This PR adds snippet completion support for NCM.

But I failed reproducing the case provided by @HerringtonDarkholme. Reading through the log file, I cannot find the `class` in vls's suggestions.

Here's the [vls](https://github.com/vuejs/vetur/tree/master/server) demo:

![snip](https://user-images.githubusercontent.com/4538941/29911142-5d76f5a0-8e5f-11e7-89ad-7ba222cf105f.gif)


## EDIT

To expand snippet after pressing enter: https://github.com/roxma/nvim-completion-manager/issues/89#issuecomment-309203879
