### PR TITLE
Prevent making vim unusable in case we are loaded in an env that does not have yarp#py3 defined.

### DIFF
--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -5,7 +5,7 @@ endif
 if !exists('yarp#py3')
     echoerr 'LanguageClient: yarp#py3 does not exist. Refusing to load.'
     finish
-fi
+endif
 
 command LanguageClientStart call LanguageClient_start()
 command LanguageClientStop call LanguageClient_stop()

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -2,6 +2,11 @@ if has('nvim')
     finish
 endif
 
+if !exists('yarp#py3')
+    echoerr 'LanguageClient: yarp#py3 does not exist. Refusing to load.'
+    finish
+fi
+
 command LanguageClientStart call LanguageClient_start()
 command LanguageClientStop call LanguageClient_stop()
 

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -2,7 +2,7 @@ if has('nvim')
     finish
 endif
 
-if !exists('yarp#py3')
+if !exists('*yarp#py3')
     echoerr 'LanguageClient: yarp#py3 does not exist. Refusing to load.'
     finish
 endif


### PR DESCRIPTION
There are unfortunately a multitude of different methods that this can be the case, but really any time you run without a working python env (eg yet/anymore), you'll find yourself an unusable vim/nvim because `yarp#py3` doesn't exist, and hooks are loaded to `HandleCursorMoved` and such ;)

This just checks for it before setting up hooks on everything.