### PR TITLE
Echo some info when calling gotoDefinition

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -953,6 +953,8 @@ impl State {
                     let loc = arr.get(0).ok_or_else(|| err_msg("Not found!"))?;
                     self.edit(&goto_cmd, loc.uri.filepath()?)?;
                     self.cursor(loc.range.start.line + 1, loc.range.start.character + 1)?;
+                    let cmd = format!("echohl Function | echom '[LC]: '.expand('%').' {}:{}' | echohl NONE", loc.range.start.line + 1, loc.range.start.character + 1);
+                    self.command(&cmd)?;
                 }
                 _ => self.display_locations(&arr)?,
             },

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -953,8 +953,8 @@ impl State {
                     let loc = arr.get(0).ok_or_else(|| err_msg("Not found!"))?;
                     self.edit(&goto_cmd, loc.uri.filepath()?)?;
                     self.cursor(loc.range.start.line + 1, loc.range.start.character + 1)?;
-                    let cmd = format!("echohl Function | echom '[LC]: '.expand('%').' {}:{}' | echohl NONE", loc.range.start.line + 1, loc.range.start.character + 1);
-                    self.command(&cmd)?;
+                    let cur_file: String = self.eval("expand('%')")?;
+                    self.echomsg_ellipsis(format!("[LC]: {} {}:{}", cur_file, loc.range.start.line + 1, loc.range.start.character + 1))?;
                 }
                 _ => self.display_locations(&arr)?,
             },


### PR DESCRIPTION
<img width="784" alt="2018-08-04 12 29 06" src="https://user-images.githubusercontent.com/8850248/43672528-7a4286bc-97e2-11e8-9f49-23c3a68d5d59.png">

Although `CTRL-G` could also show the current file name, the cursor position and so on, it's nice to have these info without extra operation when calling gotoDefinition from LCN. I know vim-go also echoes some info in this case and I think that's very useful. 