### PR TITLE
Add jdt-language-server to Dockerfile and vimrc

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,6 +12,16 @@ RUN rustup component add rls-preview rust-analysis rust-src \
         && rustc --version \
         && rls --version
 
+# The first mkdir is a workaround for the following debian bug:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
+RUN mkdir -p /usr/share/man/man1 \
+        && apt-get install --yes openjdk-8-jdk-headless \
+        && mkdir -p /jdtls \
+        && cd /jdtls \
+        && curl -sL http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz | tar -xz \
+        && cd plugins \
+        && ln -s org.eclipse.equinox.launcher_*.jar org.eclipse.equinox.launcher_.jar
+
 ENV CARGO_TARGET_DIR=/tmp
 
 CMD /bin/bash

--- a/tests/data/vimrc
+++ b/tests/data/vimrc
@@ -24,6 +24,18 @@ let g:LanguageClient_serverCommands = {
     \ 'javascript': ['javascript-typescript-stdio'],
     \ 'typescript': ['javascript-typescript-stdio'],
     \ 'rust': ['rustup', 'run', 'stable', 'rls'],
+    \ 'java': [
+    \          'java',
+    \          '-Declipse.application=org.eclipse.jdt.ls.core.id1',
+    \          '-Dosgi.bundles.defaultStartLevel=4',
+    \          '-Declipse.product=org.eclipse.jdt.ls.core.product',
+    \          '-Dlog.level=ALL',
+    \          '-noverify',
+    \          '-Xmx1G',
+    \          '-jar', '/jdtls/plugins/org.eclipse.equinox.launcher_.jar',
+    \          '-configuration', '/jdtls/config_linux',
+    \          '-data'
+    \         ]
     \ }
 let g:LanguageClient_selectionUI = 'location-list'
 set formatexpr=LanguageClient#textDocument_rangeFormatting_sync()


### PR DESCRIPTION
A prerequisite for testing on Java data in container,
and for having a base configuration
for issue reproduction and verification.