### PR TITLE
Fix deoplete completion issue.

### DIFF
--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -551,7 +551,7 @@ function! LanguageClient_NCMRefresh(info, context) abort
     return LanguageClient#Notify('LanguageClient_NCMRefresh', [a:info, a:context])
 endfunction
 
-let g:LanguageClient_completeResults = []
+let g:LanguageClient_omniCompleteResults = []
 function! LanguageClient_omniComplete(...) abort
     try
         let l:params = {
@@ -563,14 +563,15 @@ function! LanguageClient_omniComplete(...) abort
                     \ 'handle': v:false,
                     \ }
         call extend(l:params, a:0 >= 1 ? a:1 : {})
-        let l:callback = a:0 >= 2 ? a:2 : g:LanguageClient_completeResults
+        let l:callback = a:0 >= 2 ? a:2 : g:LanguageClient_omniCompleteResults
         call LanguageClient#Call('languageClient/omniComplete', l:params, l:callback)
     catch
-        call add(g:LanguageClient_completeResults, v:null)
+        call add(a:0 >= 2 ? a:2 : g:LanguageClient_omniCompleteResults, v:null)
         call s:Debug(string(v:exception))
     endtry
 endfunction
 
+let g:LanguageClient_completeResults = []
 function! LanguageClient#complete(findstart, base) abort
     if a:findstart
         let l:line = getline('.')
@@ -582,7 +583,7 @@ function! LanguageClient#complete(findstart, base) abort
     else
         call LanguageClient_omniComplete({
                     \ 'character': col('.') - 1 + len(a:base),
-                    \ })
+                    \ }, g:LanguageClient_completeResults)
         while len(g:LanguageClient_completeResults) == 0
             sleep 100m
         endwhile

--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -1,7 +1,8 @@
 from .base import Base
+import re
 
 
-CompleteResults = "g:LanguageClient_completeResults"
+CompleteResults = "g:LanguageClient_omniCompleteResults"
 
 
 class Source(Base):
@@ -11,19 +12,27 @@ class Source(Base):
         self.name = "LanguageClient"
         self.mark = "[LC]"
         self.rank = 1000
+        self.sorters = ["sorter_word"]
+        self.min_pattern_length = 1
         self.filetypes = vim.eval(
             "get(g:, 'LanguageClient_serverCommands', {})").keys()
+        self.input_pattern += r'(\.|::|->)\w*$'
+        self.complete_pos = re.compile(r"\w*$")
+
+    def get_complete_position(self, context):
+        m = self.complete_pos.search(context['input'])
+        return m.start() if m else -1
 
     def gather_candidates(self, context):
-        if not context["is_async"]:
+        if context["is_async"]:
+            results = self.vim.eval(CompleteResults)
+            if len(results) != 0:
+                context["is_async"] = False
+                return results[0]
+        else:
             context["is_async"] = True
-            self.vim.funcs.LanguageClient_omniComplete()
-            return []
-        elif self.vim.funcs.eval("len({})".format(CompleteResults)) == 0:
-            return []
-
-        context["is_async"] = False
-        result = self.vim.funcs.eval("remove({}, 0)".format(CompleteResults))
-        if not isinstance(result, list):
-            result = []
-        return result
+            self.vim.command("let {0} = []".format(CompleteResults))
+            self.vim.funcs.LanguageClient_omniComplete(
+                    {"character": context["complete_position"]}
+            )
+        return []


### PR DESCRIPTION
Fix Backspace problem(#281).
It solved by separating deoplete completion function(LanguageClient_omniComplete) and vim's omni complete function(LanguageClient#complete) in plugin/LanguageClient.vim, and completion results are cleared for each completion in deoplete source.

And fix input_pattern problem(#329), but problems still remain.
The current status can be complemented with words and complemented by "." And "::" and "->", but it does not correspond to other patterns.

There is no problem with Rust and Vue, JavaScript and TypeScript which I am using completion, but it may not work in other languages.I think it is necessary to respond separately for each language.

Since I can not solve this problem alone, I will set up an Issue or Pull Requrst separately.