### PR TITLE
Add ncm completion handler. Fix goto definition. add LanguageClientStart

### DIFF
--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -47,7 +47,7 @@ function! LanguageClient_textDocument_hover()
 endfunction
 
 function! LanguageClient_textDocument_definition()
-    return s:lc.call('textDocument_hover')
+    return s:lc.call('textDocument_definition')
 endfunction
 
 function! LanguageClient_textDocument_rename()

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -2,6 +2,9 @@ if has('nvim')
     finish
 endif
 
+command LanguageClientStart call LanguageClient_start()
+command LanguageClientStop call LanguageClient_stop()
+
 let s:lc = yarp#py3('LanguageClient_wrapper')
 
 function! LanguageClient_getState()

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -132,3 +132,7 @@ endfunction
 function! LanguageClient_notify()
     return s:lc.call('notify_vim')
 endfunction
+
+function! LanguageClient_completionManager_refresh(...)
+    return call(s:lc.notify,['completionManager_refresh'] + a:000, s:lc)
+endfunction


### PR DESCRIPTION
Goto definition works if I add a dummy function  `nvim_buf_add_highlight` into vim-hug-neovi-rpc to ignore the error.

#151 