### PR TITLE
Improve symbol display for denite

### DIFF
--- a/rplugin/python3/denite/common.py
+++ b/rplugin/python3/denite/common.py
@@ -1,0 +1,148 @@
+from typing import List, Dict
+from os.path import dirname, relpath
+from urllib import request, parse
+import sys
+from collections import namedtuple
+
+from denite.source.base import Base
+
+sys.path.insert(0, dirname(__file__))
+
+from lsp.protocol import SymbolKind  # isort:skip  # noqa: I100
+
+
+MAX_FNAME_LEN = 30
+
+HighlightDefinition = namedtuple("HighlightDefinition", (
+    "name",
+    're',
+    "contained",
+    "contains",
+    "nextgroup",
+    'link',
+), defaults=(
+    False,  # contained
+    False,  # contains
+    None,   # next group
+    None,   # link
+))
+
+SYMBOL_CANDIDATE_HIGHLIGHT_SYNTAX = [
+    HighlightDefinition(
+        name='location',
+        contains=['colon', 'number', 'path'],
+        nextgroup='kind',
+        re=r'\([^:]\+:\)\?\d\+:\d\+',
+    ),
+    HighlightDefinition(
+        name='path',
+        contained=True,
+        re=r'[^:]\+',
+        link='String',
+    ),
+    HighlightDefinition(
+        name='colon',
+        contained=True,
+        re=r':',
+        link='Comment',
+    ),
+    HighlightDefinition(
+        name='number',
+        contained=True,
+        re=r'\d\+',
+        link='Number',
+    ),
+    HighlightDefinition(
+        name='kind',
+        contained=True,
+        nextgroup='name',
+        re=r'\s\+\[\(\w\|\s\)*\]',
+        link='Type',
+    ),
+]
+
+
+def uri_to_path(uri: str) -> str:
+    return request.url2pathname(parse.urlparse(uri).path)
+
+
+def highlight_setup(source: Base, syntax: List[HighlightDefinition]) -> None:
+    def mangle_name(name: str) -> str:
+        if name in ("TOP", "NONE"):
+            return name
+        if name.startswith("@"):
+            return name
+
+        return "{}_{}".format(source.syntax_name, name)
+
+    for hl_def in syntax:
+        match = [
+            mangle_name(hl_def.name),
+            '/{}/'.format(hl_def.re),
+            'contained']
+        if hl_def.contains:
+            match.append("contains=" + ','.join(
+                mangle_name(i) for i in hl_def.contains
+            ))
+        else:
+            match.append("contains=NONE")
+
+        if hl_def.nextgroup is not None:
+            match.append("nextgroup=" + mangle_name(hl_def.nextgroup))
+
+        if not hl_def.contained:
+            match.append("containedin=" + source.syntax_name)
+
+        source.vim.command('syntax match ' + ' '.join(match))
+        if hl_def.link is not None:
+            source.vim.command(
+                'highlight default link {0}_{1} {2}'.format(
+                    source.syntax_name, hl_def.name, hl_def.link))
+
+
+def convert_symbols_to_candidates(symbols: List[Dict],
+                                  bufname: str = None,
+                                  pwd: str = None) -> List[Dict]:
+    candidates = []
+    paths = []
+    kinds = []
+    max_path_len = 0
+    max_kind_len = 0
+    for symbol in symbols:
+        name = symbol["name"]
+        start = symbol["location"]["range"]["start"]
+        line = start["line"] + 1
+        character = start["character"] + 1
+        kinds.append(SymbolKind(symbol.get("kind", 0)).describe())
+        if not bufname:
+            filepath = uri_to_path(symbol["location"]["uri"])
+            if pwd:
+                rpath = relpath(filepath, pwd)
+                if len(rpath) < len(filepath):
+                    filepath = rpath
+            disp_path = filepath
+            if len(disp_path) > MAX_FNAME_LEN:
+                disp_path = "..." + disp_path[-MAX_FNAME_LEN - 3:]
+            paths.append("{}:{}:{}".format(disp_path, line, character))
+        else:
+            filepath = bufname
+            paths.append("{}:{}".format(line, character))
+        max_path_len = max(max_path_len, len(paths[-1]))
+        max_kind_len = max(max_kind_len, len(kinds[-1]))
+        candidates.append({
+            "word": name,
+            "action__path": filepath,
+            "action__line": line,
+            "action__col": character,
+        })
+
+    for candidate, path, kind in zip(candidates, paths, kinds):
+        candidate["abbr"] = "{:<{}} [{:^{}}] {}".format(
+            path,
+            max_path_len,
+            kind,
+            max_kind_len,
+            candidate["word"],
+        )
+
+    return candidates

