### PR TITLE
fix: relative path in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,7 @@ if ($ENV:PROCESSOR_ARCHITECTURE -eq 'AMD64') {
 
 $url += '-pc-windows-gnu.exe'
 
-$path = "bin\$name.exe"
+$path = "$PSScriptRoot\bin\$name.exe"
 if (Test-Path $path) {
     Remove-Item -Force $path
 }


### PR DESCRIPTION
The relative path to `bin\` does not refer to the intended directory when
the working directory is not the same as the root of this project.

This causes `install.ps1` to fail when using a plugin manager.