### PR TITLE
add try except in rpc header handling

### DIFF
--- a/rplugin/python3/LanguageClient/RPC.py
+++ b/rplugin/python3/LanguageClient/RPC.py
@@ -62,9 +62,13 @@ class RPC:
         while not self.infile.closed:
             line = self.infile.readline().decode("UTF-8").strip()
             if line:
-                header, value = line.split(":")
-                if header == "Content-Length":
-                    content_length = int(value)
+                try:
+                    header, value = line.split(":")
+                    if header == "Content-Length":
+                        content_length = int(value)
+                except Exception:
+                    logger.error("Error while parsing header:" + header)
+
             else:
                 content = self.infile.read(content_length).decode("UTF-8")
                 logger.debug("<= " + content)


### PR DESCRIPTION
Because wrong headers  break "while not self.infile.closed" cycle silently
Example: [vscode-javac](https://github.com/georgewfraser/vscode-javac) sends `pattern: glob:/home/stcarolas/.gradle/caches/modules-*/files-*/weblogic/javax.ejb/3.0.1/*/javax.ejb-3.0.1.jar`