### PR TITLE
fix #150 textEdit issue for NCM

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -1030,10 +1030,10 @@ class LanguageClient:
         for item in items:
             match = convert_lsp_completion_item_to_vim_style(item)
 
-            # snippet & textEdit support
-            match['textEdits'] = []
             if item.get('additionalTextEdits', None):
-                match['textEdits'] = item['additionalTextEdits']
+                match['additionalTextEdits'] = item['additionalTextEdits']
+            if item.get('textEdit'):
+                match['textEdit'] = item['textEdit']
 
             insertText = item.get('insertText', "") or ""
             label = item['label']

--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -1049,8 +1049,8 @@ class LanguageClient:
                     match['snippet'] = item['textEdit']['newText'] + '$0'
             elif item.get('textEdit', None):
                 # ignore insertText
-                match['word'] = ''
-                match['textEdits'].append(item['textEdit'])
+                # TODO: Not fully conforming to LSP
+                match['word'] = item['textEdit']['newText']
             matches.append(match)
 
         state["nvim"].call('cm#complete', info['name'], ctx,


### PR DESCRIPTION
NCM currently doesn't recognize textEdit. Accept the whole newText as
completionItem['word'] for now.