### PR TITLE
Retain history in quickfix and location lists, where appropriate

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -1115,7 +1115,7 @@ impl State {
                 _ => {
                     let title = format!("[LC]: search for {}", word);
                     self.display_locations(&arr, &title)?
-                },
+                }
             },
         };
 
@@ -2229,8 +2229,10 @@ impl State {
 
     pub fn languageClient_handleTextChanged(&mut self, params: &Value) -> Result<()> {
         info!("Begin {}", NOTIFICATION__HandleTextChanged);
-        let (buftype, languageId, filename): (String, String, String) =
-            self.gather_args(&[VimVar::Buftype, VimVar::LanguageId, VimVar::Filename], params)?;
+        let (buftype, languageId, filename): (String, String, String) = self.gather_args(
+            &[VimVar::Buftype, VimVar::LanguageId, VimVar::Filename],
+            params,
+        )?;
         if !buftype.is_empty() {
             info!(
                 "Skip handleTextChanged as buftype is non-empty: {}",
@@ -2271,7 +2273,8 @@ impl State {
 
     pub fn languageClient_handleBufDelete(&mut self, params: &Value) -> Result<()> {
         info!("Begin {}", NOTIFICATION__HandleBufWritePost);
-        let (languageId, filename): (String, String) = self.gather_args(&[VimVar::LanguageId, VimVar::Filename], params)?;
+        let (languageId, filename): (String, String) =
+            self.gather_args(&[VimVar::LanguageId, VimVar::Filename], params)?;
         if !self.serverCommands.contains_key(&languageId) {
             return Ok(());
         }
@@ -2290,8 +2293,16 @@ impl State {
 
     pub fn languageClient_handleCursorMoved(&mut self, params: &Value) -> Result<()> {
         info!("Begin {}", NOTIFICATION__HandleCursorMoved);
-        let (buftype, languageId, filename, line): (String, String, String, u64) =
-            self.gather_args(&[VimVar::Buftype, VimVar::LanguageId, VimVar::Filename, VimVar::Line], params)?;
+        let (buftype, languageId, filename, line): (String, String, String, u64) = self
+            .gather_args(
+                &[
+                    VimVar::Buftype,
+                    VimVar::LanguageId,
+                    VimVar::Filename,
+                    VimVar::Line,
+                ],
+                params,
+            )?;
         if !self.serverCommands.contains_key(&languageId) {
             return Ok(());
         }

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -466,10 +466,10 @@ impl State {
 
         match self.diagnosticsList {
             DiagnosticsList::Quickfix => {
-                self.setqflist(&qflist)?;
+                self.setqflist(&qflist, "r")?;
             }
             DiagnosticsList::Location => {
-                self.setloclist(&qflist)?;
+                self.setloclist(&qflist, "r")?;
             }
             DiagnosticsList::Disabled => {}
         }
@@ -680,7 +680,7 @@ impl State {
                     .map(|loc| location_to_quickfix_entry(self, loc))
                     .collect();
                 let list = list?;
-                self.setqflist(&list)?;
+                self.setqflist(&list, " ")?;
                 self.echo("Quickfix list updated.")?;
             }
             SelectionUI::LocationList => {
@@ -689,7 +689,7 @@ impl State {
                     .map(|loc| location_to_quickfix_entry(self, loc))
                     .collect();
                 let list = list?;
-                self.setloclist(&list)?;
+                self.setloclist(&list, " ")?;
                 self.echo("Location list updated.")?;
             }
         }
@@ -1237,13 +1237,13 @@ impl State {
             SelectionUI::Quickfix => {
                 let list: Result<Vec<_>> = symbols.iter().map(QuickfixEntry::from_lsp).collect();
                 let list = list?;
-                self.setqflist(&list)?;
+                self.setqflist(&list, " ")?;
                 self.echo("Document symbols populated to quickfix list.")?;
             }
             SelectionUI::LocationList => {
                 let list: Result<Vec<_>> = symbols.iter().map(QuickfixEntry::from_lsp).collect();
                 let list = list?;
-                self.setloclist(&list)?;
+                self.setloclist(&list, " ")?;
                 self.echo("Document symbols populated to location list.")?;
             }
         }
@@ -1683,13 +1683,13 @@ impl State {
             SelectionUI::Quickfix => {
                 let list: Result<Vec<_>> = symbols.iter().map(QuickfixEntry::from_lsp).collect();
                 let list = list?;
-                self.setqflist(&list)?;
+                self.setqflist(&list, " ")?;
                 self.echo("Workspace symbols populated to quickfix list.")?;
             }
             SelectionUI::LocationList => {
                 let list: Result<Vec<_>> = symbols.iter().map(QuickfixEntry::from_lsp).collect();
                 let list = list?;
-                self.setloclist(&list)?;
+                self.setloclist(&list, " ")?;
                 self.echo("Workspace symbols populated to location list.")?;
             }
         }

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -277,17 +277,25 @@ impl State {
     }
 
     pub fn setqflist(&mut self, list: &[QuickfixEntry], action: &str, title: &str) -> Result<()> {
-        let parms = json!([list, action, title]);
+        let parms = json!([list, action]);
         if self.call::<_, u8>(None, "setqflist", parms)? != 0 {
             bail!("Failed to set quickfix list!");
+        }
+        let parms = json!([[], "a", {"title": title}]);
+        if self.call::<_, u8>(None, "setqflist", parms)? != 0 {
+            bail!("Failed to set quickfix list title!");
         }
         Ok(())
     }
 
     pub fn setloclist(&mut self, list: &[QuickfixEntry], action: &str, title: &str) -> Result<()> {
-        let parms = json!([0, list, action, title]);
+        let parms = json!([0, list, action]);
         if self.call::<_, u8>(None, "setloclist", parms)? != 0 {
             bail!("Failed to set location list!");
+        }
+        let parms = json!([0, [], "a", {"title": title}]);
+        if self.call::<_, u8>(None, "setloclist", parms)? != 0 {
+            bail!("Failed to set location list title!");
         }
         Ok(())
     }

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -276,16 +276,16 @@ impl State {
         Ok(())
     }
 
-    pub fn setqflist(&mut self, list: &[QuickfixEntry], action: &str) -> Result<()> {
-        let parms = json!([list, action]);
+    pub fn setqflist(&mut self, list: &[QuickfixEntry], action: &str, title: &str) -> Result<()> {
+        let parms = json!([list, action, title]);
         if self.call::<_, u8>(None, "setqflist", parms)? != 0 {
             bail!("Failed to set quickfix list!");
         }
         Ok(())
     }
 
-    pub fn setloclist(&mut self, list: &[QuickfixEntry], action: &str) -> Result<()> {
-        let parms = json!([0, list, action]);
+    pub fn setloclist(&mut self, list: &[QuickfixEntry], action: &str, title: &str) -> Result<()> {
+        let parms = json!([0, list, action, title]);
         if self.call::<_, u8>(None, "setloclist", parms)? != 0 {
             bail!("Failed to set location list!");
         }

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -276,15 +276,17 @@ impl State {
         Ok(())
     }
 
-    pub fn setqflist(&mut self, list: &[QuickfixEntry]) -> Result<()> {
-        if self.call::<_, u8>(None, "setqflist", json!([list, "r"]))? != 0 {
+    pub fn setqflist(&mut self, list: &[QuickfixEntry], action: &str) -> Result<()> {
+        let parms = json!([list, action]);
+        if self.call::<_, u8>(None, "setqflist", parms)? != 0 {
             bail!("Failed to set quickfix list!");
         }
         Ok(())
     }
 
-    pub fn setloclist(&mut self, list: &[QuickfixEntry]) -> Result<()> {
-        if self.call::<_, u8>(None, "setloclist", json!([0, list, "r"]))? != 0 {
+    pub fn setloclist(&mut self, list: &[QuickfixEntry], action: &str) -> Result<()> {
+        let parms = json!([0, list, action]);
+        if self.call::<_, u8>(None, "setloclist", parms)? != 0 {
             bail!("Failed to set location list!");
         }
         Ok(())


### PR DESCRIPTION
If I do a search that populates the quickfix list, and then do a second search - then the quickfix list is replaced.

But sometimes it would be convenient to have a history of my search results (per `chistory`, `colder`, `cnewer`).

On the other hand when publishing diagnostics I think it *does* make sense to replace the existing list.

So the first commit in this pull request adds a parameter to the `setqflist()` and `setloclist()` methods, arranging that only when we publish diagnostics do we set the "r"-for-replace flag.

But then I noticed that although I now have the expected history, all of my lists are called `setqflist` - which isn't very helpful!  So the second commit puts a title on the quickfix or location list.  (There's clearly scope to bikeshed the exact text, and also perhaps it would be nice to distinguish the different types of search in future).

The third commit is just a `cargo fmt`.