### PR TITLE
Fix replacing placeholders in completion text in deoplete plugin

### DIFF
--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -48,4 +48,7 @@ class Source(Base):
         result = self.vim.funcs.eval("remove({}, 0)".format(CompleteResults))
         if not isinstance(result, list):
             result = []
+        else:
+            for item in result:
+                item["word"] = simplify_snippet(item["word"])
         return result


### PR DESCRIPTION
simplify_snippet is no longer called since 5228816283

I'm not sure how correct this code is, but it works for me. May also fix #232