### PR TITLE
Use distinct sign ids when placing col signs

### DIFF
--- a/rplugin/python3/LanguageClient/DiagnosticsDisplay.py
+++ b/rplugin/python3/LanguageClient/DiagnosticsDisplay.py
@@ -1,23 +1,23 @@
 DiagnosticsDisplay = {
-    1: {
+    "1": {
         "name": "Error",
         "texthl": "ALEError",
         "signText": "✖",
         "signTexthl": "ALEErrorSign",
     },
-    2: {
+    "2": {
         "name": "Warning",
         "texthl": "ALEWarning",
         "signText": "⚠",
         "signTexthl": "ALEWarningSign",
     },
-    3: {
+    "3": {
         "name": "Information",
         "texthl": "ALEInfo",
         "signText": "ℹ",
         "signTexthl": "ALEInfoSign",
     },
-    4: {
+    "4": {
         "name": "Hint",
         "texthl": "ALEInfo",
         "signText": "➤",

--- a/rplugin/python3/LanguageClient/DiagnosticsDisplay.py
+++ b/rplugin/python3/LanguageClient/DiagnosticsDisplay.py
@@ -1,23 +1,23 @@
 DiagnosticsDisplay = {
-    "1": {
+    1: {
         "name": "Error",
         "texthl": "ALEError",
         "signText": "✖",
         "signTexthl": "ALEErrorSign",
     },
-    "2": {
+    2: {
         "name": "Warning",
         "texthl": "ALEWarning",
         "signText": "⚠",
         "signTexthl": "ALEWarningSign",
     },
-    "3": {
+    3: {
         "name": "Information",
         "texthl": "ALEInfo",
         "signText": "ℹ",
         "signTexthl": "ALEInfoSign",
     },
-    "4": {
+    4: {
         "name": "Hint",
         "texthl": "ALEInfo",
         "signText": "➤",

--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -119,12 +119,13 @@ def convert_Sign_to_vim_sign_id(sign: Sign) -> int:
     # As a polite attempt to avoid collisions with other plugins, we begin numbering far from 0
     base_id = 75000
 
+    diagnostic_names = sorted(set(map(lambda diag: diag["name"], DiagnosticsDisplay.values())))
     diagnostic_offset = 0
-    for offset, diagnostic in DiagnosticsDisplay.items():
-        if diagnostic["name"] == sign.signname:
-            diagnostic_offset = int(offset) - 1
+    for offset, name in enumerate(diagnostic_names):
+        if name == sign.signname:
+            diagnostic_offset = offset
             break
-    line_multi = len(DiagnosticsDisplay)
+    line_multi = len(diagnostic_names)
     return base_id + ((sign.line - 1) * line_multi) + diagnostic_offset
 
 

--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -122,7 +122,7 @@ def convert_Sign_to_vim_sign_id(sign: Sign) -> int:
     diagnostic_offset = 0
     for offset, diagnostic in DiagnosticsDisplay.items():
         if diagnostic["name"] == sign.signname:
-            diagnostic_offset = offset - 1
+            diagnostic_offset = int(offset) - 1
             break
     line_multi = len(DiagnosticsDisplay)
     return base_id + ((sign.line - 1) * line_multi) + diagnostic_offset

--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -12,6 +12,7 @@ import re
 from . logger import logger
 from . Sign import Sign
 from .CompletionItemKind import convert_CompletionItemKind_to_vim_kind
+from .DiagnosticsDisplay import DiagnosticsDisplay
 
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -113,6 +114,20 @@ def escape(string: str) -> str:
     return string.replace("'", "''")
 
 
+def convert_Sign_to_vim_sign_id(sign: Sign) -> int:
+    # Vim sign ids are a global namespace restricted to signed 32-bit integers.
+    # As a polite attempt to avoid collisions with other plugins, we begin numbering far from 0
+    base_id = 75000
+
+    diagnostic_offset = 0
+    for offset, diagnostic in enumerate(DiagnosticsDisplay.values()):
+        if diagnostic["name"] == sign.signname:
+            diagnostic_offset = offset
+            break
+    line_multi = len(DiagnosticsDisplay)
+    return base_id + ((sign.line - 1) * line_multi) + diagnostic_offset
+
+
 def retry(span, count, condition):
     while count > 0 and condition():
         logger.info("retrying...")
@@ -128,13 +143,14 @@ def get_command_goto_file(path, bufnames, l, c) -> str:
 
 
 def get_command_delete_sign(sign: Sign) -> str:
-    return " | execute('sign unplace {}')".format(sign.line)
+    return " | execute('sign unplace {} buffer={}')".format(
+            convert_Sign_to_vim_sign_id(sign), sign.bufnumber)
 
 
 def get_command_add_sign(sign: Sign) -> str:
     return (" | execute('sign place {} line={} "
             "name=LanguageClient{} buffer={}')").format(
-                sign.line, sign.line, sign.signname, sign.bufnumber)
+                convert_Sign_to_vim_sign_id(sign), sign.line, sign.signname, sign.bufnumber)
 
 
 def get_command_update_signs(signs: List[Sign], next_signs: List[Sign]) -> str:

--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -120,9 +120,9 @@ def convert_Sign_to_vim_sign_id(sign: Sign) -> int:
     base_id = 75000
 
     diagnostic_offset = 0
-    for offset, diagnostic in enumerate(DiagnosticsDisplay.values()):
+    for offset, diagnostic in DiagnosticsDisplay.items():
         if diagnostic["name"] == sign.signname:
-            diagnostic_offset = offset
+            diagnostic_offset = offset - 1
             break
     line_multi = len(DiagnosticsDisplay)
     return base_id + ((sign.line - 1) * line_multi) + diagnostic_offset

--- a/rplugin/python3/LanguageClient/util_test.py
+++ b/rplugin/python3/LanguageClient/util_test.py
@@ -49,14 +49,38 @@ def test_getGotoFileCommand():
 
 def test_getCommandDeleteSign():
     sign = Sign(1, "Error", 1)
-    assert get_command_delete_sign(sign) == " | execute('sign unplace 1')"
+    assert get_command_delete_sign(sign) == " | execute('sign unplace 75000 buffer=1')"
+
+    sign = Sign(1, "Warning", 2)
+    assert get_command_delete_sign(sign) == " | execute('sign unplace 75001 buffer=2')"
+
+    sign = Sign(1, "Information", 3)
+    assert get_command_delete_sign(sign) == " | execute('sign unplace 75002 buffer=3')"
+
+    sign = Sign(1, "Hint", 4)
+    assert get_command_delete_sign(sign) == " | execute('sign unplace 75003 buffer=4')"
 
 
 def test_getCommandAddSign():
-    sign = Sign(1, "Error", 1)
+    sign = Sign(7, "Error", 4)
     assert (get_command_add_sign(sign) ==
-            " | execute('sign place 1 line=1"
-            " name=LanguageClientError buffer=1')")
+            " | execute('sign place 75024 line=7"
+            " name=LanguageClientError buffer=4')")
+
+    sign = Sign(7, "Warning", 3)
+    assert (get_command_add_sign(sign) ==
+            " | execute('sign place 75025 line=7"
+            " name=LanguageClientWarning buffer=3')")
+
+    sign = Sign(7, "Information", 2)
+    assert (get_command_add_sign(sign) ==
+            " | execute('sign place 75026 line=7"
+            " name=LanguageClientInformation buffer=2')")
+
+    sign = Sign(7, "Hint", 1)
+    assert (get_command_add_sign(sign) ==
+            " | execute('sign place 75027 line=7"
+            " name=LanguageClientHint buffer=1')")
 
 
 def test_getCommandUpdateSigns_unique():
@@ -70,7 +94,7 @@ def test_getCommandUpdateSigns_unique():
         Sign(3, "Error", 1),
     ]
     assert (get_command_update_signs(signs, nextSigns) ==
-            "echo | execute('sign place 2 line=2"
+            "echo | execute('sign place 75004 line=2"
             " name=LanguageClientError buffer=1')")
 
 
@@ -92,10 +116,10 @@ def test_getCommandUpdateSigns_withDuplicates():
     ]
 
     cmd = get_command_update_signs(signs, nextSigns)
-    assert "execute('sign place 1 line=1 name=LanguageClientError buffer=1')" not in cmd
-    assert "execute('sign place 2 line=2 name=LanguageClientError buffer=1')" in cmd
-    assert "execute('sign unplace 3')" in cmd
-    assert "execute('sign unplace 4')" not in cmd
+    assert "execute('sign place 75000 line=1 name=LanguageClientError buffer=1')" not in cmd
+    assert "execute('sign place 75004 line=2 name=LanguageClientError buffer=1')" in cmd
+    assert "execute('sign unplace 75008 buffer=1')" in cmd
+    assert "execute('sign unplace 75012 buffer=1')" not in cmd
 
 
 def test_convertVimCommandArgsToKwargs():

--- a/rplugin/python3/LanguageClient/util_test.py
+++ b/rplugin/python3/LanguageClient/util_test.py
@@ -51,13 +51,13 @@ def test_getCommandDeleteSign():
     sign = Sign(1, "Error", 1)
     assert get_command_delete_sign(sign) == " | execute('sign unplace 75000 buffer=1')"
 
-    sign = Sign(1, "Warning", 2)
+    sign = Sign(1, "Hint", 2)
     assert get_command_delete_sign(sign) == " | execute('sign unplace 75001 buffer=2')"
 
     sign = Sign(1, "Information", 3)
     assert get_command_delete_sign(sign) == " | execute('sign unplace 75002 buffer=3')"
 
-    sign = Sign(1, "Hint", 4)
+    sign = Sign(1, "Warning", 4)
     assert get_command_delete_sign(sign) == " | execute('sign unplace 75003 buffer=4')"
 
 
@@ -67,20 +67,20 @@ def test_getCommandAddSign():
             " | execute('sign place 75024 line=7"
             " name=LanguageClientError buffer=4')")
 
-    sign = Sign(7, "Warning", 3)
+    sign = Sign(7, "Hint", 3)
     assert (get_command_add_sign(sign) ==
             " | execute('sign place 75025 line=7"
-            " name=LanguageClientWarning buffer=3')")
+            " name=LanguageClientHint buffer=3')")
 
     sign = Sign(7, "Information", 2)
     assert (get_command_add_sign(sign) ==
             " | execute('sign place 75026 line=7"
             " name=LanguageClientInformation buffer=2')")
 
-    sign = Sign(7, "Hint", 1)
+    sign = Sign(7, "Warning", 1)
     assert (get_command_add_sign(sign) ==
             " | execute('sign place 75027 line=7"
-            " name=LanguageClientHint buffer=1')")
+            " name=LanguageClientWarning buffer=1')")
 
 
 def test_getCommandUpdateSigns_unique():


### PR DESCRIPTION
In Vim, placing or unplacing a sign requires binding an id for that sign. Currently we use the line # of a sign as the id of that sign. This leads us to define the same id multiple times if, for instance, a single line has both a warning and an error. `unplace`ing that sign id 
 (for example, by solving that line's warning but not the error) then incorrectly clears both signs.

This change adds a simple calculation for determining an id for a given Sign. Note that we start numbering at 75000- an [arbitrarily-high number](https://github.com/airblade/vim-gitgutter/blob/master/autoload/gitgutter/sign.vim#L1) to attempt to avoid trampling other plugins' sign ids. We also only `unplace` within the sign's given buffer.