### PR TITLE
Add diagnostic highlighting to vim

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -463,14 +463,14 @@ impl State {
                     .ok_or_else(|| err_msg("Failed to get display"))?
                     .texthl
                     .clone();
-                let ranges: Vec<_> = dns.iter()
+                let ranges: Vec<Vec<_>> = dns.iter()
                     .flat_map(|dn| {
                         if dn.range.start.line == dn.range.end.line {
                             let length = dn.range.end.character - dn.range.start.character;
                             // Vim line numbers are 1 off
                             // `matchaddpos` expects an array of [line, col, length]
                             // for each match.
-                            vec![[
+                            vec![vec![
                                 dn.range.start.line + 1,
                                 dn.range.start.character + 1,
                                 length,
@@ -478,14 +478,15 @@ impl State {
                         } else {
                             let mut middleLines: Vec<_> = (dn.range.start.line + 1
                                 ..dn.range.end.line)
-                                .map(|l| [l + 1, 0, 0])
+                                .map(|l| vec![l + 1])
                                 .collect();
-                            let startLine = [
+                            let startLine = vec![
                                 dn.range.start.line + 1,
                                 dn.range.start.character + 1,
                                 999_999, //Clear to the end of the line
                             ];
-                            let endLine = [dn.range.end.line + 1, 1, dn.range.end.character + 1];
+                            let endLine =
+                                vec![dn.range.end.line + 1, 1, dn.range.end.character + 1];
                             middleLines.push(startLine);
                             middleLines.push(endLine);
                             middleLines

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -441,8 +441,6 @@ impl State {
                 )?;
             }
         } else {
-            self.call::<_, u8>(None, "clearmatches", json!([]))?;
-
             // Group diagnostics by severity so we can highlight them
             // in a single call.
             let mut match_groups: HashMap<_, Vec<_>> = HashMap::new();
@@ -493,7 +491,18 @@ impl State {
                         }
                     })
                     .collect();
-                self.call::<_, u8>(None, "matchaddpos", json!([hl_group, ranges]))?;
+
+                let match_id = self.call(None, "matchaddpos", json!([hl_group, ranges]))?;
+
+                let mut match_to_delete = None;
+                self.update(|state| {
+                    match_to_delete = state.highlight_match_ids.pop();
+                    state.highlight_match_ids.push(match_id);
+                    Ok(())
+                })?;
+                if let Some(match_id) = match_to_delete {
+                    self.call(None, "matchdelete", json!([match_id]))?;
+                }
             }
         }
 
@@ -1874,6 +1883,15 @@ impl State {
     pub fn exit(&mut self, params: &Option<Params>) -> Result<()> {
         info!("Begin {}", lsp::notification::Exit::METHOD);
         let (languageId,): (String,) = self.gather_args(&[VimVar::LanguageId], params)?;
+
+        //Tidy up highlighting
+        for match_id in self.get(|state| Ok(state.highlight_match_ids.clone()))? {
+            self.call(None, "matchdelete", json!([match_id]))?;
+        }
+        self.update(|state| {
+            state.highlight_match_ids = Vec::new();
+            Ok(())
+        })?;
 
         let result = self.notify(
             Some(&languageId),

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -395,7 +395,6 @@ impl State {
             self.command(&cmd)?;
         }
 
-        // self.call(None, "matchaddpos", json!(["Error", [1]]))?;
         let diagnosticsDisplay = self.get(|state| Ok(state.diagnosticsDisplay.clone()))?;
 
         // Highlight.

--- a/src/types.rs
+++ b/src/types.rs
@@ -101,6 +101,7 @@ pub struct State {
     pub line_diagnostics: HashMap<(String, u64), String>,
     pub signs: HashMap<String, Vec<Sign>>,
     pub highlight_source: Option<u64>,
+    pub highlight_match_ids: Vec<u32>,
     pub user_handlers: HashMap<String, String>,
     #[serde(skip_serializing)]
     pub watchers: HashMap<String, notify::RecommendedWatcher>,
@@ -161,6 +162,7 @@ impl State {
             line_diagnostics: HashMap::new(),
             signs: HashMap::new(),
             highlight_source: None,
+            highlight_match_ids: Vec::new(),
             user_handlers: HashMap::new(),
             watchers: HashMap::new(),
             watcher_rxs: HashMap::new(),


### PR DESCRIPTION
Use `matchaddpos` to add highlight groups to diagnostics in plain old vim