### PR TITLE
Clear cache before creating completion candidates in deoplete.

### DIFF
--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -39,6 +39,7 @@ class Source(Base):
     def gather_candidates(self, context):
         if not context["is_async"]:
             context["is_async"] = True
+            self.vim.command("let {} = []".format(CompleteResults))
             self.vim.funcs.LanguageClient_omniComplete()
             return []
         elif self.vim.funcs.eval("len({})".format(CompleteResults)) == 0:


### PR DESCRIPTION
I encountered a problem in which completion candidates do not work out if I type Backspace during completion similar to #281.

Since it seemed that the previous completion candidates remained, I cleared the previous completion result each time we create an completion candidate.

Thank you.