### PR TITLE
Use proper filetype when showing hover info in preview

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -726,7 +726,9 @@ impl ToString for NumberOrString {
 
 pub trait ToDisplay {
     fn to_display(&self) -> Vec<String>;
-    fn vim_filetype(&self) -> Option<String> { None }
+    fn vim_filetype(&self) -> Option<String> {
+        None
+    }
 }
 
 impl ToDisplay for lsp::MarkedString {
@@ -763,8 +765,9 @@ impl ToDisplay for Hover {
     fn to_display(&self) -> Vec<String> {
         match self.contents {
             HoverContents::Scalar(ref ms) => ms.to_display(),
-            HoverContents::Array(ref arr) => {
-                arr.iter().flat_map(|ms| {
+            HoverContents::Array(ref arr) => arr
+                .iter()
+                .flat_map(|ms| {
                     if let MarkedString::LanguageString(ref ls) = ms {
                         let mut buf = Vec::new();
 
@@ -776,8 +779,7 @@ impl ToDisplay for Hover {
                     } else {
                         ms.to_display()
                     }
-                }).collect()
-            },
+                }).collect(),
             HoverContents::Markup(ref mc) => mc.to_display(),
         }
     }


### PR DESCRIPTION
Currently the preview window is opened with `filetype=markdown` in all cases, which might cause mis-highlighting for non-markdown content. LSP has explicit statements about where markdown are used, including the deprecated `MarkedString` which has no `language` specified, and the new `MarkupContent` when `kind = "markdown"`. This PR addresses these specifications on a best effort. An exception is that when multiple `MarkedString`s are returned, `markdown` is always used as vim cannot have multiple filetypes in a single buffer.