### PR TITLE
Make rangeFormatting tab behavior same as regular

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -581,8 +581,6 @@ function! LanguageClient#textDocument_rangeFormatting(...) abort
                 \ 'text': LSP#text(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
-                \ '&tabstop': &tabstop,
-                \ '&expandtab': &expandtab,
                 \ 'LSP#range_start_line()': LSP#range_start_line(),
                 \ 'LSP#range_end_line()': LSP#range_end_line(),
                 \ 'handle': s:IsFalse(l:callback),

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -1526,22 +1526,30 @@ impl State {
     pub fn textDocument_rangeFormatting(&mut self, params: &Option<Params>) -> Result<Value> {
         self.textDocument_didChange(params)?;
         info!("Begin {}", lsp::request::RangeFormatting::METHOD);
-        let (buftype, languageId, filename, handle, tab_size, insert_spaces, start_line, end_line):
-            (String, String, String, bool, u64, u64, u64, u64) = self.gather_args(
-                &[
+        let (buftype, languageId, filename, handle, start_line, end_line): (
+            String,
+            String,
+            String,
+            bool,
+            u64,
+            u64,
+        ) = self.gather_args(
+            &[
                 VimVar::Buftype.to_key().as_str(),
                 VimVar::LanguageId.to_key().as_str(),
                 VimVar::Filename.to_key().as_str(),
                 VimVar::Handle.to_key().as_str(),
-                "&tabstop",
-                "&expandtab",
                 "LSP#range_start_line()",
                 "LSP#range_end_line()",
-                ], params)?;
+            ],
+            params,
+        )?;
         if !buftype.is_empty() || languageId.is_empty() {
             return Ok(Value::Null);
         }
 
+        let (tab_size, insert_spaces): (u64, u64) =
+            self.eval(["shiftwidth()", "&expandtab"].as_ref())?;
         let insert_spaces = insert_spaces == 1;
         let result = self.call(
             Some(&languageId),


### PR DESCRIPTION
I noticed this when trying out range formatting for the first time. It's the same change as was requested for normal formatting in #403.