### PR TITLE
Changed split for CodeAction to include a space

### DIFF
--- a/rplugin/python3/LanguageClient/LanguageClient.py
+++ b/rplugin/python3/LanguageClient/LanguageClient.py
@@ -1251,7 +1251,7 @@ class LanguageClient:
 
     @neovim.function("LanguageClient_FZFSinkTextDocumentCodeAction")
     def fzfSinkTextDocumentCodeAction(self, lines: str) -> None:
-        command, title = lines[0].split(":")
+        command, title = lines[0].split(": ")
         command = command.strip()
         title = title.strip()
         logger.info("Selected action with command {} title {}".format(


### PR DESCRIPTION
As the protocol specifies that commands should be followed by a colon and a space, if there is a colon the command itself it breaks as  the issue [here](https://github.com/autozimu/LanguageClient-neovim/issues/166) with the haskell language server.