### PR TITLE
Only add/remove signs on a unique change

### DIFF
--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -119,7 +119,6 @@ def retry(span, count, condition):
         time.sleep(span)
         count -= 1
 
-
 def get_command_goto_file(path, bufnames, l, c) -> str:
     if path in bufnames:
         return "exe 'buffer +:call\\ cursor({},{}) ' . fnameescape('{}')".format(l, c, path)
@@ -139,19 +138,21 @@ def get_command_add_sign(sign: Sign) -> str:
 
 def get_command_update_signs(signs: List[Sign], next_signs: List[Sign]) -> str:
     cmd = "echo"
-    diff = difflib.SequenceMatcher(None, signs, next_signs)
+    signs_uniq = list(set(signs))
+    next_signs_uniq = list(set(next_signs))
+    diff = difflib.SequenceMatcher(None, signs_uniq, next_signs_uniq)
     for op, i1, i2, j1, j2 in diff.get_opcodes():
         if op == "replace":
             for i in range(i1, i2):
-                cmd += get_command_delete_sign(signs[i])
+                cmd += get_command_delete_sign(signs_uniq[i])
             for i in range(j1, j2):
-                cmd += get_command_add_sign(next_signs[i])
+                cmd += get_command_add_sign(next_signs_uniq[i])
         elif op == "delete":
             for i in range(i1, i2):
-                cmd += get_command_delete_sign(signs[i])
+                cmd += get_command_delete_sign(signs_uniq[i])
         elif op == "insert":
             for i in range(j1, j2):
-                cmd += get_command_add_sign(next_signs[i])
+                cmd += get_command_add_sign(next_signs_uniq[i])
         elif op == "equal":
             pass
         else:

--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -119,6 +119,7 @@ def retry(span, count, condition):
         time.sleep(span)
         count -= 1
 
+
 def get_command_goto_file(path, bufnames, l, c) -> str:
     if path in bufnames:
         return "exe 'buffer +:call\\ cursor({},{}) ' . fnameescape('{}')".format(l, c, path)

--- a/rplugin/python3/LanguageClient/util_test.py
+++ b/rplugin/python3/LanguageClient/util_test.py
@@ -59,7 +59,7 @@ def test_getCommandAddSign():
             " name=LanguageClientError buffer=1')")
 
 
-def test_getCommandUpdateSigns():
+def test_getCommandUpdateSigns_unique():
     signs = [
         Sign(1, "Error", 1),
         Sign(3, "Error", 1),
@@ -73,6 +73,28 @@ def test_getCommandUpdateSigns():
             "echo | execute('sign place 2 line=2"
             " name=LanguageClientError buffer=1')")
 
+def test_getCommandUpdateSigns_withDuplicates():
+    signs = [
+        Sign(1, "Error", 1),
+        Sign(3, "Error", 1),
+        Sign(3, "Error", 1),
+        Sign(4, "Error", 1),
+        Sign(4, "Error", 1),
+    ]
+
+    nextSigns = [
+        Sign(1, "Error", 1),
+        Sign(1, "Error", 1), # A duplicate value (1) has been added
+        Sign(2, "Error", 1), # A unique value (2) has been added
+                             # A unique value (3) has been removed
+        Sign(4, "Error", 1), # A duplicate value (4) has been removed
+    ]
+
+    cmd = get_command_update_signs(signs, nextSigns)
+    assert "execute('sign place 1 line=1 name=LanguageClientError buffer=1')" not in cmd
+    assert "execute('sign place 2 line=2 name=LanguageClientError buffer=1')" in cmd
+    assert "execute('sign unplace 3')" in cmd
+    assert "execute('sign unplace 4')" not in cmd
 
 def test_convertVimCommandArgsToKwargs():
     assert convert_vim_command_args_to_kwargs(["rootPath=/tmp"]) == {

--- a/rplugin/python3/LanguageClient/util_test.py
+++ b/rplugin/python3/LanguageClient/util_test.py
@@ -73,6 +73,7 @@ def test_getCommandUpdateSigns_unique():
             "echo | execute('sign place 2 line=2"
             " name=LanguageClientError buffer=1')")
 
+
 def test_getCommandUpdateSigns_withDuplicates():
     signs = [
         Sign(1, "Error", 1),
@@ -84,10 +85,10 @@ def test_getCommandUpdateSigns_withDuplicates():
 
     nextSigns = [
         Sign(1, "Error", 1),
-        Sign(1, "Error", 1), # A duplicate value (1) has been added
-        Sign(2, "Error", 1), # A unique value (2) has been added
-                             # A unique value (3) has been removed
-        Sign(4, "Error", 1), # A duplicate value (4) has been removed
+        Sign(1, "Error", 1),  # A duplicate value (1) has been added
+        Sign(2, "Error", 1),  # A unique value (2) has been added
+                              # A unique value (3) has been removed
+        Sign(4, "Error", 1),  # A duplicate value (4) has been removed
     ]
 
     cmd = get_command_update_signs(signs, nextSigns)
@@ -95,6 +96,7 @@ def test_getCommandUpdateSigns_withDuplicates():
     assert "execute('sign place 2 line=2 name=LanguageClientError buffer=1')" in cmd
     assert "execute('sign unplace 3')" in cmd
     assert "execute('sign unplace 4')" not in cmd
+
 
 def test_convertVimCommandArgsToKwargs():
     assert convert_vim_command_args_to_kwargs(["rootPath=/tmp"]) == {


### PR DESCRIPTION
Currently to add/remove signs to the signcol (to highlight lines with errors, warnings, etc), we're walking through the diff of `oldSigns` vs `newSigns` and performing the appropriate action. 

However, the signcol doesn't care if I have multiple of a sign for a line (perhaps an error on col 3 AND an error on col 17 of the same line). If I just eliminate one of the two errors, the diff is still a deletion, which removes the sign from the signcol entirely.

This fix instead compares a unique `oldSigns` vs a unique `newSigns` to only generate a diff action that changes the flat signcol.