### PR TITLE
Fix ncm2/ncm2#58 and ncm2/ncm2#59

### DIFF
--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -109,6 +109,9 @@ augroup languageClient
     autocmd BufDelete * call LanguageClient#handleBufDelete()
     autocmd TextChanged * call LanguageClient#handleTextChanged()
     autocmd TextChangedI * call LanguageClient#handleTextChanged()
+    if exists('##TextChangedP')
+        autocmd TextChangedP * call LanguageClient#handleTextChanged()
+    endif
     autocmd CursorMoved * call LanguageClient#handleCursorMoved()
     autocmd VimLeavePre * call LanguageClient#handleVimLeavePre()
 


### PR DESCRIPTION
- handleTextChanged in TextChangedP
- force  `is_incomplete=true` when there's something wrong to invalidate ncm2's cache

https://github.com/ncm2/ncm2/issues/58

https://github.com/ncm2/ncm2/issues/59