### PR TITLE
Also look for ".vim" when searching for the project root directory.

### DIFF
--- a/rplugin/python3/LanguageClient/util.py
+++ b/rplugin/python3/LanguageClient/util.py
@@ -58,6 +58,7 @@ def get_rootPath(filepath: str, languageId: str) -> str:
         rootPath = traverse_up(
             filepath,
             lambda folder: (
+                os.path.exists(os.path.join(folder, ".vim")) or
                 os.path.exists(os.path.join(folder, ".git")) or
                 os.path.exists(os.path.join(folder, ".hg")) or
                 os.path.exists(os.path.join(folder, ".svn"))))


### PR DESCRIPTION
This improves the situation for developers using vim and e.g. C++ where there is no clear root project file, like "Cargo.toml" for rust, and especially the case when they use Subversion because the checkout and thus the location of ".svn" is often at a higher level, encompassing multiple projects.