### PR TITLE
Fix file path calculation when using FZF

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -1838,14 +1838,8 @@ pub trait ILanguageClient: IVim {
                 .pop()
                 .ok_or_else(|| format_err!("Failed to get file path! tokens: {:?}", tokens))?
                 .to_owned();
-            let languageId: String = self.eval(VimVar::LanguageId)?;
-            let root =
-                self.get(|state| {
-                    state.roots.get(&languageId).cloned().ok_or_else(|| {
-                        format_err!("Failed to get root! languageId: {}", languageId)
-                    })
-                })?;
-            Path::new(&root)
+            let cwd: String = self.eval("getcwd()")?;
+            Path::new(&cwd)
                 .join(relpath)
                 .to_str()
                 .ok_or_else(|| err_msg("Failed to convert PathBuf to str"))?


### PR DESCRIPTION
When a list of locations are received from language server, relative
path is calculated from getcwd() before passing to FZF for selection.
However, when a selection is returned, the relative path is appended
to project root rather than cwd, which will result in the wrong file
being opened. Fix this by appending relative path to cwd instead.