### PR TITLE
Fix match in completion

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -775,7 +775,14 @@ function! LanguageClient#complete(findstart, base) abort
         let l:line = getline('.')
         let l:cursor = LSP#character()
         let l:input = l:line[:l:cursor]
-        let l:start = match(l:input, '\%(.\{-}[^\k]\{-}\)*\zs\k*\ze.\=$')
+
+        " Check for no identifier chars, but cursor is right after a non identifier char
+        " ie completing when the cursor is after the '.' in 'foo_class.'
+        if l:input[l:cursor-1:l:cursor-1] !~# "\k"
+            let l:start = l:cursor
+        else
+            let l:start = match(l:input, '\k*\ze[^\k]\=$')
+        endif
         return l:start
     else
         let l:result = LanguageClient_runSync(

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -778,10 +778,10 @@ function! LanguageClient#complete(findstart, base) abort
 
         " Check for no identifier chars, but cursor is right after a non identifier char
         " ie completing when the cursor is after the '.' in 'foo_class.'
-        if l:input[l:cursor-1:l:cursor-1] !~# "\k"
+        if l:input[l:cursor-1:l:cursor-1] !~# "\w"
             let l:start = l:cursor
         else
-            let l:start = match(l:input, '\k*\ze[^\k]\=$')
+            let l:start = match(l:input, '\k*\ze\W*$')
         endif
         return l:start
     else

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -775,7 +775,7 @@ function! LanguageClient#complete(findstart, base) abort
         let l:line = getline('.')
         let l:cursor = LSP#character()
         let l:input = l:line[:l:cursor]
-        let l:start = match(l:input, '\k*\ze\K')
+        let l:start = match(l:input, '\%(.\{-}[^\k]\{-}\)*\zs\k*\ze.\=$')
         return l:start
     else
         let l:result = LanguageClient_runSync(

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -775,7 +775,7 @@ function! LanguageClient#complete(findstart, base) abort
         let l:line = getline('.')
         let l:cursor = LSP#character()
         let l:input = l:line[:l:cursor]
-        let l:start = match(l:input, '\k*$')
+        let l:start = match(l:input, '\k*\ze\K')
         return l:start
     else
         let l:result = LanguageClient_runSync(


### PR DESCRIPTION
Some language servers send non-keyword characters like ';',
so the old pattern doesn't match. Which caused situations like:
```c
fo# -> foo(#);

foo(ba#); -> foo(babar#);
```