### PR TITLE
Fix FreeBSD detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,6 @@ case "${arch}" in
     "Linux x86_64") download $name-$version-x86_64-unknown-linux-musl ;;
     "Linux i686") download $name-$version-i686-unknown-linux-musl ;;
     "Darwin x86_64") download $name-$version-x86_64-apple-darwin ;;
-    "FreeBSD x86_64") download $name-$version-x86_64-unknown-freebsd ;;
+    "FreeBSD amd64") download $name-$version-x86_64-unknown-freebsd ;;
     *) echo "No pre-built binary available for ${arch}."; try_build ;;
 esac


### PR DESCRIPTION
On FreeBSD, the `uname -sm` command gives the following output for 64-bit Intel processors:

```
$ uname -sm
FreeBSD amd64
```