### PR TITLE
Handle symlinks when switching to buffers.

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -126,14 +126,17 @@ endfunction
 
 function! s:Edit(action, path) abort
     " If editing current file, push current location to jump list.
-    if bufnr(a:path) == bufnr('%')
+    let l:bufnr = bufnr(a:path)
+    if l:bufnr == bufnr('%')
         execute 'normal m`'
+        return
     endif
 
     let l:action = a:action
     " Avoid the 'not saved' warning.
-    if l:action ==# 'edit' && bufnr(a:path) != -1
-        let l:action = 'buffer'
+    if l:action ==# 'edit' && l:bufnr != -1
+        execute 'buffer' l:bufnr
+        return
     endif
 
     execute l:action . ' ' . fnameescape(a:path)


### PR DESCRIPTION
In some setups, the editor and language server may access a file via
different paths due to symlinks.

In Vim, bufnr(path) will resolve symlinks when doing patch matches.
Unlike bufnr, :buffer [bufname] does not resolve symlinks.

Before this change, when the editor/language server have different
symlinked paths, attempting to go to an already-open file would result
in "No matching buffer" errors. Fix this by passing the buffer number to
:buffer instead.