### PR TITLE
Add matched line content to ':Denite references'

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -784,7 +784,7 @@ class LanguageClient:
                 start = loc["range"]["start"]
                 line = start["line"] + 1
                 character = start["character"] + 1
-                text = get_file_line(uri_to_path(loc["uri"]), line)
+                text = loc["text"]
                 entry = "{}:{}:{}: {}".format(path, line, character, text)
                 source.append(entry)
             fzf(source, "LanguageClient#FZFSinkTextDocumentReferences")
@@ -795,7 +795,7 @@ class LanguageClient:
                 start = loc["range"]["start"]
                 line = start["line"] + 1
                 character = start["character"] + 1
-                text = get_file_line(path, line)
+                text = loc["text"]
                 loclist.append({
                     "filename": path,
                     "lnum": line,

--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -761,7 +761,19 @@ class LanguageClient:
             },
         })
 
-        if locations is None or not handle:
+        if locations is None:
+            return locations
+
+        # enhance with the line's contents for Denite
+        for loc in locations:
+            path = uri_to_path(loc["uri"])
+            start = loc["range"]["start"]
+            line = start["line"] + 1
+            character = start["character"] + 1
+            text = get_file_line(path, line)
+            loc['text'] = text
+
+        if not handle:
             return locations
 
         if state["selectionUI"] == "fzf":

--- a/rplugin/python3/denite/source/references.py
+++ b/rplugin/python3/denite/source/references.py
@@ -30,6 +30,7 @@ GREP_LINE_HIGHLIGHT = 'highlight default link deniteSource_grepLineNR LineNR'
 
 GREP_PATTERNS_HIGHLIGHT = 'highlight default link deniteGrepPatterns Function'
 
+
 class Source(Base):
     def __init__(self, vim):
         super().__init__(vim)

--- a/rplugin/python3/denite/source/references.py
+++ b/rplugin/python3/denite/source/references.py
@@ -30,8 +30,6 @@ GREP_LINE_HIGHLIGHT = 'highlight default link deniteSource_grepLineNR LineNR'
 
 GREP_PATTERNS_HIGHLIGHT = 'highlight default link deniteGrepPatterns Function'
 
-
-
 class Source(Base):
     def __init__(self, vim):
         super().__init__(vim)

--- a/rplugin/python3/denite/source/references.py
+++ b/rplugin/python3/denite/source/references.py
@@ -10,6 +10,27 @@ LanguageClientPath = path.dirname(path.dirname(path.dirname(
 sys.path.append(LanguageClientPath)
 from LanguageClient import LanguageClient, path_to_uri  # noqa: E402
 
+GREP_HEADER_SYNTAX = (
+    'syntax match deniteSource_grepHeader '
+    r'/\v[^:]*:\d+(:\d+)? / '
+    'contained keepend')
+
+GREP_FILE_SYNTAX = (
+    'syntax match deniteSource_grepFile '
+    r'/[^:]*:/ '
+    'contained containedin=deniteSource_grepHeader '
+    'nextgroup=deniteSource_grepLineNR')
+GREP_FILE_HIGHLIGHT = 'highlight default link deniteSource_grepFile Comment'
+
+GREP_LINE_SYNTAX = (
+    'syntax match deniteSource_grepLineNR '
+    r'/\d\+\(:\d\+\)\?/ '
+    'contained containedin=deniteSource_grepHeader')
+GREP_LINE_HIGHLIGHT = 'highlight default link deniteSource_grepLineNR LineNR'
+
+GREP_PATTERNS_HIGHLIGHT = 'highlight default link deniteGrepPatterns Function'
+
+
 
 class Source(Base):
     def __init__(self, vim):
@@ -18,6 +39,25 @@ class Source(Base):
 
         self.name = 'references'
         self.kind = 'file'
+
+    def define_syntax(self):
+        self.vim.command(
+                'syntax region ' + self.syntax_name + ' start=// end=/$/ '
+                'contains=deniteSource_grepHeader,deniteMatchedRange contained')
+        # TODO: make this match the 'range' on each location
+        # self.vim.command(
+        #         'syntax match deniteGrepPatterns ' +
+        #         r'/%s/ ' % r'\|'.join(util.regex_convert_str_vim(pattern)
+        #             for pattern in self.context['__patterns']) +
+        #         'contained containedin=' + self.syntax_name)
+
+    def highlight(self):
+        self.vim.command(GREP_HEADER_SYNTAX)
+        self.vim.command(GREP_FILE_SYNTAX)
+        self.vim.command(GREP_FILE_HIGHLIGHT)
+        self.vim.command(GREP_LINE_SYNTAX)
+        self.vim.command(GREP_LINE_HIGHLIGHT)
+        self.vim.command(GREP_PATTERNS_HIGHLIGHT)
 
     def convert_to_candidates(self, locations: List[Dict]) -> List[Dict]:
         candidates = []
@@ -28,8 +68,15 @@ class Source(Base):
             start = loc["range"]["start"]
             line = start["line"] + 1
             character = start["character"] + 1
+            text = loc["text"]
+            output = '{0}:{1}{2} {3}'.format(
+                filepath,
+                line,
+                (':' + str(character) if character != 0 else ''),
+                text)
             candidates.append({
-                "word": "{}:{}:{}".format(filepath, line, character),
+                "word": output,
+                "abbr": output,
                 "action__path": filepath,
                 "action__line": line,
                 "action__col": character,


### PR DESCRIPTION
```
Firstly by modifying the location dicts, and secondly by reading it off
again in the references plugin.

Then, adds the same highlighting as ':Denite grep' to the plugin. Also
copies the grep output format such that character ':0' is not rendered.
```

-----

It's not quite good to merge, I'm not very far into the codebase so I can't debug one thing, that only happens the first time you run it in a session. Repro:

1. Start LanguageClient-neovim. I'm using `sourcegraph/javascript-typescript-langserver`.
2. Find a token to find refs for and `Denite references` it.
3. Click through error output. Here is [my error output](https://pastebin.com/bYHhpM8u)
4. Do step 2 again, and it works from then on. 

I can't tell what's really happening behind that error (a keyboard interrupt? huh?). You can ignore that [Warning] readFile stuff, it happens on master branch too, it's just js-ts-langserver being silly.

Any ideas?

Edit: should refer to #81 since that's what this is implementing


**EDIT 2: fixed! That was just because I had :set shell=powershell. Never do that, folks!**