### PR TITLE
Add context menu with all available actions. #442

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ More recordings at [Updates, screenshots & GIFs](https://github.com/autozimu/Lan
 
 - Non-blocking asynchronous calls.
 - [Sensible completion](https://github.com/autozimu/LanguageClient-neovim/issues/35#issuecomment-288731936).
-  Integrated with [deoplete](https://github.com/Shougo/deoplete.nvim) 
+  Integrated with [deoplete](https://github.com/Shougo/deoplete.nvim)
   or [nvim-completion-manager](https://github.com/roxma/nvim-completion-manager). Or with vim built-in `omnifunc`.
 - [Realtime diagnostics/compiler/lint message.](https://github.com/autozimu/LanguageClient-neovim/issues/35#issuecomment-288732042)
 - [Rename.](https://github.com/autozimu/LanguageClient-neovim/issues/35#issuecomment-288731403)
@@ -56,6 +56,8 @@ let g:LanguageClient_serverCommands = {
     \ 'javascript.jsx': ['tcp://127.0.0.1:2089'],
     \ }
 
+nnoremap <F5> :call LanguageClient_contextMenu()<CR>
+" Or map each action separately
 nnoremap <silent> K :call LanguageClient#textDocument_hover()<CR>
 nnoremap <silent> gd :call LanguageClient#textDocument_definition()<CR>
 nnoremap <silent> <F2> :call LanguageClient#textDocument_rename()<CR>

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -238,6 +238,13 @@ Controls how hover output is displayed. Must be one of the following:
 Default: "Auto"
 Valid options: "Never", "Auto", "Always"
 
+2.20 g:LanguageClient_fzfContextMenu         *g:LanguageClient_fzfContextMenu*
+
+Should FZF be used for `LanguageClient_contextMenu()`.
+
+Default: 1
+Valid options: 1 | 0
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 
@@ -266,6 +273,20 @@ handled by this plugin default handler.
 Signature: LanguageClient#Notify(method: String, params: Map | List)
 
 Send a notification to the current language server.
+
+*LanguageClient_contextMenu()*
+Signature: LanguageClient#contextMenu(...)
+
+Show list of all available actions.
+
+If optional dependency FZF is installed, actions will be displayed in a FZF
+prompt, selecting one of the action will then call the action's function.
+
+To skip FZF prompt even if FZF is installed and use native numbered list,
+add this variable to vimrc:
+`let g:LanguageClient_fzfContextMenu = 0`
+
+For Denite users, a source with name 'contextMenu' is provided.
 
 *LanguageClient#textDocument_hover()*
 *LanguageClient_textDocument_hover()*

--- a/rplugin/python3/denite/source/contextMenu.py
+++ b/rplugin/python3/denite/source/contextMenu.py
@@ -1,0 +1,21 @@
+from typing import List, Dict
+from .base import Base
+
+
+class Source(Base):
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'contextMenu'
+        self.kind = 'command'
+
+    def convert_to_candidate(self, item):
+        return {
+            "word": item,
+            'action__command': 'call '
+            'LanguageClient_handleContextMenuItem("{}")'.format(item),
+        }
+
+    def gather_candidates(self, context: Dict) -> List[Dict]:
+        result = self.vim.funcs.LanguageClient_contextMenuItems() or {}
+        return [self.convert_to_candidate(key) for key in result.keys()]


### PR DESCRIPTION
Here's implementation of context menu discussed in https://github.com/autozimu/LanguageClient-neovim/issues/442. I think i put all available actions in the dictionary. If i missed some, let me know.

By default, it uses native `inputlist()` with the numbered list, where you can select the action by number. Like a second screenshot in issue.

If fzf iz available, it wraps prompt in it, like documentSymbol for example.

For Denite users, `contextMenu` source is added.