### PR TITLE
Remove final empty line after formatting

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -170,7 +170,10 @@ def apply_TextDocumentEdit(textDocumentEdit: Dict) -> None:
     text = buffer[:]
     for edit in edits:
         text = apply_TextEdit(text, edit)
-    buffer[:] = text
+    if buffer.options["fixendofline"] and text[-1] == "":
+        buffer[:] = text[:-1]
+    else:
+        buffer[:] = text
 
 
 def apply_WorkspaceEdit(workspaceEdit: Dict) -> None:


### PR DESCRIPTION
Vim inserts a newline at the end of the file if `fixendofline` is set (set by default). When the formatting result includes a `\n` at the end, an empty line will be inserted and an additional `\n` is added, which means that the file ends with `\n\n`.

To avoid that, the final empty line is removed from the buffer if `fixendofline` is set.