### PR TITLE
Replace placeholders in completion text

### DIFF
--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -15,7 +15,9 @@ from LanguageClient import (
 
 
 def simplify_snippet(snip: str) -> str:
-    return re.sub(r'(?<!\\)\$\d+', '', snip)
+    snip = re.sub(r'(?<!\\)\$(?P<num>\d+)', '<`\g<num>`>', snip)
+    return re.sub(r'(?<!\\)\${(?P<num>\d+):(?P<desc>.+?)}',
+                  '<`\g<num>:\g<desc>`>', snip)
 
 
 def convert_to_deoplete_candidate(item: Dict) -> Dict:


### PR DESCRIPTION
In deoplete source, replace the placeholders with the neosnippet format.

We should probably make this behavior configurable.