### PR TITLE
Handle new RLS build notifications

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -2074,45 +2074,40 @@ pub trait ILanguageClient: IVim {
         Ok(())
     }
 
-    fn window_handleProgress(&self, params: &Option<Params>) -> Result<()> {
+    fn window_progress(&self, params: &Option<Params>) -> Result<()> {
         info!("Begin {}", NOTIFICATION__WindowProgress);
         let params: WindowProgressParams = serde_json::from_value(params.clone().to_value())?;
 
-        let busy = !params.done.unwrap_or(false);
+        let done = params.done.unwrap_or(false);
 
         let mut buf = "LS: ".to_owned();
 
-        if busy {
+        if done {
+            buf += "Idle";
+        } else {
             // For RLS this can be "Build" or "Diagnostics" or "Indexing".
-            buf.push_str(
-                params
-                    .title
-                    .as_ref()
-                    .map(|title| title.as_ref())
-                    .unwrap_or("Busy"),
-            );
+            buf += params
+                .title
+                .as_ref()
+                .map(|title| title.as_ref())
+                .unwrap_or("Busy");
 
             // For RLS this is the crate name, present only if the progress isn't known.
             if let Some(message) = params.message {
-                buf.push_str(&format!(" ({})", &message));
+                buf += &format!(" ({})", &message);
             }
             // For RLS this is the progress percentage, present only if the it's known.
             if let Some(percentage) = params.percentage {
-                buf.push_str(&format!(" ({:.1}% done)", percentage));
+                buf += &format!(" ({:.1}% done)", percentage);
             }
-        } else {
-            buf.push_str("Idle");
         }
-
-        // Sanitize before sending to vim.
-        buf.replace('\'', "''");
 
         self.command(&format!(
             "let {}={} | let {}='{}'",
             VIM__ServerStatus,
-            if busy { 1 } else { 0 },
+            if done { 0 } else { 1 },
             VIM__ServerStatusMessage,
-            &buf
+            &escape_single_quote(buf)
         ))?;
         info!("End {}", NOTIFICATION__WindowProgress);
         Ok(())

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -119,7 +119,7 @@ impl IRpcHandler for Arc<Mutex<State>> {
             NOTIFICATION__RustDiagnosticsEnd => {
                 self.rust_handleDiagnosticsEnd(&notification.params)?
             }
-            NOTIFICATION__WindowProgress => self.window_handleProgress(&notification.params)?,
+            NOTIFICATION__WindowProgress => self.window_progress(&notification.params)?,
             NOTIFICATION__CqueryProgress => self.cquery_handleProgress(&notification.params)?,
 
             _ => {

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -119,6 +119,7 @@ impl IRpcHandler for Arc<Mutex<State>> {
             NOTIFICATION__RustDiagnosticsEnd => {
                 self.rust_handleDiagnosticsEnd(&notification.params)?
             }
+            NOTIFICATION__WindowProgress => self.window_handleProgress(&notification.params)?,
             NOTIFICATION__CqueryProgress => self.cquery_handleProgress(&notification.params)?,
 
             _ => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,6 +30,9 @@ pub const REQUEST__RustImplementations: &str = "rustDocument/implementations";
 pub const NOTIFICATION__RustBeginBuild: &str = "rustDocument/beginBuild";
 pub const NOTIFICATION__RustDiagnosticsBegin: &str = "rustDocument/diagnosticsBegin";
 pub const NOTIFICATION__RustDiagnosticsEnd: &str = "rustDocument/diagnosticsEnd";
+// This is an RLS extension but the name is general enough to assume it might be implemented by
+// other language servers or planned for inclusion in the base protocol.
+pub const NOTIFICATION__WindowProgress: &str = "window/progress";
 pub const REQUEST__CqueryBase: &str = "$cquery/base";
 pub const REQUEST__CqueryCallers: &str = "$cquery/callers";
 pub const REQUEST__CqueryDerived: &str = "$cquery/derived";
@@ -523,7 +526,7 @@ impl ToDisplay for lsp::MarkedString {
                 buf.push("```".to_string());
 
                 buf
-            },
+            }
         }
     }
 }
@@ -725,6 +728,14 @@ pub struct LanguageStatusParams {
 pub enum RootMarkers {
     Array(Vec<String>),
     Map(HashMap<String, Vec<String>>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WindowProgressParams {
+    pub title: Option<String>,
+    pub message: Option<String>,
+    pub percentage: Option<f64>,
+    pub done: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
With Rust 1.25.0, RLS delivers new (more interesting) progress messages.

The notification name seems general enough though, so instead of outputting `Rust: <something>` I decided to output `LS: <something>` for "LanguageServer".

I tested this and it seems to work well.

I'm yet to see it output `params.percentage` though, it's specified in their [docs](https://github.com/rust-lang-nursery/rls/blob/master/contributing.md#extensions-to-the-language-server-protocol) and there's a reference in the [source](https://github.com/rust-lang-nursery/rls/blob/f5a0c91a39368395b1c1ad322e04be7b6074bc65/src/build/plan.rs#L499-L502) but I'm not sure when that happens.

The comma in the `MarkedString` was removed by `cargo fmt`, I can strip that change away if needed.