### PR TITLE
Store documentHighlight buffer

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -79,6 +79,12 @@ pub enum Call {
     Notification(Option<String>, rpc::Notification),
 }
 
+#[derive(Clone, Copy, Serialize)]
+pub struct HighlightSource {
+    pub buffer: u64,
+    pub source: u64,
+}
+
 #[derive(Serialize)]
 pub struct State {
     // Program state.
@@ -109,7 +115,7 @@ pub struct State {
     pub highlights_placed: HashMap<String, Vec<Highlight>>,
     // TODO: make file specific.
     pub highlight_match_ids: Vec<u32>,
-    pub document_highlight_source: Option<u64>,
+    pub document_highlight_source: Option<HighlightSource>,
     pub user_handlers: HashMap<String, String>,
     #[serde(skip_serializing)]
     pub watchers: HashMap<String, notify::RecommendedWatcher>,


### PR DESCRIPTION
I was hitting an issue that switching to a different window (or otherwise to a different buffer) was leaving document highlights hanging indefinitely. This was due to the clear notification being processed after the window was switched, resulting in `nvim_buf_clear_highlight` targeting the wrong buffer and doing nothing.

This MR makes documentHighlight store both the highlight source and the buffer ID so that `nvim_buf_clear_highlight` always targets the correct buffer.