### PR TITLE
Add `DiagnosticsList::Disabled` option

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -142,7 +142,7 @@ Valid options: "off" | "messages" | "verbose"
 List used to fill diagnostic messages.
 
 Default: "Quickfix"
-Valid options: "Quickfix" | "Location" | |v:null|
+Valid options: "Quickfix" | "Location" | "Disabled"
 
 2.9 g:LanguageClient_diagnosticsEnable    *g:LanguageClient_diagnosticsEnable*
 

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -1676,6 +1676,7 @@ pub trait ILanguageClient: IVim {
                     bail!("Failed to set location list!");
                 }
             }
+            DiagnosticsList::Disabled => {}
         }
 
         let current_filename: String = self.eval(VimVar::Filename)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -173,6 +173,7 @@ impl FromStr for SelectionUI {
 pub enum DiagnosticsList {
     Quickfix,
     Location,
+    Disabled,
 }
 
 impl Default for DiagnosticsList {
@@ -188,6 +189,7 @@ impl FromStr for DiagnosticsList {
         match s.to_ascii_uppercase().as_str() {
             "QUICKFIX" => Ok(DiagnosticsList::Quickfix),
             "LOCATION" => Ok(DiagnosticsList::Location),
+            "DISABLED" => Ok(DiagnosticsList::Disabled),
             _ => bail!("Invalid option for LanguageClient_diagnosticsList: {}", s),
         }
     }


### PR DESCRIPTION
When picked, neither the quickfix list nor the loclist will be modified by LanguageClient-neovim.

The ability to set it to `v:null` was removed at [commit 5de7a52](https://github.com/autozimu/LanguageClient-neovim/commit/5de7a52a23c13097065f57487933dca0d30b0c02#diff-ba80c739c25b55f01f58c3724bcc93ddL295). I'm making it explicit to make sure it won't get accidentally removed again.