### PR TITLE
LanguageClient-neovim should tell the truth

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -46,19 +46,6 @@ function! s:Debug(message) abort
 endfunction
 
 function! s:hasSnippetSupport() abort
-    " https://github.com/SirVer/ultisnips
-    if exists('g:did_plugin_ultisnips')
-        return 1
-    endif
-    " https://github.com/Shougo/neosnippet.vim
-    if exists('g:loaded_neosnippet')
-        return 1
-    endif
-    " https://github.com/garbas/vim-snipmate
-    if exists('loaded_snips')
-        return 1
-    endif
-
     return 0
 endfunction
 


### PR DESCRIPTION
LanguageClient-neovim not have the ability to handle snippet kind of completion, even if the user have snippet plugin,
None of them works with LanguageClient-neovim.

Current implementation would send :
```
10:37:21 INFO Handler-main src/vim.rs:135 => {"jsonrpc":"2.0","method":"initialize","params":{"capabilities":{"textDocument":{"completion":{"completionItem":{"commitCharactersSupport":null,"documentationFormat":null,"snippetSupport":true},"dynamicRegistration":null}}}
``` 
on initialize and  make the LSP server send bad snippet completion item sometimes.