### PR TITLE
fix error on vim exit

### DIFF
--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -103,7 +103,7 @@ function! s:HandleMessage(job, lines, event) abort
             call s:Echoerr('LanguageClient stderr: ' . string(a:lines))
         endif
     elseif a:event == 'exit'
-        if a:lines !=# '0'
+        if a:lines !=# [-1]
             echomsg 'LanguageClient exited with: ' . string(a:lines)
         endif
     else


### PR DESCRIPTION
Opening and closing vim results in:
```
Error detected while processing function <SNR>13_HandleExitVim[1]..<SNR>13_HandleMessage:
line 94:
E691: Can only compare List with List
E15: Invalid expression: a:lines !=# '0'
```