### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ set hidden
 let g:LanguageClient_serverCommands = {
     \ 'rust': ['rustup', 'run', 'nightly', 'rls'],
     \ 'javascript': ['javascript-typescript-stdio'],
+    \ 'javascript.jsx': ['javascript-typescript-stdio'],
     \ }
 
 nnoremap <silent> K :call LanguageClient_textDocument_hover()<CR>


### PR DESCRIPTION
Added a line for javascript.jsx in the readme.
Popular vim plugins like vim-ployglot and vim-flow automatically set `javascript` filetypes to `javascript.jsx`
This took me a couple hours of frustration so I'd like to add this line in the README to help others out.