### PR TITLE
Make LanguageClient_runSync reentrant

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -745,13 +745,13 @@ function! s:ExecuteAutocmd(event) abort
 endfunction
 
 function! LanguageClient_runSync(fn, ...) abort
-    let s:LanguageClient_runSync_outputs = []
-    let l:arguments = add(a:000[:], s:LanguageClient_runSync_outputs)
+    let l:LanguageClient_runSync_outputs = []
+    let l:arguments = add(a:000[:], l:LanguageClient_runSync_outputs)
     call call(a:fn, l:arguments)
-    while len(s:LanguageClient_runSync_outputs) == 0
+    while len(l:LanguageClient_runSync_outputs) == 0
         sleep 100m
     endwhile
-    let l:output = remove(s:LanguageClient_runSync_outputs, 0)
+    let l:output = remove(l:LanguageClient_runSync_outputs, 0)
     return s:HandleOutput(l:output, v:true)
 endfunction
 


### PR DESCRIPTION
By changing `LanguageClient_runSync_outputs` from being source local to
being function local we gurantee that if the function is called from
multiple threads the function will still work.

This also documents that this variable *is* function local and should
not be referenced outside this function.