### PR TITLE
is_incomplete=true when Err

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -2448,7 +2448,7 @@ impl State {
             let completion = serde_json::from_value(value.clone())?;
             is_incomplete = match completion {
                 CompletionResponse::List(ref list) => list.is_incomplete,
-                _ => true,
+                _ => false,
             };
             let matches_result: Result<Vec<VimCompleteItem>> = match completion {
                 CompletionResponse::Array(arr) => arr,
@@ -2458,7 +2458,7 @@ impl State {
                 .collect();
             matches = matches_result?;
         } else {
-            is_incomplete = false;
+            is_incomplete = true;
             matches = vec![];
         }
         self.call::<_, u8>(


### PR DESCRIPTION
Before this PR:

The gif shows the behavior when I'm using pyls for editting python code.

Due to ncm2's caching behavior, `datetime.n|` won't trigger completion if `datetime.|` has already triggered completion and has produced `is_incomplete=false`.

Note that I need to return to normal mode and get back to insert mode to get completion displayed for the typing `datetime.n`.

![before](https://user-images.githubusercontent.com/4538941/44009379-0c54322e-9ede-11e8-94f6-fc0809ce3ec7.gif)

After this PR:

![after](https://user-images.githubusercontent.com/4538941/44009380-10d36e46-9ede-11e8-80c5-e19be59f4a5a.gif)

minimal vimrc:

```vim
execute 'source ' . $WORKSPACE_DIR . '/plug.vim'

set nocompatible            " Must be first line
filetype plugin indent on   " Automatically detect file types.
syntax on                   " Syntax highlighting
set autoread                " Autoread file if it was changed on disk
set mouse=a                 " Automatically enable mouse usage
set mousehide               " Hide the mouse cursor while typing
scriptencoding utf-8
set encoding=utf8
if has('clipboard')
    if has('unnamedplus')  " When possible use + register for copy-paste
        set clipboard=unnamed,unnamedplus
    else         " On mac and Windows, use * register for copy-paste
        set clipboard=unnamed
    endif
endif
set autowrite                       " Automatically write a file when leaving a modified buffer
set shortmess+=filmnrxcoOtT         " Abbrev. of messages (avoids 'hit enter')
set viewoptions=folds,options,cursor,unix,slash " Better Unix / Windows compatibility
set virtualedit=onemore             " Allow for cursor beyond last character
set history=250                     " Store a ton of history (default is 20)
set hidden                          " Allow buffer switching without saving
set lazyredraw                      " Don't redraw on macros
set iskeyword -=.                    " '.' is an end of word designator
set iskeyword -=#                    " '#' is an end of word designator
set iskeyword -=-                    " '-' is an end of word designator

" Set completeopt to menuone only to disable the preview =_=
"set completeopt=noinsert,menuone,preview,noselect
au User Ncm2PopupOpen set completeopt=noinsert,menuone,noselect
au User Ncm2PopupClose set completeopt=menuone


call plug#begin($WORKSPACE_DIR)
Plug 'autozimu/LanguageClient-neovim', { 'branch': 'next', 'do': 'bash install.sh' }
Plug 'ncm2/ncm2'
Plug 'roxma/nvim-yarp'
call plug#end()

let g:LanguageClient_serverCommands = {
            \ 'python': ['pyls'],
            \ 'rust': ['rustup', 'run', 'stable', 'rls'],
            \ 'go' : ['go-langserver', '-gocodecompletion'],
            \ }

autocmd BufEnter * call ncm2#enable_for_buffer()
inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"

" annoying
let g:LanguageClient_diagnosticsSignsMax = 0

" debug
set noshowmode
let g:LanguageClient_loggingFile = '/tmp/lc.log'
let g:LanguageClient_loggingLevel = 'DEBUG'
```
