### PR TITLE
Add g:LanguageClient_hoverPreview option

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -231,12 +231,12 @@ Valid options: number
 2.19 g:LanguageClient_hoverPreview             *g:LanguageClient_hoverPreview*
 
 Controls how hover output is displayed. Must be one of the following:
-    0 - Never use preview window, always echo hover output
-    1 - Use preview window for hover entries longer than one line (default)
-    2 - Always use preview window, never echo hover output
+    Never  - Never use preview window, always echo hover output
+    Auto   - Use preview window for hover entries longer than one line (default)
+    Always - Always use preview window, never echo hover output
 
-Default: 1
-Valid options: 0 | 1 | 2
+Default: "Auto"
+Valid options: "Never", "Auto", "Always"
 
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -228,6 +228,16 @@ before timing out.
 Default: 10
 Valid options: number
 
+2.19 g:LanguageClient_hoverPreview             *g:LanguageClient_hoverPreview*
+
+Controls how hover output is displayed. Must be one of the following:
+    0 - Never use preview window, always echo hover output
+    1 - Use preview window for hover entries longer than one line (default)
+    2 - Always use preview window, never echo hover output
+
+Default: 1
+Valid options: 0 | 1 | 2
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -67,6 +67,7 @@ impl State {
             diagnosticsList,
             diagnosticsDisplay,
             windowLogMessageLevel,
+            hoverPreview,
             is_nvim,
         ): (
             u64,
@@ -82,6 +83,7 @@ impl State {
             Option<String>,
             Value,
             String,
+            Option<String>,
             u64,
         ) = self.eval(
             [
@@ -98,6 +100,7 @@ impl State {
                 "get(g:, 'LanguageClient_diagnosticsList', 'Quickfix')",
                 "get(g:, 'LanguageClient_diagnosticsDisplay', {})",
                 "get(g:, 'LanguageClient_windowLogMessageLevel', 'Warning')",
+                "get(g:, 'LanguageClient_hoverPreview', 'Auto')",
                 "has('nvim')",
             ].as_ref(),
         )?;
@@ -147,6 +150,12 @@ impl State {
             ),
         };
 
+        let hoverPreview = if let Some(s) = hoverPreview {
+            HoverPreviewOption::from_str(&s)?
+        } else {
+            HoverPreviewOption::Auto
+        };
+
         let is_nvim = is_nvim == 1;
 
         self.update(|state| {
@@ -165,6 +174,7 @@ impl State {
             state.rootMarkers = rootMarkers;
             state.change_throttle = change_throttle;
             state.wait_output_timeout = wait_output_timeout;
+            state.hoverPreview = hoverPreview;
             state.is_nvim = is_nvim;
             Ok(())
         })?;
@@ -720,14 +730,13 @@ impl State {
             return Ok(result);
         }
 
-        let hover_preview: u8 = self.eval("get(g:, 'LanguageClient_hoverPreview', 1)")?;
-
         let hover: Option<Hover> = serde_json::from_value(result.clone())?;
         if let Some(hover) = hover {
-            if hover_preview == 2 || (hover_preview == 1 && hover.lines_len() > 1) {
-                self.preview(&hover.to_display())?;
-            } else {
-                self.echo(hover.to_string().lines().last().unwrap_or_default())?;
+            match (&self.hoverPreview, hover.lines_len()) {
+                (HoverPreviewOption::Always, _) => self.preview(&hover.to_display())?,
+                (HoverPreviewOption::Auto, 1) => self.echo_ellipsis(hover.to_string())?,
+                (HoverPreviewOption::Auto, _) => self.preview(&hover.to_display())?,
+                (HoverPreviewOption::Never, _) => self.echo_ellipsis(hover.to_string())?,
             }
         }
 

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -720,14 +720,17 @@ impl State {
             return Ok(result);
         }
 
+        let hover_preview: u8 = self.eval("get(g:, 'LanguageClient_hoverPreview', 1)")?;
+
         let hover: Option<Hover> = serde_json::from_value(result.clone())?;
         if let Some(hover) = hover {
-            if hover.lines_len() <= 1 {
-                self.echo(hover.to_string())?;
-            } else {
+            if hover_preview == 2 || (hover_preview == 1 && hover.lines_len() > 1) {
                 self.preview(&hover.to_display())?;
+            } else {
+                self.echo(hover.to_string().lines().last().unwrap_or_default())?;
             }
         }
+
 
         info!("End {}", lsp::request::HoverRequest::METHOD);
         Ok(result)

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,6 +123,7 @@ pub struct State {
     pub rootMarkers: Option<RootMarkers>,
     pub change_throttle: Option<Duration>,
     pub wait_output_timeout: Duration,
+    pub hoverPreview: HoverPreviewOption,
 
     #[serde(skip_serializing)]
     pub logger: log4rs::Handle,
@@ -184,6 +185,7 @@ impl State {
             rootMarkers: None,
             change_throttle: None,
             wait_output_timeout: Duration::from_secs(10),
+            hoverPreview: HoverPreviewOption::default(),
 
             logger,
         })
@@ -212,6 +214,32 @@ impl FromStr for SelectionUI {
             "QUICKFIX" => Ok(SelectionUI::Quickfix),
             "LOCATIONLIST" | "LOCATION-LIST" => Ok(SelectionUI::LocationList),
             _ => bail!("Invalid option for LanguageClient_selectionUI: {}", s),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum HoverPreviewOption {
+    Always,
+    Auto,
+    Never,
+}
+
+impl Default for HoverPreviewOption {
+    fn default() -> Self {
+        HoverPreviewOption::Auto
+    }
+}
+
+impl FromStr for HoverPreviewOption {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_ascii_uppercase().as_str() {
+            "ALWAYS" => Ok(HoverPreviewOption::Always),
+            "AUTO" => Ok(HoverPreviewOption::Auto),
+            "NEVER" => Ok(HoverPreviewOption::Never),
+            _ => bail!("Invalid option for LanguageClient_hoverPreview: {}", s),
         }
     }
 }


### PR DESCRIPTION
Fixes: #428 

Add a new global option `g:LanguageClient_hoverPreview` with three valid values:
'Never': Never use preview window, always echo hover output
'Auto': Use preview window for hover entries longer than one line (default)
'Always': Always use preview window, never echo hover output