### PR TITLE
Fix warning about unknown project type

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,12 +27,12 @@ pub fn get_rootPath<'a>(path: &'a Path, languageId: &str) -> Result<&'a Path> {
         "haskell" => traverse_up(path, |dir| dir.join("stack.yaml").exists())
             .or_else(|_| traverse_up(path, |dir| dir.join(".cabal").exists())),
         _ => Err(format_err!("Unknown languageId: {}", languageId)),
-    }.or({
+    }.or_else(|_| {
         traverse_up(path, |dir| {
             dir.join(".git").exists() || dir.join(".hg").exists() || dir.join(".svn").exists()
         })
     })
-        .or({
+        .or_else(|_| {
             let parent = path.parent()
                 .ok_or_else(|| format_err!("Failed to get file dir"));
             warn!(


### PR DESCRIPTION
Result.or() gets executed even when the value is Result::Ok, which
causes the warning about "Unknown project type" to show even though the
project directory was successfully found. It also unnecessarily
traverses the directory tree in search for VCS files.