### PR TITLE
Make messages OrderedDict for clangd compatibility

### DIFF
--- a/rplugin/python3/LanguageClient/RPC.py
+++ b/rplugin/python3/LanguageClient/RPC.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import json
 import time
 from typing import Dict, Any
@@ -35,23 +36,24 @@ class RPC:
         """
         mid = self.inc_mid()
 
-        message = {
-            "jsonrpc": "2.0",
-            "id": mid,
-            "method": method,
-            "params": params,
-        }  # type: Dict[str, Any]
+        message = OrderedDict([
+            ("jsonrpc", "2.0"),
+            ("id",      mid),
+            ("method",  method),
+            ("params",  params)
+        ])  # type: Dict[str, Any]
 
         self.send_message(message)
 
         return suspend(mid)
 
     def notify(self, method: str, params: Dict[str, Any]) -> None:
-        message = {
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-        }  # type: Dict[str, Any]
+
+        message = OrderedDict([
+            ("jsonrpc", "2.0"),
+            ("method",  method),
+            ("params",  params)
+        ])  # type: Dict[str, Any]
 
         self.send_message(message)
 


### PR DESCRIPTION
Without this change clangd is throwing `JSON dispatch failed` errors.

I tested with clangd compiled from this commit: https://github.com/llvm-project/llvm-project-20170507/commit/b6c8897e62eb9194db66c0210b9d0b74325ae207.

```
health#nvim#check                                                                                                                                                                                                                                                                                                             
========================================================================                                                                                                                                                                                                                                                      
## Configuration                                                                                                                                                                                                                                                                                                              
  - SUCCESS: no issues found                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                              
## Performance                                                                                                                                                                                                                                                                                                                
  - SUCCESS: Build type: RelWithDebInfo                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
## Remote Plugins                                                                                                                                                                                                                                                                                                             
  - SUCCESS: Up to date                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
## terminal                                                                                                                                                                                                                                                                                                                   
  - INFO: key_backspace (kbs) terminfo entry: key_backspace=^H                                                                                                                                                                                                                                                                
  - INFO: key_dc (kdch1) terminfo entry: key_dc=\E[3~                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                              
## tmux                                                                                                                                                                                                                                                                                                                       
  - SUCCESS: escape-time: 0ms                                                                                                                                                                                                                                                                                                 
  - INFO: $TERM: screen-256color                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                              
health#provider#check                                                                                                                                                                                                                                                                                                         
========================================================================                                                                                                                                                                                                                                                      
## Clipboard (optional)                                                                                                                                                                                                                                                                                                       
  - SUCCESS: Clipboard tool found: xsel                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
## Python 2 provider (optional)                                                                                                                                                                                                                                                                                               
  - INFO: Using: g:python_host_prog = ~~hidden~~                                                                                                                                                                                                 
  - INFO: Executable: ~~hidden~~                                                                                                                                                                                                                   
  - INFO: Python2 version: 2.7.12                                                                                                                                                                                                                                                                                             
  - INFO: python-neovim version: 0.1.13                                                                                                                                                                                                                                                                                       
  - SUCCESS: Latest python-neovim is installed: 0.1.13                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                              
## Python 3 provider (optional)                                                                                                                                                                                                                                                                                               
  - INFO: Using: g:python3_host_prog = ~~hidden~~                                                                                                                                                                                                
  - INFO: Executable: ~~hidden~~                                                                                                                                                                                                                  
  - INFO: Python3 version: 3.5.2                                                                                                                                                                                                                                                                                              
  - INFO: python-neovim version: 0.1.13                                                                                                                                                                                                                                                                                       
  - SUCCESS: Latest python-neovim is installed: 0.1.13                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                              
## Ruby provider (optional)                                                                                                                                                                                                                                                                                                   
  - INFO: Ruby: ruby 2.3.1p112 (2016-04-26) [x86_64-linux-gnu]                                                                                                                                                                                                                                                                
  - WARNING: Missing "neovim" gem.                                                                                                                                                                                                                                                                                            
    - SUGGESTIONS:                                                                                                                                                                                                                                                                                                            
      - Run in shell: gem install neovim                                                                                                                                                                                                                                                                                      
      - Is the gem bin directory in $PATH? Check `gem environment`.                                                                                                                                                                                                                                                           
      - If you are using rvm/rbenv/chruby, try "rehashing".                                                                                                                                                                                                                                                                   
```