### PR TITLE
Don't include full debugging info in the release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,6 @@ regex = "1"
 glob = "0"
 notify = "4"
 
-[profile.release]
-debug = true
-
 [package.metadata.release]
 no-dev-version = true
 pre-release-replacements = [


### PR DESCRIPTION
Including debug information makes the binaries over 60 MB, which is unacceptable. Binaries without full debug info are around 5 MB.