### PR TITLE
Specify the next branch explicitly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ functional.)
 Using [`vim-plug`](https://github.com/junegunn/vim-plug):
 
 ```vim
-Plug 'autozimu/LanguageClient-neovim', {'do': './install.sh' }
+Plug 'autozimu/LanguageClient-neovim', {
+    \ 'branch': 'next',
+    \ 'do': './install.sh'
+    \ }
 
 " (Optional) Multi-entry selection UI.
 Plug 'junegunn/fzf'

--- a/min-init.vim
+++ b/min-init.vim
@@ -1,6 +1,6 @@
 call plug#begin('~/.local/share/nvim/plugged')
 
-Plug 'autozimu/LanguageClient-neovim', {'do': './install.sh' }
+Plug 'autozimu/LanguageClient-neovim', { 'branch': 'next', 'do': './install.sh' }
 
 call plug#end()
 


### PR DESCRIPTION
According https://github.com/junegunn/vim-plug/issues/288#issuecomment-151896611 we have to precise the branch to clone if different of "master" in despite the fact that the "next" branch is set by default:

> `Plug 'something'` is simply a shorthand notation of `Plug 'something', { 'branch': 'master' }`

I was trying many times to install LanguageClient-neovim from scratch and invariably the master branch was cloned.