### PR TITLE
Add includeDeclaration to textDocument/references

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -1263,18 +1263,26 @@ impl ILanguageClient for Arc<Mutex<State>> {
     fn textDocument_references(&self, params: &Option<Params>) -> Result<Value> {
         info!("Begin {}", lsp::request::References::METHOD);
 
-        let (buftype, languageId, filename, line, character, handle): (String, String, String, u64, u64, bool) =
-            self.gather_args(
-                &[
-                    VimVar::Buftype,
-                    VimVar::LanguageId,
-                    VimVar::Filename,
-                    VimVar::Line,
-                    VimVar::Character,
-                    VimVar::Handle,
-                ],
-                params,
-            )?;
+        let (buftype, languageId, filename, line, character, handle, include_declaration): (
+            String,
+            String,
+            String,
+            u64,
+            u64,
+            bool,
+            bool,
+        ) = self.gather_args(
+            &[
+                VimVar::Buftype,
+                VimVar::LanguageId,
+                VimVar::Filename,
+                VimVar::Line,
+                VimVar::Character,
+                VimVar::Handle,
+                VimVar::IncludeDeclaration,
+            ],
+            params,
+        )?;
         if !buftype.is_empty() || languageId.is_empty() {
             return Ok(Value::Null);
         }
@@ -1288,7 +1296,7 @@ impl ILanguageClient for Arc<Mutex<State>> {
                 },
                 position: Position { line, character },
                 context: ReferenceContext {
-                    include_declaration: true,
+                    include_declaration,
                 },
             },
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,9 @@ use std::fs::File;
 use std::env;
 use std::process::{ChildStdin, Stdio};
 
-extern crate log4rs;
 #[macro_use]
 extern crate log;
+extern crate log4rs;
 
 #[macro_use]
 extern crate failure;

--- a/src/types.rs
+++ b/src/types.rs
@@ -511,6 +511,7 @@ pub enum VimVar {
     NewName,
     GotoCmd,
     Handle,
+    IncludeDeclaration,
 }
 
 pub trait VimExp {
@@ -531,6 +532,7 @@ impl VimExp for VimVar {
             VimVar::NewName => "newName",
             VimVar::GotoCmd => "gotoCmd",
             VimVar::Handle => "handle",
+            VimVar::IncludeDeclaration => "includeDeclaration",
         }.to_owned()
     }
 
@@ -545,6 +547,7 @@ impl VimExp for VimVar {
             VimVar::Cword => "expand('<cword>')",
             VimVar::NewName | VimVar::GotoCmd => "v:null",
             VimVar::Handle => "v:true",
+            VimVar::IncludeDeclaration => "v:true",
         }.to_owned()
     }
 }


### PR DESCRIPTION
If users want to include declarations:

```vim
nn <M-,> :call LanguageClient_textDocument_references({'includeDeclaration': v:true})<cr>
```