### PR TITLE
skip handleCompleteDone if edits is empty, fix ncm2/ncm2#16

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -2210,6 +2210,10 @@ impl State {
             edits.extend(aedits.clone());
         };
 
+        if edits.is_empty() {
+            return Ok(())
+        }
+
         self.apply_TextEdits(filename, &edits)?;
         self.cursor(line + 1, character + 1)
     }


### PR DESCRIPTION
 ncm2/ncm2#16

@HybridEidolon please test this PR

Note that you need to recompile LanguageClient-neovim and make sure the `bin/languageclient` is the latest build.