### PR TITLE
Allow plugins to support additionalTextEdits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_derive = "1"
 serde_json = "1"
 
 jsonrpc-core = "8"
-languageserver-types = "0"
+languageserver-types = ">=0.47.0"
 url = "1"
 pathdiff = "0"
 diff = "0"

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -548,6 +548,16 @@ function! LanguageClient#textDocument_rangeFormatting(...) abort
     return LanguageClient#Call('textDocument/rangeFormatting', l:params, l:callback)
 endfunction
 
+function! LanguageClient#completionItem_resolve(completion_item, ...)
+    let l:callback = get(a:000, 0, v:null)
+    let l:params = {
+                \ 'completionItem': a:completion_item,
+                \ 'handle': s:IsFalse(l:callback)
+                \ }
+    echom "callback: [" . json_encode(l:callback) . "]"
+    return LanguageClient#Call('completionItem/resolve', l:params, l:callback)
+endfunction
+
 function! LanguageClient#textDocument_rangeFormatting_sync(...) abort
     let l:result = LanguageClient_runSync('LanguageClient#textDocument_rangeFormatting', {
                 \ 'handle': v:true,

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -549,12 +549,12 @@ function! LanguageClient#textDocument_rangeFormatting(...) abort
 endfunction
 
 function! LanguageClient#completionItem_resolve(completion_item, ...)
-    let l:callback = get(a:000, 0, v:null)
+    let l:callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'completionItem': a:completion_item,
                 \ 'handle': s:IsFalse(l:callback)
                 \ }
-    echom "callback: [" . json_encode(l:callback) . "]"
+    call extend(l:params, get(a:000, 0, {}))
     return LanguageClient#Call('completionItem/resolve', l:params, l:callback)
 endfunction
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -474,6 +474,8 @@ pub struct VimCompleteItemUserData {
     pub additional_text_edits: Option<Vec<lsp::TextEdit>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snippet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_item: Option<CompletionItem>,
 }
 
 impl VimCompleteItemUserData {
@@ -482,11 +484,13 @@ impl VimCompleteItemUserData {
             text_edit: None,
             additional_text_edits: None,
             snippet: None,
+            completion_item: None,
         }
     }
 
     pub fn is_none(&self) -> bool {
-        self.text_edit.is_none() && self.additional_text_edits.is_none() && self.snippet.is_none()
+        let data = self.completion_item.as_ref().map(|c| c.data.as_ref());
+        return self.text_edit.is_none() && self.additional_text_edits.is_none() && self.snippet.is_none() && data.is_none();
     }
 }
 
@@ -982,6 +986,8 @@ pub fn to_vim_complete_item(
     if lspitem.additional_text_edits.is_some() {
         user_data.additional_text_edits = lspitem.additional_text_edits.clone();
     }
+
+    user_data.completion_item = Some(lspitem.clone());
 
     Ok(VimCompleteItem {
         word,


### PR DESCRIPTION
vue-language-server requires completionItem/resolve to get the additionalTextEdits.

Changes:
- add LanguageClient#completionItem_resolve
- add completion_item in user_data

Demo works with either [ncm2-snipmate](https://github.com/ncm2/ncm2-snipmate) or [ncm2-ultisnips](https://github.com/ncm2/ncm2-ultisnips)

![rec-snipmate](https://user-images.githubusercontent.com/4538941/42627061-827c095c-85fe-11e8-909c-2881336c94b6.gif)
