### PR TITLE
Open file and navigate to line:column in one step

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -605,10 +605,10 @@ class LanguageClient:
             echo("{}:{}".format(defn["uri"], defn["range"]["start"]["line"]))
             return result
         path = uri_to_path(defn["uri"])
-        cmd = get_command_goto_file(path, bufnames)
         line = defn["range"]["start"]["line"] + 1
         character = defn["range"]["start"]["character"] + 1
-        cmd += "| normal! {}G{}|".format(line, character)
+        cmd = get_command_goto_file(path, bufnames, line, character)
+
         execute_command(cmd)
 
         logger.info("End textDocument/definition")
@@ -764,8 +764,7 @@ class LanguageClient:
         line = splitted[1]
         character = splitted[2]
 
-        cmd = get_command_goto_file(path, bufnames)
-        cmd += "| normal! {}G{}|".format(line, character)
+        cmd = get_command_goto_file(path, bufnames, line, character)
         execute_command(cmd)
 
     @neovim.function("LanguageClient_textDocument_references")
@@ -838,8 +837,7 @@ class LanguageClient:
         line = splitted[1]
         character = splitted[2]
 
-        cmd = get_command_goto_file(path, bufnames)
-        cmd += "| normal! {}G{}|".format(line, character)
+        cmd = get_command_goto_file(path, bufnames, line, character)
         execute_command(cmd)
 
     @neovim.autocmd("TextChanged", pattern="*", eval='fnamemodify(expand("<afile>"), ":p")')

--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -118,11 +118,11 @@ def retry(span, count, condition):
         count -= 1
 
 
-def get_command_goto_file(path, bufnames) -> str:
+def get_command_goto_file(path, bufnames, l, c) -> str:
     if path in bufnames:
-        return "exe 'buffer ' . fnameescape('{}')".format(path)
+        return "exe 'buffer +:call\\ cursor({},{}) ' . fnameescape('{}')".format(l, c, path)
     else:
-        return "exe 'edit ' . fnameescape('{}')".format(path)
+        return "exe 'edit +:call\\ cursor({},{}) ' . fnameescape('{}')".format(l, c, path)
 
 
 def get_command_delete_sign(sign: Sign) -> str:

--- a/rplugin/python3/LanguageClient/util_test.py
+++ b/rplugin/python3/LanguageClient/util_test.py
@@ -39,12 +39,12 @@ def test_getGotoFileCommand():
     assert get_command_goto_file("/tmp/+some str%nge|name", [
         "/tmp/+some str%nge|name",
         "/tmp/somethingelse"
-    ]) == "exe 'buffer ' . fnameescape('/tmp/+some str%nge|name')"
+    ], 1, 2) == "exe 'buffer +:call\\ cursor(1,2) ' . fnameescape('/tmp/+some str%nge|name')"
 
     assert get_command_goto_file("/tmp/+some str%nge|name", [
         "/tmp/notsample",
         "/tmp/somethingelse"
-    ]) == "exe 'edit ' . fnameescape('/tmp/+some str%nge|name')"
+    ], 3, 4) == "exe 'edit +:call\\ cursor(3,4) ' . fnameescape('/tmp/+some str%nge|name')"
 
 
 def test_getCommandDeleteSign():


### PR DESCRIPTION
After `LanguageClient_textDocument_definition` you have to press Ctrl-O twice to return back where you started, this is not very convenient. This happens because it first opens the file, then moves the cursor.