### PR TITLE
Remove redundant `[LC]` prefix

### DIFF
--- a/src/languageclient.rs
+++ b/src/languageclient.rs
@@ -1093,7 +1093,7 @@ impl State {
                     self.cursor(loc.range.start.line + 1, loc.range.start.character + 1)?;
                     let cur_file: String = self.eval("expand('%')")?;
                     self.echomsg_ellipsis(format!(
-                        "[LC]: {} {}:{}",
+                        "{} {}:{}",
                         cur_file,
                         loc.range.start.line + 1,
                         loc.range.start.character + 1


### PR DESCRIPTION
echomsg_ellipsis always adds the prefix, so we were getting two of them

Edit: for reference, [here](https://github.com/autozimu/LanguageClient-neovim/blob/f9a9123582abfd0f0433e7f8813daf7e615a18b6/autoload/LanguageClient.vim#L44) is where the prefix is added.