### PR TITLE
Fix loggingFile in vimrc

### DIFF
--- a/tests/data/vimrc
+++ b/tests/data/vimrc
@@ -17,7 +17,7 @@ autocmd BufRead *.ts setlocal filetype=typescript
 autocmd BufRead *.rs setlocal filetype=rust
 
 let g:LanguageClient_devel = 1
-let g:LanguageClient_loggingLevel = '/tmp/LanguageClient.log'
+let g:LanguageClient_loggingFile = '/tmp/LanguageClient.log'
 let g:LanguageClient_loggingLevel = 'INFO'
 let g:LanguageClient_serverStderr = '/tmp/LanguageServer.log'
 let g:LanguageClient_serverCommands = {


### PR DESCRIPTION
Setting loggingLevel twice in a row is superfluous anyway.