### PR TITLE
Implement textDocument/documentHighlight

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1034,6 +1034,7 @@ function! LanguageClient_contextMenuItems() abort
                 \ 'Rename': 'LanguageClient#textDocument_rename',
                 \ 'Signature Help': 'LanguageClient#textDocument_signatureHelp',
                 \ 'Type Definition': 'LanguageClient#textDocument_typeDefinition',
+                \ 'Document Highlight': 'LanguageClient#textDocument_documentHighlight',
                 \ 'Workspace Symbol': 'LanguageClient#workspace_symbol',
                 \ }
 endfunction

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -646,6 +646,19 @@ function! LanguageClient#textDocument_didClose() abort
                 \ })
 endfunction
 
+function! LanguageClient#textDocument_documentHighlight(...) abort
+    let l:callback = get(a:000, 1, v:null)
+    let l:params = {
+                \ 'filename': LSP#filename(),
+                \ 'text': LSP#text(),
+                \ 'line': LSP#line(),
+                \ 'character': LSP#character(),
+                \ 'handle': s:IsFalse(l:callback),
+                \ }
+    call extend(l:params, get(a:000, 0, {}))
+    return LanguageClient#Call('textDocument/documentHighlight', l:params, l:callback)
+endfunction
+
 function! LanguageClient#getState(callback) abort
     return LanguageClient#Call('languageClient/getState', {}, a:callback)
 endfunction

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -659,6 +659,10 @@ function! LanguageClient#textDocument_documentHighlight(...) abort
     return LanguageClient#Call('textDocument/documentHighlight', l:params, l:callback)
 endfunction
 
+function! LanguageClient#clearDocumentHighlight() abort
+    return LanguageClient#Notify('languageClient/clearDocumentHighlight', {})
+endfunction
+
 function! LanguageClient#getState(callback) abort
     return LanguageClient#Call('languageClient/getState', {}, a:callback)
 endfunction

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -281,6 +281,26 @@ neovim >= 0.3.0.
 Default: 0
 Valid options: 1 | 0
 
+2.22 g:LanguageClient_documentHighlightDisplay *g:LanguageClient_documentHighlightDisplay*
+
+Control how document highlights are displayed.
+
+Default: >
+    {
+        1: {
+            "name": "Text",
+            "texthl": "LanguageClientText",
+        },
+        2: {
+            "name": "Read",
+            "texthl": "LanguageClientRead",
+        },
+        3: {
+            "name": "Write",
+            "texthl": "LanguageClientWrite",
+        },
+    }
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -424,6 +424,18 @@ Signature: LanguageClient#textDocument_rangeFormatting(...)
 
 Format selected lines.
 
+*LanguageClient#textDocument_documentHighlight()*
+*LanguageClient_textDocument_documentHighlight()*
+Signature: LanguageClient#textDocument_documentHighlight(...)
+
+Highlight usages of the symbol under the cursor.
+
+*LanguageClient#clearDocumentHighlight()*
+*LanguageClient_clearDocumentHighlight()*
+Signature: LanguageClient#clearDocumentHighlight()
+
+Clear the symbol usages highlighting.
+
 *LanguageClient#workspace_symbol()*
 *LanguageClient_workspace_symbol()*
 Signature: LanguageClient#workspace_symbol([query: String], ...)

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -289,15 +289,15 @@ Default: >
     {
         1: {
             "name": "Text",
-            "texthl": "LanguageClientText",
+            "texthl": "SpellCap",
         },
         2: {
             "name": "Read",
-            "texthl": "LanguageClientRead",
+            "texthl": "SpellLocal",
         },
         3: {
             "name": "Write",
-            "texthl": "LanguageClientWrite",
+            "texthl": "SpellRare",
         },
     }
 

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -90,6 +90,10 @@ function! LanguageClient_statusLine(...)
     return call('LanguageClient#statusLine', a:000)
 endfunction
 
+function! LanguageClient_clearDocumentHighlight(...)
+    return call('LanguageClient#clearDocumentHighlight', a:000)
+endfunction
+
 function! LanguageClient_cquery_base(...)
     return call('LanguageClient#cquery_base', a:000)
 endfunction

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -42,6 +42,10 @@ function! LanguageClient_textDocument_rangeFormatting(...)
     return call('LanguageClient#textDocument_rangeFormatting', a:000)
 endfunction
 
+function! LanguageClient_textDocument_documentHighlight(...)
+    return call('LanguageClient#textDocument_documentHighlight', a:000)
+endfunction
+
 function! LanguageClient_workspace_symbol(...)
     return call('LanguageClient#workspace_symbol', a:000)
 endfunction

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -120,8 +120,12 @@ impl State {
             ].as_ref(),
         )?;
 
