### PR TITLE
fix positioning of edits when applying text edits

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -953,10 +953,15 @@ pub fn to_vim_complete_item(
     preferTextEdit: bool,
 ) -> Result<VimCompleteItem> {
     let abbr = lspitem.label.clone();
+    let new_text = match lspitem.text_edit.clone() {
+        Some(text_edit) => text_edit.new_text,
+        None => lspitem.label.clone()
+    };
+
     let word = lspitem
         .insert_text
         .clone()
-        .unwrap_or_else(|| lspitem.label.clone());
+        .unwrap_or_else(|| new_text);
 
     let mut user_data = VimCompleteItemUserData::new();
 


### PR DESCRIPTION
Here's a sketch of some attempts to fix the positioning problem for the haxe language server.
I have another branch over on the haxe language server itself with some complimentary changes : https://github.com/vshaxe/haxe-languageserver/pull/35#pullrequestreview-129359549

Please bear with me, this is my first time working with rust!

There's actually a few problems at play here.  Ocassionally I'm not sure if fixes are more appropriate in the nvim client, or over on the haxe langserver side.  I'll go through and annotate the sections below. 

This pull request addresses the issues here in a more direct fashion: 
https://github.com/autozimu/LanguageClient-neovim/issues/478
https://github.com/autozimu/LanguageClient-neovim/issues/491


cc @roxma 