### PR TITLE
Use :normal! instead of :normal

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -218,7 +218,7 @@ function! s:Edit(action, path) abort
     " If editing current file, push current location to jump list.
     let l:bufnr = bufnr(a:path)
     if l:bufnr == bufnr('%')
-        execute 'normal m`'
+        execute 'normal! m`'
         return
     endif
 


### PR DESCRIPTION
Hi,

In my `init.vim`, `m` mapping is overridden and I found that `LanguageClient#textDocument_definition` was broken on my local. After some investigation, I noticed that `:normal` was used in this plugin. Plugin should use `:normal!` instead of `:normal`.