### PR TITLE
Retire support for rustDocument/implementations

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -625,18 +625,6 @@ function! LanguageClient#textDocument_rangeFormatting_sync(...) abort
     return l:result isnot v:null
 endfunction
 
-function! LanguageClient#rustDocument_implementations(...) abort
-    let l:params = {
-                \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
-                \ 'line': LSP#line(),
-                \ 'character': LSP#character(),
-                \ }
-    call extend(l:params, a:0 >= 1 ? a:1 : {})
-    let l:Callback = a:0 >= 2 ? a:2 : v:null
-    return LanguageClient#Call('rustDocument/implementations', l:params, l:Callback)
-endfunction
-
 function! LanguageClient#textDocument_didOpen() abort
     return LanguageClient#Notify('textDocument/didOpen', {
                 \ 'filename': LSP#filename(),

--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -2677,55 +2677,6 @@ impl State {
         Ok(())
     }
 
-    pub fn rustDocument_implementations(&mut self, params: &Value) -> Result<Value> {
-        info!("Begin {}", REQUEST__RustImplementations);
-        let (buftype, languageId, filename, word, line, character, handle): (
-            String,
-            String,
-            String,
-            String,
-            u64,
-            u64,
-            bool,
-        ) = self.gather_args(
-            &[
-                VimVar::Buftype,
-                VimVar::LanguageId,
-                VimVar::Filename,
-                VimVar::Cword,
-                VimVar::Line,
-                VimVar::Character,
-                VimVar::Handle,
-            ],
-            params,
-        )?;
-        if !buftype.is_empty() || languageId.is_empty() {
-            return Ok(Value::Null);
-        }
-
-        let result = self.call(
-            Some(&languageId),
-            REQUEST__RustImplementations,
-            TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier {
-                    uri: filename.to_url()?,
-                },
-                position: Position { line, character },
-            },
-        )?;
-
-        if !handle {
-            return Ok(result);
-        }
-
-        let locations: Vec<Location> = serde_json::from_value(result.clone())?;
-        let title = format!("[LC]: implementations for {}", word);
-        self.display_locations(&locations, &title)?;
-
-        info!("End {}", REQUEST__RustImplementations);
-        Ok(result)
-    }
-
     pub fn rust_handleBeginBuild(&mut self, _params: &Value) -> Result<()> {
         info!("Begin {}", NOTIFICATION__RustBeginBuild);
         self.command(vec![

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -47,7 +47,6 @@ impl State {
             lsp::request::DocumentHighlightRequest::METHOD => {
                 self.textDocument_documentHighlight(&params)
             }
-            REQUEST__RustImplementations => self.rustDocument_implementations(&params),
             // Extensions.
             REQUEST__GetState => self.languageClient_getState(&params),
             REQUEST__IsAlive => self.languageClient_isAlive(&params),

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,6 @@ pub const NOTIFICATION__ServerExited: &str = "$languageClient/serverExited";
 pub const NOTIFICATION__ClearDocumentHighlight: &str = "languageClient/clearDocumentHighlight";
 
 // Extensions by language servers.
-pub const REQUEST__RustImplementations: &str = "rustDocument/implementations";
 pub const NOTIFICATION__RustBeginBuild: &str = "rustDocument/beginBuild";
 pub const NOTIFICATION__RustDiagnosticsBegin: &str = "rustDocument/diagnosticsBegin";
 pub const NOTIFICATION__RustDiagnosticsEnd: &str = "rustDocument/diagnosticsEnd";


### PR DESCRIPTION
It was removed from RLS some time ago.

Fixes #652.