--- a/rplugin/python3/denite/lsp/protocol.py
+++ b/rplugin/python3/denite/lsp/protocol.py
@@ -1,0 +1,55 @@
+from enum import IntEnum
+import re
+
+
+class SymbolKind(IntEnum):
+    Unknown = 0
+    File = 1
+    Module = 2
+    Namespace = 3
+    Package = 4
+    Class = 5
+    Method = 6
+    Property = 7
+    Field = 8
+    Constructor = 9
+    Enum = 10
+    Interface = 11
+    Function = 12
+    Variable = 13
+    Constant = 14
+    String = 15
+    Number = 16
+    Boolean = 17
+    Array = 18
+    Object = 19
+    Key = 20
+    Null = 21
+    EnumMember = 22
+    Struct = 23
+    Event = 24
+    Operator = 25
+    TypeParameter = 26
+    # ccls extensions
+    # See also https://github.com/Microsoft/language-server-protocol/issues/344
+    TypeAlias = 252
+    Parameter = 253
+    StaticMethod = 254
+    Macro = 255
+
+    @staticmethod
+    def _missing_(value):
+        return SymbolKind.Unknown
+
+    def describe(self):
+        return self._pprint_map[self]
+
+
+SymbolKind._pprint_map = {}
+for e in SymbolKind:
+    if e == SymbolKind.Unknown:
+        s = ""
+    else:
+        s = re.sub("([a-z])([A-Z])", r"\g<1> \g<2>", str(e).split(".", 1)[1])
+
+    SymbolKind._pprint_map[int(e)] = s

--- a/rplugin/python3/denite/source/documentSymbol.py
+++ b/rplugin/python3/denite/source/documentSymbol.py
@@ -1,19 +1,16 @@
 from typing import List, Dict
+from os.path import dirname
+import sys
 
 from .base import Base
 
+sys.path.insert(0, dirname(dirname(__file__)))
 
-def convert_to_candidate(symbol: Dict, bufname: str) -> Dict:
-    name = symbol["name"]
-    start = symbol["location"]["range"]["start"]
-    line = start["line"] + 1
-    character = start["character"] + 1
-    return {
-        "word": "{}:{}:\t{}".format(line, character, name),
-        "action__path": bufname,
-        "action__line": line,
-        "action__col": character,
-    }
+from common import (  # isort:skip  # noqa: I100
+    convert_symbols_to_candidates,
+    SYMBOL_CANDIDATE_HIGHLIGHT_SYNTAX,
+    highlight_setup,
+)
 
 
 class Source(Base):
@@ -23,9 +20,11 @@ class Source(Base):
         self.name = 'documentSymbol'
         self.kind = 'file'
 
+    def highlight(self):
+        highlight_setup(self, SYMBOL_CANDIDATE_HIGHLIGHT_SYNTAX)
+
     def gather_candidates(self, context: Dict) -> List[Dict]:
         bufname = self.vim.current.buffer.name
         result = self.vim.funcs.LanguageClient_runSync(
             'LanguageClient_textDocument_documentSymbol', {}) or []
-        return [convert_to_candidate(symbol, bufname) for
-                symbol in result]
+        return convert_symbols_to_candidates(result, bufname)

--- a/rplugin/python3/denite/source/workspaceSymbol.py
+++ b/rplugin/python3/denite/source/workspaceSymbol.py
@@ -24,7 +24,30 @@ class Source(Base):
         highlight_setup(self, SYMBOL_CANDIDATE_HIGHLIGHT_SYNTAX)
 
     def gather_candidates(self, context):
+        context['is_interactive'] = True
+        prefix = context['input']
+        bufnr = context['bufnr']
+
+        # This a hack to get around the fact that LanguageClient APIs
+        # work in the context of the active buffer, when filtering results
+        # interactively, the denite buffer is the active buffer and it doesn't
+        # have a language server asscosiated with it.
+        # We just switch to the buffer that initiated the denite transaction
+        # and execute the command from it. This should be changed when we
+        # have a better way to run requests out of the buffer.
+        # See issue#674
+        current_buffer = self.vim.current.buffer.number
+        if current_buffer != bufnr:
+            self.vim.command("tabedit %")
+            self.vim.command(
+                "execute 'noautocmd keepalt buffer' {}".format(bufnr))
         result = self.vim.funcs.LanguageClient_runSync(
-            'LanguageClient#workspace_symbol', '', {}) or []
-        return convert_symbols_to_candidates(result,
-                                             pwd=self.vim.funcs.getcwd())
+            'LanguageClient#workspace_symbol', prefix, {}) or []
+        if current_buffer != bufnr:
+            self.vim.command("tabclose")
+
+        candidates = convert_symbols_to_candidates(
+            result,
+            pwd=self.vim.funcs.getcwd())
+
+        return candidates


### PR DESCRIPTION
* Aligns to actual columns instead of using \t
* Shows symbol's kind
* Searches the symbol name instead of the whole display line
* Highlights the results

![documentSymbol](https://i.imgur.com/a4kWwcI.png)
![workspaceSymbol](https://i.imgur.com/TFQhpxn.png)
