### PR TITLE
Ensure buflisted after jumping to a location

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -172,6 +172,7 @@ function! s:Edit(action, path) abort
     " Avoid the 'not saved' warning.
     if l:action ==# 'edit' && l:bufnr != -1
         execute 'buffer' l:bufnr
+        set buflisted
         return
     endif
 


### PR DESCRIPTION
If a buffer was "deleted" via `:bdelete`, it was not actually completed deleted, and still can be queried via `bufnr`. `s:Edit` currently uses `buffer` to jump to an existing buffer, but `buffer` does not add the buffer to the buflist, which is the root cause of #586. `set buflisted` should ensure the buffer we just jumped into presents in the buflist normally.