-        let (diagnosticsSignsMax,): (Option<u64>,) =
-            self.eval(["get(g:, 'LanguageClient_diagnosticsSignsMax', v:null)"].as_ref())?;
+        let (diagnosticsSignsMax, documentHighlightDisplay): (Option<u64>, Value) = self.eval(
+            [
+                "get(g:, 'LanguageClient_diagnosticsSignsMax', v:null)",
+                "get(g:, 'LanguageClient_documentHighlightDisplay', {})",
+            ].as_ref(),
+        )?;
 
         // vimscript use 1 for true, 0 for false.
         let autoStart = autoStart == 1;
@@ -190,6 +194,10 @@ impl State {
                 serde_json::to_value(&state.diagnosticsDisplay)?.combine(diagnosticsDisplay),
             )?;
             state.diagnosticsSignsMax = diagnosticsSignsMax;
+            state.documentHighlightDisplay = serde_json::from_value(
+                serde_json::to_value(&state.documentHighlightDisplay)?
+                    .combine(documentHighlightDisplay),
+            )?;
             state.windowLogMessageLevel = windowLogMessageLevel;
             state.settingsPath = settingsPath;
             state.loadSettings = loadSettings;
@@ -254,6 +262,80 @@ impl State {
         self.cursor(line + 1, character + 1)?;
         debug!("End apply WorkspaceEdit");
         Ok(())
+    }
+
+    pub fn textDocument_documentHighlight(&mut self, params: &Option<Params>) -> Result<Value> {
+        self.textDocument_didChange(params)?;
+        info!("Begin {}", lsp::request::DocumentHighlightRequest::METHOD);
+        let (languageId, filename, line, character, handle): (
+            String,
+            String,
+            u64,
+            u64,
+            bool,
+        ) = self.gather_args(
+            &[
+                VimVar::LanguageId,
+                VimVar::Filename,
+                VimVar::Line,
+                VimVar::Character,
+                VimVar::Handle,
+            ],
+            params,
+        )?;
+
+        let result = self.call(
+            Some(&languageId),
+            lsp::request::DocumentHighlightRequest::METHOD,
+            TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: filename.to_url()?,
+                },
+                position: Position { line, character },
+            },
+        )?;
+
+        if !handle {
+            return Ok(result);
+        }
+
+        let document_highlight: Option<Vec<DocumentHighlight>> =
+            serde_json::from_value(result.clone())?;
+        if let Some(document_highlight) = document_highlight {
+            let highlights = document_highlight
+                .into_iter()
+                .map(|DocumentHighlight { range, kind }| Highlight {
+                    line: range.start.line,
+                    character_start: range.start.character,
+                    character_end: range.end.character,
+                    group: self.documentHighlightDisplay[&kind
+                                                             .unwrap_or(DocumentHighlightKind::Text)
+                                                             .to_int()
+                                                             .unwrap()]
+                        .texthl
+                        .clone(),
+                    text: String::new(),
+                })
+                .collect::<Vec<_>>();
+
+            let source = if let Some(source) = self.document_highlight_source {
+                source
+            } else {
+                let source = self.call(
+                    None,
+                    "nvim_buf_add_highlight",
+                    json!([0, 0, "Error", 1, 1, 1]),
+                )?;
+                self.document_highlight_source = Some(source);
+                source
+            };
+
+            self.notify(None, "nvim_buf_clear_highlight", json!([0, source, 0, -1]))?;
+            self.notify(None, "s:AddHighlights", json!([source, highlights]))?;
+        }
+
+        info!("End {}", lsp::request::DocumentHighlightRequest::METHOD);
+        Ok(result)
     }
 
     fn apply_TextEdits<P: AsRef<Path>>(&mut self, path: P, edits: &[TextEdit]) -> Result<()> {
@@ -2230,6 +2312,11 @@ impl State {
             )?;
 
             self.notify(None, "s:AddHighlights", json!([source, highlights]))?;
+        }
+
+        // Clear all document highlights.
+        if let Some(source) = self.document_highlight_source.take() {
+            self.notify(None, "nvim_buf_clear_highlight", json!([0, source, 0, -1]))?;
         }
 
         info!("End {}", NOTIFICATION__HandleCursorMoved);

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -2332,11 +2332,6 @@ impl State {
             self.notify(None, "s:AddHighlights", json!([source, highlights]))?;
         }
 
