### PR TITLE
Fix: types::State can not be serialized as json

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -95,6 +95,7 @@ pub struct State {
     #[serde(skip_serializing)]
     pub tx: crossbeam_channel::Sender<Call>,
 
+    #[serde(skip_serializing)]
     pub clients: HashMap<LanguageId, RpcClient>,
 
     pub capabilities: HashMap<String, Value>,


### PR DESCRIPTION
c101096f0289cd932e84ee3c12a2624b19ffe499 intruduced a `clients` `HashMap` in `types::State`, whose key is `LanguageId`, which makes `types::State` can not be serialized as json, and it breaks some vim functions like `LanguageClient#getState()`. One example is that Airline can not display diagnostic info from LanguageClient, and keeps poping up errors instead. This PR skip serializing this field as it seems not being used in vim script currently.