### PR TITLE
Make sure bin/languageclient is always executable if built locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ vint:
 release:
 	cargo build --release
 	cp -f target/release/languageclient bin/
+	chmod a+x bin/languageclient
 
 bump-version:
 	cargo release --level=patch


### PR DESCRIPTION
`make release` was missing making `bin/languageclient` executable which shows this error when you open neovim

```sh
$ nvim
LanguageClient: Not executable!
Press ENTER or type command to continue
```