-        // Clear all document highlights.
-        if let Some(source) = self.document_highlight_source.take() {
-            self.notify(None, "nvim_buf_clear_highlight", json!([0, source, 0, -1]))?;
-        }
-
         info!("End {}", NOTIFICATION__HandleCursorMoved);
         Ok(())
     }

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -304,19 +304,26 @@ impl State {
         if let Some(document_highlight) = document_highlight {
             let highlights = document_highlight
                 .into_iter()
-                .map(|DocumentHighlight { range, kind }| Highlight {
-                    line: range.start.line,
-                    character_start: range.start.character,
-                    character_end: range.end.character,
-                    group: self.documentHighlightDisplay[&kind
-                                                             .unwrap_or(DocumentHighlightKind::Text)
-                                                             .to_int()
-                                                             .unwrap()]
-                        .texthl
-                        .clone(),
-                    text: String::new(),
+                .map(|DocumentHighlight { range, kind }| {
+                    Ok(Highlight {
+                        line: range.start.line,
+                        character_start: range.start.character,
+                        character_end: range.end.character,
+                        group: self
+                            .documentHighlightDisplay
+                            .get(
+                                &kind
+                                    .unwrap_or(DocumentHighlightKind::Text)
+                                    .to_int()
+                                    .unwrap(),
+                            )
+                            .ok_or_else(|| err_msg("Failed to get display"))?
+                            .texthl
+                            .clone(),
+                        text: String::new(),
+                    })
                 })
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>>>()?;
 
             let source = if let Some(source) = self.document_highlight_source {
                 source

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -345,6 +345,17 @@ impl State {
         Ok(result)
     }
 
+    pub fn languageClient_clearDocumentHighlight(&mut self, _: &Option<Params>) -> Result<()> {
+        info!("Begin {}", NOTIFICATION__ClearDocumentHighlight);
+
+        if let Some(source) = self.document_highlight_source.take() {
+            self.notify(None, "nvim_buf_clear_highlight", json!([0, source, 0, -1]))?;
+        }
+
+        info!("End {}", NOTIFICATION__ClearDocumentHighlight);
+        Ok(())
+    }
+
     fn apply_TextEdits<P: AsRef<Path>>(&mut self, path: P, edits: &[TextEdit]) -> Result<()> {
         debug!("Begin apply TextEdits: {:?}", edits);
         if edits.is_empty() {

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -177,6 +177,9 @@ impl State {
             NOTIFICATION__FZFSinkCommand => {
                 self.languageClient_FZFSinkCommand(&notification.params)?
             }
+            NOTIFICATION__ClearDocumentHighlight => {
+                self.languageClient_clearDocumentHighlight(&notification.params)?
+            }
             // Extensions by language servers.
             NOTIFICATION__LanguageStatus => self.language_status(&notification.params)?,
             NOTIFICATION__RustBeginBuild => self.rust_handleBeginBuild(&notification.params)?,

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -61,6 +61,9 @@ impl State {
             lsp::request::ApplyWorkspaceEdit::METHOD => {
                 self.workspace_applyEdit(&method_call.params)
             }
+            lsp::request::DocumentHighlightRequest::METHOD => {
+                self.textDocument_documentHighlight(&method_call.params)
+            }
             REQUEST__RustImplementations => self.rustDocument_implementations(&method_call.params),
             // Extensions.
             REQUEST__GetState => self.languageClient_getState(&method_call.params),

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,6 +29,7 @@ pub const NOTIFICATION__HandleCompleteDone: &str = "languageClient/handleComplet
 pub const NOTIFICATION__FZFSinkLocation: &str = "LanguageClient_FZFSinkLocation";
 pub const NOTIFICATION__FZFSinkCommand: &str = "LanguageClient_FZFSinkCommand";
 pub const NOTIFICATION__ServerExited: &str = "$languageClient/serverExited";
+pub const NOTIFICATION__ClearDocumentHighlight: &str = "languageClient/clearDocumentHighlight";
 
 // Extensions by language servers.
 pub const REQUEST__RustImplementations: &str = "rustDocument/implementations";

--- a/src/types.rs
+++ b/src/types.rs
@@ -379,21 +379,21 @@ impl DocumentHighlightDisplay {
             1,
             DocumentHighlightDisplay {
                 name: "Text".to_owned(),
-                texthl: "LanguageClientText".to_owned(),
+                texthl: "SpellCap".to_owned(),
             },
         );
         map.insert(
             2,
             DocumentHighlightDisplay {
                 name: "Read".to_owned(),
-                texthl: "LanguageClientRead".to_owned(),
+                texthl: "SpellLocal".to_owned(),
             },
         );
         map.insert(
             3,
             DocumentHighlightDisplay {
                 name: "Write".to_owned(),
-                texthl: "LanguageClientWrite".to_owned(),
+                texthl: "SpellRare".to_owned(),
             },
         );
         map

--- a/src/types.rs
+++ b/src/types.rs
@@ -106,6 +106,7 @@ pub struct State {
     pub highlights_placed: HashMap<String, Vec<Highlight>>,
     // TODO: make file specific.
     pub highlight_match_ids: Vec<u32>,
+    pub document_highlight_source: Option<u64>,
     pub user_handlers: HashMap<String, String>,
     #[serde(skip_serializing)]
     pub watchers: HashMap<String, notify::RecommendedWatcher>,
@@ -126,6 +127,7 @@ pub struct State {
     pub diagnosticsList: DiagnosticsList,
     pub diagnosticsDisplay: HashMap<u64, DiagnosticsDisplay>,
     pub diagnosticsSignsMax: Option<u64>,
+    pub documentHighlightDisplay: HashMap<u64, DocumentHighlightDisplay>,
     pub windowLogMessageLevel: MessageType,
     pub settingsPath: String,
     pub loadSettings: bool,
@@ -170,6 +172,7 @@ impl State {
             highlights: HashMap::new(),
             highlights_placed: HashMap::new(),
             highlight_match_ids: Vec::new(),
+            document_highlight_source: None,
             user_handlers: HashMap::new(),
             watchers: HashMap::new(),
             watcher_rxs: HashMap::new(),
@@ -187,6 +190,7 @@ impl State {
             diagnosticsList: DiagnosticsList::Quickfix,
             diagnosticsDisplay: DiagnosticsDisplay::default(),
             diagnosticsSignsMax: None,
+            documentHighlightDisplay: DocumentHighlightDisplay::default(),
             windowLogMessageLevel: MessageType::Warning,
             settingsPath: format!(".vim{}settings.json", std::path::MAIN_SEPARATOR),
             loadSettings: false,
@@ -358,6 +362,40 @@ impl Sign {
                 .unwrap_or(DiagnosticSeverity::Hint)
                 .to_int()
                 .unwrap_or(4) - 1
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentHighlightDisplay {
+    pub name: String,
+    pub texthl: String,
+}
+
+impl DocumentHighlightDisplay {
+    pub fn default() -> HashMap<u64, DocumentHighlightDisplay> {
+        let mut map = HashMap::new();
+        map.insert(
+            1,
+            DocumentHighlightDisplay {
+                name: "Text".to_owned(),
+                texthl: "LanguageClientText".to_owned(),
+            },
+        );
+        map.insert(
+            2,
+            DocumentHighlightDisplay {
+                name: "Read".to_owned(),
+                texthl: "LanguageClientRead".to_owned(),
+            },
+        );
+        map.insert(
+            3,
+            DocumentHighlightDisplay {
+                name: "Write".to_owned(),
+                texthl: "LanguageClientWrite".to_owned(),
+            },
+        );
+        map
     }
 }
 
@@ -736,6 +774,12 @@ impl ToInt for DiagnosticSeverity {
 }
 
 impl ToInt for MessageType {
+    fn to_int(&self) -> Result<u64> {
+        Ok(*self as u64)
+    }
+}
+
+impl ToInt for DocumentHighlightKind {
     fn to_int(&self) -> Result<u64> {
         Ok(*self as u64)
     }


### PR DESCRIPTION
This request highlights usages of the symbol under the cursor.

Usage: position cursor on symbol (like hover), `:call LanguageClient_textDocument_documentHighlight()`.

The highlights are controlled with a new variable, `g:LanguageClient_documentHighlightDisplay`, in a similar fashion to the existing `g:LanguageClient_diagnosticsDisplay`. The default values are `LanguageClient{Text,Read,Write}` for text mentions, variable reads and writes, respectively.

Test vimrc:
```vim
call plug#begin('~/.local/share/nvim/plugged')

Plug 'autozimu/LanguageClient-neovim', {
    \ 'branch': 'next',
    \ 'do': 'bash install.sh',
    \ }

call plug#end()

augroup filetype_rust
    autocmd!
    autocmd BufReadPost *.rs setlocal filetype=rust
augroup END

let g:LanguageClient_serverCommands = {
    \ 'rust': ['rustup', 'run', 'stable', 'rls'],
    \ 'python': ['pyls'],
\ }

highlight link LanguageClientText Visual
highlight link LanguageClientRead Visual
highlight link LanguageClientWrite FoldColumn
```
Example (RLS, doesn't do read/write):
![image](https://user-images.githubusercontent.com/1794388/43991408-f5396d1c-9d74-11e8-94e1-858e84a20a28.png)
Example (pyls, does read/write):
![image](https://user-images.githubusercontent.com/1794388/43991423-3a45ee1c-9d75-11e8-8213-d3b0dbfbafb0.png)

Known issues:
- I clear the highlight on `CursorMoved` (because it's likely that the cursor was moved out of the symbol), but currently `CursorMoved` is only issued when the cursor moves up or down, not left or right.
  - Also due to clearing in `CursorMoved` I can't reliably call this from my own `CursorMoved` (since it can end up being called before LanguageClient's and the highlight will be immediately erased). Not sure how to handle this.
  - An alternative would be to not clear the highlights automatically and instead add a function to clear them.
- I'm not sure what the best way of adding vim support is.