### PR TITLE
Use bash for install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Try install by
 #   - download binary
 #   - build with cargo

--- a/install.sh
+++ b/install.sh
@@ -1,30 +1,29 @@
 #!/usr/bin/env bash
 # Try install by
-#   - download binary
 #   - build with cargo
 
-set -o nounset    # error when referencing undefined variable
-set -o errexit    # exit when command fails
+set -o nounset # error when referencing undefined variable
+set -o errexit # exit when command fails
 set -o pipefail
 
 version=0.1.77
 name=languageclient
 
-function try_curl() {
-    command -v curl > /dev/null && \
-        curl --fail --location $1 --output bin/$name
+try_curl() {
+    command -v curl >/dev/null &&
+        curl --fail --location "$1" --output bin/$name
 }
 
-function try_wget() {
-    command -v wget > /dev/null && \
-        wget --output-document=bin/$name $1
+try_wget() {
+    command -v wget >/dev/null &&
+        wget --output-document="bin/$name" "$1"
 }
 
-function download() {
+download() {
     echo "Downloading bin/${name}..."
     local url=https://github.com/autozimu/LanguageClient-neovim/releases/download/$version/${1}
-    if (try_curl $url || try_wget $url); then
-        chmod a+x bin/$name
+    if (try_curl "$url" || try_wget "$url"); then
+        chmod a+x "bin/$name"
         return
     else
         echo "Failed to download with curl and wget"
@@ -39,8 +38,7 @@ function try_build() {
 
 rm -f bin/languageclient
 
-arch=$(uname -sm)
-binary=""
+arch="$(uname -sm)"
 case "${arch}" in
     "Linux x86_64") download $name-$version-x86_64-unknown-linux-musl ;;
     "Linux i686") download $name-$version-i686-unknown-linux-musl ;;


### PR DESCRIPTION
The script assumes bash only features anyway and the install instructions in the
README say to use bash.