### PR TITLE
Change preview buffer name to avoid conflicts with fugitive

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -618,7 +618,7 @@ impl State {
     where
         S: AsRef<str> + Serialize,
     {
-        let bufname = "//LanguageClient";
+        let bufname = "__LanguageClient__";
 
         let mut cmd = String::new();
         cmd += "silent! pedit! +setlocal\\ buftype=nofile\\ filetype=markdown\\ nobuflisted\\ noswapfile\\ nonumber ";

--- a/tests/LanguageClient_test.py
+++ b/tests/LanguageClient_test.py
@@ -57,7 +57,7 @@ def test_textDocument_hover(nvim):
     nvim.funcs.cursor(13, 19)
     nvim.funcs.LanguageClient_textDocument_hover()
     time.sleep(1)
-    b = next(b for b in nvim.buffers if b.name.endswith('LanguageClient'))
+    b = next(b for b in nvim.buffers if b.name.endswith('__LanguageClient__'))
     expect = "function greet(): number"
 
     assert expect in b


### PR DESCRIPTION
When LanguageClient-neovim opens a preview buffer, my Vim echoes the following error message:
```
'Vim(let):E94: No matching buffer for /LanguageClient'
```
This is because [fugitive](https://github.com/tpope/vim-fugitive) does something nasty to buffers whose name is started with `//`. The code of fugitive is a little bit complex, I don't want to spend time on it. 

As many plugins surround temp buffer with "__", I change it from `//LanguageClient` to `__LanguageClient__`.