### PR TITLE
Expose RLS and cquery build progress

### DIFF
--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -581,13 +581,13 @@ function! LanguageClient_exit() abort
                 \ })
 endfunction
 
-" Set to 1 when the language server is building something.
-let g:LanguageClient_building = 0
+" Set to 1 when the language server is busy (e.g. building the code).
+let g:LanguageClient_serverBusy = 0
 function! LanguageClient_statusLine() abort
-    if !exists('g:LanguageClient_buildStatus')
+    if !exists('g:LanguageClient_serverStatusMessage')
         return ''
     endif
-    return '['.g:LanguageClient_buildStatus.']'
+    return '['.g:LanguageClient_serverStatusMessage.']'
 endfunction
 
 " When editing a [No Name] file, neovim reports filename as "", while vim reports null.

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -581,6 +581,15 @@ function! LanguageClient_exit() abort
                 \ })
 endfunction
 
+" Set to 1 when the language server is building something.
+let g:LanguageClient_building = 0
+function! LanguageClient_statusLine() abort
+    if !exists('g:LanguageClient_buildStatus')
+        return ''
+    endif
+    return '['.g:LanguageClient_buildStatus.']'
+endfunction
+
 " When editing a [No Name] file, neovim reports filename as "", while vim reports null.
 function! s:Expand(exp) abort
     let l:result = expand(a:exp)

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -81,6 +81,9 @@ pub trait ILanguageClient {
 
     // Extensions by languge servers.
     fn language_status(&self, params: &Option<Params>) -> Result<()>;
+    fn rust_handleBeginBuild(&self, params: &Option<Params>) -> Result<()>;
+    fn rust_handleDiagnosticsBegin(&self, params: &Option<Params>) -> Result<()>;
+    fn rust_handleDiagnosticsEnd(&self, params: &Option<Params>) -> Result<()>;
 }
 
 impl ILanguageClient for Arc<Mutex<State>> {
@@ -294,6 +297,9 @@ impl ILanguageClient for Arc<Mutex<State>> {
                     NOTIFICATION__NCMRefresh => self.NCM_refresh(&notification.params)?,
                     // Extensions by language servers.
                     NOTIFICATION__LanguageStatus => self.language_status(&notification.params)?,
+                    NOTIFICATION__RustBeginBuild => self.rust_handleBeginBuild(&notification.params)?,
+                    NOTIFICATION__RustDiagnosticsBegin => self.rust_handleDiagnosticsBegin(&notification.params)?,
+                    NOTIFICATION__RustDiagnosticsEnd => self.rust_handleDiagnosticsEnd(&notification.params)?,
                     _ => warn!("Unknown notification: {:?}", notification.method),
                 }
             }
