### PR TITLE
Fix debugInfo function formatting

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -564,7 +564,7 @@ Signature: LanguageClient#explainErrorAtPoint(...)
 
 Show detailed error under cursor.
 
-LanguageClient#debugInfo
+*LanguageClient#debugInfo*
 Signature: LanguageClient#debugInfo(...)
 
 Print out debug info.


### PR DESCRIPTION
Thanks for implementing the feature!

I believe, the function name should be enclosed in `*` so that the formatting style matches the rest of documentation.