### PR TITLE
Don’t open hover preview window on empty output

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -768,11 +768,15 @@ impl State {
 
         let hover: Option<Hover> = serde_json::from_value(result.clone())?;
         if let Some(hover) = hover {
-            match (&self.hoverPreview, hover.lines_len()) {
-                (HoverPreviewOption::Always, _) => self.preview(&hover.to_display())?,
-                (HoverPreviewOption::Auto, 1) => self.echo_ellipsis(hover.to_string())?,
-                (HoverPreviewOption::Auto, _) => self.preview(&hover.to_display())?,
-                (HoverPreviewOption::Never, _) => self.echo_ellipsis(hover.to_string())?,
+            let use_preview = match &self.hoverPreview {
+                HoverPreviewOption::Always => true,
+                HoverPreviewOption::Never => false,
+                HoverPreviewOption::Auto => hover.lines_len() > 1,
+            };
+            if use_preview {
+                self.preview(&hover.to_display())?
+            } else {
+                self.echo_ellipsis(hover.to_string())?
             }
         }
 


### PR DESCRIPTION
Summary:
This fixes a bug in #443. With the default “auto” setting, the preview
window is supposed to open “for hover entries longer than one line”, but
in fact it opens for hover output with line count not exactly 1; that
is, it opens on empty output as well.

After this patch, empty hover output will result in an empty string
being echoed.

Test Plan:
With the default setting for this variable, trigger hover text with line
counts zero, one, and more than one, and note that only the last
category opens the preview window.

wchargin-branch: hover-no-preview-empty