### PR TITLE
Fix: registerHandlers does not register callback function correctly

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2122,10 +2122,11 @@ impl LanguageClient {
                     return None;
                 }
 
-                Some(match serde_json::to_string(v) {
-                    Ok(v) => Ok((k.clone(), v)),
-                    Err(err) => Err(err.into()),
-                })
+                if let serde_json::Value::String(v) = v {
+                    Some(Ok((k.clone(), v.clone())))
+                } else {
+                    None
+                }
             })
             .collect();
         let handlers = handlers?;


### PR DESCRIPTION
`registerHandlers` accepts callbacks as function name strings, and serializing the names again makes them being registered as `"function_name"`, which makes the callbacks do not get called correctly.