@@ -2295,6 +2301,27 @@ impl ILanguageClient for Arc<Mutex<State>> {
         let msg = format!("{} {}", params.typee, params.message);
         self.echomsg(&msg)?;
         info!("End {}", NOTIFICATION__LanguageStatus);
+        Ok(())
+    }
+
+    fn rust_handleBeginBuild(&self, _params: &Option<Params>) -> Result<()> {
+        info!("Begin {}", NOTIFICATION__RustBeginBuild);
+        self.echo("Rust: build started")?;
+        info!("End {}", NOTIFICATION__RustBeginBuild);
+        Ok(())
+    }
+
+    fn rust_handleDiagnosticsBegin(&self, _params: &Option<Params>) -> Result<()> {
+        info!("Begin {}", NOTIFICATION__RustDiagnosticsBegin);
+        self.echo("Rust: diagnostics started")?;
+        info!("End {}", NOTIFICATION__RustDiagnosticsBegin);
+        Ok(())
+    }
+
+    fn rust_handleDiagnosticsEnd(&self, _params: &Option<Params>) -> Result<()> {
+        info!("Begin {}", NOTIFICATION__RustDiagnosticsEnd);
+        self.echo("Rust: build completed")?;
+        info!("End {}", NOTIFICATION__RustDiagnosticsEnd);
         Ok(())
     }
 }

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -2294,10 +2294,10 @@ impl ILanguageClient for Arc<Mutex<State>> {
         if self.eval::<_, u64>("exists('#User#LanguageClientStopped')")? == 1 {
             self.command("doautocmd User LanguageClientStopped")?;
         }
-        if self.eval::<_, u64>(format!("exists('{}')", VIM__BuildStatus).as_str())? == 1 {
-            self.command(&format!("unlet {}", VIM__BuildStatus))?;
+        if self.eval::<_, u64>(format!("exists('{}')", VIM__ServerStatusMessage).as_str())? == 1 {
+            self.command(&format!("unlet {}", VIM__ServerStatusMessage))?;
         }
-        self.command(&format!("let {}=0", VIM__Building))?;
+        self.command(&format!("let {}=0", VIM__ServerBusy))?;
         Ok(())
     }
 
@@ -2314,7 +2314,7 @@ impl ILanguageClient for Arc<Mutex<State>> {
         info!("Begin {}", NOTIFICATION__RustBeginBuild);
         self.command(&format!(
             "let {}=1 | let {}='Rust: build started'",
-            VIM__Building, VIM__BuildStatus
+            VIM__ServerBusy, VIM__ServerStatusMessage
         ))?;
         info!("End {}", NOTIFICATION__RustBeginBuild);
         Ok(())
@@ -2324,7 +2324,7 @@ impl ILanguageClient for Arc<Mutex<State>> {
         info!("Begin {}", NOTIFICATION__RustDiagnosticsBegin);
         self.command(&format!(
             "let {}=1 | let {}='Rust: diagnostics started'",
-            VIM__Building, VIM__BuildStatus
+            VIM__ServerBusy, VIM__ServerStatusMessage
         ))?;
         info!("End {}", NOTIFICATION__RustDiagnosticsBegin);
         Ok(())
@@ -2334,7 +2334,7 @@ impl ILanguageClient for Arc<Mutex<State>> {
         info!("Begin {}", NOTIFICATION__RustDiagnosticsEnd);
         self.command(&format!(
             "let {}=0 | let {}='Rust: build completed'",
-            VIM__Building, VIM__BuildStatus
+            VIM__ServerBusy, VIM__ServerStatusMessage
         ))?;
         info!("End {}", NOTIFICATION__RustDiagnosticsEnd);
         Ok(())
@@ -2348,12 +2348,12 @@ impl ILanguageClient for Arc<Mutex<State>> {
         if total != 0 {
             self.command(&format!(
                 "let {}=1 | let {}='cquery: indexing ({} jobs)'",
-                VIM__Building, VIM__BuildStatus, params.indexRequestCount
+                VIM__ServerBusy, VIM__ServerStatusMessage, params.indexRequestCount
             ))?;
         } else {
             self.command(&format!(
                 "let {}=0 | let {}='cquery: idle'",
-                VIM__Building, VIM__BuildStatus
+                VIM__ServerBusy, VIM__ServerStatusMessage
             ))?;
         }
         info!("End {}", NOTIFICATION__CqueryProgress);

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,8 +62,8 @@ pub const NOTIFICATION__LanguageStatus: &str = "language/status";
 pub const CommandsClient: &[&str] = &["java.apply.workspaceEdit"];
 
 // Vim variable names
-pub const VIM__Building: &str = "g:LanguageClient_building";
-pub const VIM__BuildStatus: &str = "g:LanguageClient_buildStatus";
+pub const VIM__ServerBusy: &str = "g:LanguageClient_serverBusy";
+pub const VIM__ServerStatusMessage: &str = "g:LanguageClient_serverStatusMessage";
 
 #[derive(Debug, Serialize)]
 pub struct State {

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,10 @@ pub const NOTIFICATION__LanguageStatus: &str = "language/status";
 
 pub const CommandsClient: &[&str] = &["java.apply.workspaceEdit"];
 
+// Vim variable names
+pub const VIM__Building: &str = "g:LanguageClient_building";
+pub const VIM__BuildStatus: &str = "g:LanguageClient_buildStatus";
+
 #[derive(Debug, Serialize)]
 pub struct State {
     // Program state.
@@ -82,8 +86,6 @@ pub struct State {
     pub last_cursor_line: u64,
     pub last_line_diagnostic: String,
     pub stashed_codeAction_commands: Vec<Command>,
-    pub showed_first_build_complete: bool,
-    pub showed_cquery_build_progress: bool,
 
     // User settings.
     pub serverCommands: HashMap<String, Vec<String>>,
@@ -117,8 +119,6 @@ impl State {
             last_cursor_line: 0,
             last_line_diagnostic: " ".into(),
             stashed_codeAction_commands: vec![],
-            showed_first_build_complete: false,
-            showed_cquery_build_progress: false,
 
             serverCommands: HashMap::new(),
             autoStart: true,

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,6 +56,7 @@ pub const REQUEST__RustImplementations: &str = "rustDocument/implementations";
 pub const NOTIFICATION__RustBeginBuild: &str = "rustDocument/beginBuild";
 pub const NOTIFICATION__RustDiagnosticsBegin: &str = "rustDocument/diagnosticsBegin";
 pub const NOTIFICATION__RustDiagnosticsEnd: &str = "rustDocument/diagnosticsEnd";
+pub const NOTIFICATION__CqueryProgress: &str = "$cquery/progress";
 pub const NOTIFICATION__LanguageStatus: &str = "language/status";
 
 pub const CommandsClient: &[&str] = &["java.apply.workspaceEdit"];
@@ -645,4 +646,13 @@ pub struct LanguageStatusParams {
 pub enum RootMarkers {
     Array(Vec<String>),
     Map(HashMap<String, Vec<String>>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CqueryProgressParams {
+    pub indexRequestCount: u64,
+    pub doIdMapCount: u64,
+    pub loadPreviousIndexCount: u64,
+    pub onIdMappedCount: u64,
+    pub onIndexedCount: u64,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,6 +53,9 @@ pub const NOTIFICATION__NCMRefresh: &str = "LanguageClient_NCMRefresh";
 
 // Extensions by language servers.
 pub const REQUEST__RustImplementations: &str = "rustDocument/implementations";
+pub const NOTIFICATION__RustBeginBuild: &str = "rustDocument/beginBuild";
+pub const NOTIFICATION__RustDiagnosticsBegin: &str = "rustDocument/diagnosticsBegin";
+pub const NOTIFICATION__RustDiagnosticsEnd: &str = "rustDocument/diagnosticsEnd";
 pub const NOTIFICATION__LanguageStatus: &str = "language/status";
 
 pub const CommandsClient: &[&str] = &["java.apply.workspaceEdit"];

--- a/src/types.rs
+++ b/src/types.rs
@@ -82,6 +82,8 @@ pub struct State {
     pub last_cursor_line: u64,
     pub last_line_diagnostic: String,
     pub stashed_codeAction_commands: Vec<Command>,
+    pub showed_first_build_complete: bool,
+    pub showed_cquery_build_progress: bool,
 
     // User settings.
     pub serverCommands: HashMap<String, Vec<String>>,
@@ -115,6 +117,8 @@ impl State {
             last_cursor_line: 0,
             last_line_diagnostic: " ".into(),
             stashed_codeAction_commands: vec![],
+            showed_first_build_complete: false,
+            showed_cquery_build_progress: false,
 
             serverCommands: HashMap::new(),
             autoStart: true,


### PR DESCRIPTION
Resolves #235.

This PR adds two global variables:
- `g:LanguageClient_building` is 1 when the language server is building something and 0 otherwise,
- `g:LanguageClient_buildStatus` is a short string describing the build status (`Rust: build started`, `cquery: indexing (5 jobs)`, `cquery: idle`, etc).

It also adds a function, `LanguageClient_statusLine()`, which returns either an empty string or a message like `[Rust: build completed]` which can be put into the statusline.

The variables are updated by listening to RLS's and cqeury's build progress notifications. It's easy to extend the functionality to other language servers.

There's one issue with the implementation: cquery's build progress messages arrive very quickly and due to each message being processed in a separate thread, the next-to-last progress message frequently ends up being processed last and the build status remains set to "building". Not sure what the best way of addressing that would be.