### PR TITLE
added sync version LanguageClient#textDocument_formatting

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -636,6 +636,13 @@ function! LanguageClient#textDocument_formatting(...) abort
     return LanguageClient#Call('textDocument/formatting', l:params, l:Callback)
 endfunction
 
+function! LanguageClient#textDocument_formatting_sync(...) abort
+    let l:result = LanguageClient_runSync('LanguageClient#textDocument_formatting', {
+                \ 'handle': v:true,
+                \ })
+    return l:result isnot v:null
+endfunction
+
 function! LanguageClient#textDocument_rangeFormatting(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {


### PR DESCRIPTION
Not sure if there is a better way but this is useful to autoformat the code on save with:

```
au BufWritePre *.py,*.go :call LanguageClient#textDocument_formatting_sync()
```

Otherwise, the async nature of the call will make nvim to save the buffer before the code has actually been formatted.