### PR TITLE
Remove __init__.py from rootMarkers

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,9 +45,7 @@ pub fn get_rootPath<'a>(
         "rust" => traverse_up(path, |dir| dir.join("Cargo.toml").exists()),
         "php" => traverse_up(path, |dir| dir.join("composer.json").exists()),
         "javascript" | "typescript" => traverse_up(path, |dir| dir.join("package.json").exists()),
-        "python" => traverse_up(path, |dir| {
-            dir.join("__init__.py").exists() || dir.join("setup.py").exists()
-        }),
+        "python" => traverse_up(path, |dir| dir.join("setup.py").exists()),
         "c" | "cpp" => traverse_up(path, |dir| dir.join("compile_commands.json").exists()),
         "cs" => traverse_up(path, is_dotnet_root),
         "java" => traverse_up(path, |dir| {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,7 +45,11 @@ pub fn get_rootPath<'a>(
         "rust" => traverse_up(path, |dir| dir.join("Cargo.toml").exists()),
         "php" => traverse_up(path, |dir| dir.join("composer.json").exists()),
         "javascript" | "typescript" => traverse_up(path, |dir| dir.join("package.json").exists()),
-        "python" => traverse_up(path, |dir| dir.join("setup.py").exists()),
+        "python" => traverse_up(path, |dir| {
+            dir.join("setup.py").exists()
+                || dir.join("Pipfile").exists()
+                || dir.join("requirements.txt").exists()
+        }),
         "c" | "cpp" => traverse_up(path, |dir| dir.join("compile_commands.json").exists()),
         "cs" => traverse_up(path, is_dotnet_root),
         "java" => traverse_up(path, |dir| {


### PR DESCRIPTION
In python a common folder layout is something like:

    /
    /pkg_name
    /pkg_name/__init__.py
    /pkg_name/main.py
    /setup.py
    /setup.cfg

If `__init__py` is used as root marker the root will be `/pkg_name`.
This is for example problematic for
https://github.com/palantir/python-language-server because it picks up
certain settings from `setup.cfg` or `tox.ini` (among others)


(Maybe it would make sense to add `requirements.txt` or `Pipfile` instead)