### PR TITLE
Don't overload get_complete_position

### DIFF
--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -54,11 +54,6 @@ class Source(Base):
 
         logger.info("deoplete LanguageClientSource initialized.")
 
-    def get_complete_position(self, context):
-        m = re.search('(?:' + context['keyword_patterns'] + ')*$',
-                      context['input'])
-        return m.start() if m else -1
-
     def gather_candidates(self, context):
         # context["is_async"] = True
 


### PR DESCRIPTION
The default one is just fine. Adding a `*` risks triggering exponential behaviour in Python re.

I don't quite see the point of adding a `*`? But if that's really necessary, we should move to a different regex implementation.