### PR TITLE
Support ncm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ More recordings at [Updates, screenshots & GIFs](https://github.com/autozimu/Lan
 
 - Non-blocking asynchronous calls.
 - [Sensible completion](https://github.com/autozimu/LanguageClient-neovim/issues/35#issuecomment-288731936).
-  Integrated with [deoplete](https://github.com/Shougo/deoplete.nvim)
-  or [nvim-completion-manager](https://github.com/roxma/nvim-completion-manager). Or with vim built-in `omnifunc`.
+  Integrated with [deoplete](https://github.com/Shougo/deoplete.nvim) or
+  [ncm2](https://github.com/ncm2/ncm2). Or with vim built-in `omnifunc`.
 - [Realtime diagnostics/compiler/lint message.](https://github.com/autozimu/LanguageClient-neovim/issues/35#issuecomment-288732042)
 - [Rename.](https://github.com/autozimu/LanguageClient-neovim/issues/35#issuecomment-288731403)
 - [Hover/Get identifer info.](https://github.com/autozimu/LanguageClient-neovim/issues/35#issuecomment-288731665)

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -766,6 +766,12 @@ function! LanguageClient_NCMRefresh(info, context) abort
                 \ }, v:null)
 endfunction
 
+function! LanguageClient_NCM2OnComplete(context) abort
+    return LanguageClient#Call('LanguageClient_NCM2OnComplete', {
+                \ 'ctx': a:context,
+                \ }, v:null)
+endfunction
+
 function! LanguageClient#explainErrorAtPoint(...) abort
     if &buftype !=# '' || &filetype ==# ''
         return

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -585,7 +585,7 @@ impl State {
                 "on_complete": REQUEST__NCM2OnComplete,
             }]),
         )?;
-        info!("End register NCM source");
+        info!("End register NCM2 source");
         Ok(())
     }
 

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -74,6 +74,7 @@ impl State {
             REQUEST__SetLoggingLevel => self.languageClient_setLoggingLevel(&method_call.params),
             REQUEST__RegisterHandlers => self.languageClient_registerHandlers(&method_call.params),
             REQUEST__NCMRefresh => self.NCM_refresh(&method_call.params),
+            REQUEST__NCM2OnComplete => self.NCM2_on_complete(&method_call.params),
             REQUEST__ExplainErrorAtPoint => {
                 self.languageClient_explainErrorAtPoint(&method_call.params)
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -445,11 +445,6 @@ pub struct NCM2Context {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct NCM2OnCompleteParams {
-    pub ctx: NCM2Context,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct VimCompleteItem {
     pub word: String,
     pub abbr: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,7 @@ pub const REQUEST__OmniComplete: &str = "languageClient/omniComplete";
 pub const REQUEST__SetLoggingLevel: &str = "languageClient/setLoggingLevel";
 pub const REQUEST__RegisterHandlers: &str = "languageClient/registerHandlers";
 pub const REQUEST__NCMRefresh: &str = "LanguageClient_NCMRefresh";
+pub const REQUEST__NCM2OnComplete: &str = "LanguageClient_NCM2OnComplete";
 pub const REQUEST__ExplainErrorAtPoint: &str = "$languageClient/explainErrorAtPoint";
 pub const NOTIFICATION__HandleBufNewFile: &str = "languageClient/handleBufNewFile";
 pub const NOTIFICATION__HandleBufReadPost: &str = "languageClient/handleBufReadPost";
@@ -428,6 +429,24 @@ pub struct NCMContext {
 pub struct NCMRefreshParams {
     pub info: NCMInfo,
     pub ctx: NCMContext,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NCM2Context {
+    pub bufnr: u64,
+    pub lnum: u64,
+    pub ccol: u64,
+    pub filetype: String,
+    pub typed: String,
+    pub filepath: String,
+    pub scope: String,
+    pub startccol: u64,
+    pub base: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NCM2OnCompleteParams {
+    pub ctx: NCM2Context,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
https://github.com/ncm2/ncm2

Note that the ctx field in the callback may have extra fields in the future, it could be added either by ncm2 core or by ncm2 plugins. It's better to send the whole copy back instead of sending the strongly typed context, which might lose some data.

```rust
       let orig_ctx: Value = serde_json::from_value(rpc::to_value(params.clone())?)?;
       let orig_ctx = &orig_ctx["ctx"];
```

This PR is tested with rls.