### PR TITLE
Signature help minor fixes

### DIFF
--- a/rplugin/python3/LanguageClient/state.py
+++ b/rplugin/python3/LanguageClient/state.py
@@ -172,14 +172,15 @@ def echo_signature(signature: str, activeParameter: str = None) -> None:
     """
     if activeParameter is None:
         echo(signature)
+        return
     parts = signature.split(activeParameter, 1)
     if (len(parts) != 2):
-        # active paramter is not part of a signature
+        # active parameter is not part of a signature
         echo(signature)
         return
     [begin, end] = parts
     execute_command("echon '{}' | echohl Bold | echon '{}' | echohl None | echon '{}'".format(
-        begin, activeParameter, end
+        escape(begin), escape(activeParameter), escape(end)
     ))
 
 


### PR DESCRIPTION
I noticed a couple of bugs when using signature help:

* If there's no active parameter it can crash because of a missing return
* In PHP function parameters can have a `'` character in them which need to be escaped to display properly

Off topic but it would be really nice to have a popup which displayed signature help, triggered by the triggerCharacters, similar to what vscode does. I had a quick look and it doesn't look straightforward to do this with neovim though.