### PR TITLE
Don't assume rpc message is always valid UTF8

### DIFF
--- a/rplugin/python3/LanguageClient/RPC.py
+++ b/rplugin/python3/LanguageClient/RPC.py
@@ -60,13 +60,25 @@ class RPC:
     def serve(self):
         content_length = 0
         while not self.infile.closed:
-            line = self.infile.readline().decode("UTF-8").strip()
+            try:
+                data = self.infile.readline()
+                line = data.decode("UTF-8").strip()
+            except UnicodeError:
+                msg = "Failed to decode message as UTF-8: " + str(data)
+                logger.exception(msg)
+                continue
             if line:
                 header, value = line.split(":")
                 if header == "Content-Length":
                     content_length = int(value)
             else:
-                content = self.infile.read(content_length).decode("UTF-8")
+                try:
+                    data = self.infile.read(content_length)
+                    content = data.decode("UTF-8")
+                except UnicodeError:
+                    msg = "Failed to decode message as UTF-8: " + str(data)
+                    logger.exception(msg)
+                    continue
                 logger.debug("<= " + content)
                 try:
                     msg = json.loads(content)


### PR DESCRIPTION
Ignore invalid message instead of crashing