### PR TITLE
Replace newlines in completion items details

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -599,7 +599,7 @@ impl VimCompleteItem {
             abbr,
             icase: Some(1),
             dup: Some(1),
-            menu: lspitem.detail.clone().unwrap_or_default(),
+            menu: lspitem.detail.clone().unwrap_or_default().replace("\n"," "),
             info,
             kind: lspitem.kind.map(|k| format!("{:?}", k)).unwrap_or_default(),
             snippet,


### PR DESCRIPTION
Fixes #638 I don't know much rust but this seemed easy enough.

Before: <img width="1027" alt="skarmavbild 2018-10-24 kl 19 16 03" src="https://user-images.githubusercontent.com/762115/47449156-41101380-d7c2-11e8-8244-b9fa06437687.png"> 

After: <img width="1027" alt="skarmavbild 2018-10-25 kl 00 19 35" src="https://user-images.githubusercontent.com/762115/47465128-d07dec80-d7eb-11e8-8928-78cb7720cf45.png">
