### PR TITLE
Use buffer options for formatting

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -1291,8 +1291,8 @@ class LanguageClient:
 
         self.textDocument_didChange()
         options = {
-            "tabSize": state["nvim"].options["tabstop"],
-            "insertSpaces": state["nvim"].options["expandtab"],
+            "tabSize": state["nvim"].current.buffer.options["tabstop"],
+            "insertSpaces": state["nvim"].current.buffer.options["expandtab"],
         }
         textEdits = state["rpcs"][languageId].call("textDocument/formatting", {
             "textDocument": {
@@ -1326,8 +1326,8 @@ class LanguageClient:
 
         self.textDocument_didChange()
         options = {
-            "tabSize": state["nvim"].options["tabstop"],
-            "insertSpaces": state["nvim"].options["expandtab"],
+            "tabSize": state["nvim"].current.buffer.options["tabstop"],
+            "insertSpaces": state["nvim"].current.buffer.options["expandtab"],
         }
         start_line = state["nvim"].eval("v:lnum") - 1
         end_line = start_line + state["nvim"].eval("v:count")


### PR DESCRIPTION
The formatting should use the `tabstop` and `expandtab` settings from the current buffer, not the global settings.

For example with this config:

```vim
set tabstop=2
set expandtab

autocmd FileType rust setlocal tabstop=4
```

The formatting of a Rust file should be done with `tabSize: 4`.