### PR TITLE
Reimplement hover window with floating window for Neovim 0.4.0 or later

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -263,7 +263,8 @@ function! s:GetVar(...) abort
 endfunction
 
 function! s:ShouldUseFloatWindow() abort
-    return s:FLOAT_WINDOW_AVAILABLE && get(g:, 'LanguageClient_useFloatingHover', 1)
+    let use = s:GetVar('LanguageClient_useFloatingHover')
+    return s:FLOAT_WINDOW_AVAILABLE && (use || use is v:null)
 endfunction
 
 function! s:CloseFloatingHoverOnCursorMove(win_id, opened) abort

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -315,7 +315,11 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
         " Calculate width and height and give margin to lines
         let width = 0
         for index in range(len(lines))
-            let line = ' ' . lines[index]
+            let line = lines[index]
+            if line !=# ''
+                " Give a left margin
+                let line = ' ' . line
+            endif
             let lw = strdisplaywidth(line)
             if lw > width
                 let width = lw

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1299,7 +1299,7 @@ function! LanguageClient#debugInfo(...) abort
     return LanguageClient#Call('languageClient/debugInfo', l:params, l:Callback)
 endfunction
 
-function! LanguageClient#openHoverInSeparateWindow() abort
+function! LanguageClient#reopenHoverInSeparateWindow() abort
     let bufnr = s:GetHoverPreviewBufnr()
     if bufnr == -1
         echo 'No hover found'

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -343,11 +343,13 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
             let col = 1
         endif
 
-        let float_win_id = nvim_open_win(bufnr, v:true, width, height, {
+        let float_win_id = nvim_open_win(bufnr, v:true, {
         \   'relative': 'cursor',
         \   'anchor': vert . hor,
         \   'row': row,
         \   'col': col,
+        \   'width': width,
+        \   'height': height,
         \ })
 
         execute 'noswapfile edit!' a:bufname

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -271,7 +271,7 @@ function! s:CloseFloatingHoverAfterCursorMove(win_id, opened) abort
     endif
     autocmd! plugin-LC-neovim-close-hover
     let winnr = win_id2win(a:win_id)
-    if winnr == -1
+    if winnr == 0
         return
     endif
     execute winnr . 'wincmd c'
@@ -279,7 +279,7 @@ endfunction
 
 function! s:CloseFloatingHoverAfterEnterAnotherWin(win_id) abort
     let winnr = win_id2win(a:win_id)
-    if winnr == -1
+    if winnr == 0
         " Float window was already closed
         autocmd! plugin-LC-neovim-close-hover
         return
@@ -320,7 +320,8 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
 
         " Calculate anchor
         " Prefer North, but if there is no space, fallback into South
-        if pos[1] + height <= &lines
+        let bottom_line = line('w0') + winheight() - 1
+        if pos[1] + height <= bottom_line
             let vert = 'N'
             let row = 1
         else

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -262,6 +262,10 @@ function! s:GetVar(...) abort
     endif
 endfunction
 
+function! s:ShouldUseFloatWindow() abort
+    return s:FLOAT_WINDOW_AVAILABLE && get(g:, 'LanguageClient_useFloatingHover', 1)
+endfunction
+
 function! s:CloseFloatingHoverOnCursorMove(win_id, opened) abort
     if getpos('.') == a:opened
         " Just after opening floating window, CursorMoved event is run.
@@ -304,7 +308,8 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
     let lines = a:lines
     let bufnr = bufnr('%')
 
-    if s:FLOAT_WINDOW_AVAILABLE
+    let use_float_win = s:ShouldUseFloatWindow()
+    if use_float_win
         let pos = getpos('.')
 
         " Calculate width and height and give margin to lines
@@ -371,7 +376,7 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
 
     wincmd p
 
-    if s:FLOAT_WINDOW_AVAILABLE
+    if use_float_win
         " Unlike preview window, :pclose does not close window. Instead, close
         " hover window automatically when cursor is moved.
         let call_after_move = printf('<SID>CloseFloatingHoverOnCursorMove(%d, %s)', float_win_id, string(pos))
@@ -664,7 +669,7 @@ function! LanguageClient#Notify(method, params) abort
 endfunction
 
 function! LanguageClient#textDocument_hover(...) abort
-    if s:FLOAT_WINDOW_AVAILABLE && s:MoveIntoHoverPreview()
+    if s:ShouldUseFloatWindow() && s:MoveIntoHoverPreview()
         return
     endif
     let l:Callback = get(a:000, 1, v:null)

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -273,7 +273,7 @@ function! s:CloseFloatingHoverOnCursorMove(win_id, opened) abort
         " was really moved
         return
     endif
-    silent! autocmd! plugin-LC-neovim-close-hover
+    autocmd! plugin-LC-neovim-close-hover
     let winnr = win_id2win(a:win_id)
     if winnr == 0
         return
@@ -285,7 +285,7 @@ function! s:CloseFloatingHoverOnBufEnter(win_id, bufnr) abort
     let winnr = win_id2win(a:win_id)
     if winnr == 0
         " Float window was already closed
-        silent! autocmd! plugin-LC-neovim-close-hover
+        autocmd! plugin-LC-neovim-close-hover
         return
     endif
     if winnr == winnr()
@@ -296,7 +296,7 @@ function! s:CloseFloatingHoverOnBufEnter(win_id, bufnr) abort
         " When current buffer opened hover window, it's not another buffer. Skipped
         return
     endif
-    silent! autocmd! plugin-LC-neovim-close-hover
+    autocmd! plugin-LC-neovim-close-hover
     execute winnr . 'wincmd c'
 endfunction
 
@@ -392,22 +392,17 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
     endif
 endfunction
 
-function! s:GetHoverPreviewBufnr() abort
+function! s:MoveIntoHoverPreview() abort
     for bufnr in range(1, bufnr('$'))
         if bufname(bufnr) ==# '__LanguageClient__'
-            return bufnr
+            let winnr = bufwinnr(bufnr)
+            if winnr != -1
+                execute winnr . 'wincmd w'
+            endif
+            return v:true
         endif
     endfor
-    return -1
-endfunction
-
-function! s:MoveIntoHoverPreview() abort
-    let winnr = bufwinnr(s:GetHoverPreviewBufnr())
-    if winnr == -1
-        return v:false
-    endif
-    execute winnr . 'wincmd w'
-    return v:true
+    return v:false
 endfunction
 
 let s:id = 1
@@ -1301,32 +1296,6 @@ function! LanguageClient#debugInfo(...) abort
     let l:params = get(a:000, 0, {})
     let l:Callback = get(a:000, 1, v:null)
     return LanguageClient#Call('languageClient/debugInfo', l:params, l:Callback)
-endfunction
-
-function! LanguageClient#reopenHoverInSeparateWindow() abort
-    let bufnr = s:GetHoverPreviewBufnr()
-    if bufnr == -1
-        echo 'No hover found'
-        return
-    endif
-
-    let lines = nvim_buf_get_lines(bufnr, 1, -1, v:false)
-    let filetype = nvim_buf_get_option(bufnr, 'filetype')
-    let name = bufname(bufnr)
-
-    silent! autocmd! plugin-LC-neovim-close-hover
-    let winnr = bufwinnr(bufnr)
-    if winnr != -1
-        execute winnr . 'wincmd c'
-    endif
-
-    execute 'silent! noswapfile pedit!' name
-    wincmd P
-    setlocal buftype=nofile nobuflisted bufhidden=wipe nonumber norelativenumber signcolumn=no
-    let &filetype = filetype
-    call setline(1, lines)
-    setlocal nomodified nomodifiable
-    wincmd p
 endfunction
 
 let g:LanguageClient_loaded = s:Launch()

--- a/autoload/health/LanguageClient.vim
+++ b/autoload/health/LanguageClient.vim
@@ -15,11 +15,20 @@ function! s:checkBinary() abort
                     \ l:path)
     endif
 
-    let output = system([l:path, '--version'])
+    let output = substitute(system([l:path, '--version']), '\n$', '', '')
     call health#report_ok(output)
+endfunction
+
+function! s:checkFloatingWindow() abort
+    if !exists('*nvim_open_win')
+        call health#report_info('Floating window is not supported. Preview window will be used for hover')
+        return
+    endif
+    call health#report_ok('Floating window is supported and will be used for hover')
 endfunction
 
 function! health#LanguageClient#check() abort
     call s:checkJobFeature()
     call s:checkBinary()
+    call s:checkFloatingWindow()
 endfunction

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -354,6 +354,16 @@ Specify whether to use virtual text to display diagnostics.
 Default: 1 whenever virtual text is supported.
 Valid Options: 1 | 0
 
+2.26 g:LanguageClient_useFloatingHover *g:LanguageClient_useFloatingHover*
+
+When the value is set to 1, |LanguageClient#textDocument_hover()| opens
+documentation in a floating window instead of preview.
+This variable is effective only when the floating window feature is
+supported.
+
+Default: 1 when a floating window is supported, otherwise 0
+Valid Options: 1 | 0
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -633,8 +633,8 @@ Signature: LanguageClient#debugInfo(...)
 
 Print out debug info.
 
-*LanguageClient#openHoverInSeparateWindow*
-Signature: LanguageClient#openHoverInSeparateWindow()
+*LanguageClient#reopenHoverInSeparateWindow*
+Signature: LanguageClient#reopenHoverInSeparateWindow()
 
 When a hover is open in floating window, calling this function reopens the
 content in a separate preview window. This function is useful when you want to

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -633,13 +633,6 @@ Signature: LanguageClient#debugInfo(...)
 
 Print out debug info.
 
-*LanguageClient#reopenHoverInSeparateWindow*
-Signature: LanguageClient#reopenHoverInSeparateWindow()
-
-When a hover is open in floating window, calling this function reopens the
-content in a separate preview window. This function is useful when you want to
-keep it open.
-
 ==============================================================================
 5. Events                                               *LanguageClientEvents*
 

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -63,13 +63,6 @@ accessed by regular quickfix/location list operations.
 To use the language server with Vim's formatting operator |gq|, set 'formatexpr': >
     set formatexpr=LanguageClient#textDocument_rangeFormatting_sync()
 <
-If you're using Neovim 0.4.0 or later, |LanguageClient#textDocument_hover()|
-opens documentation in a floating window. The window is automatically closed
-when you move the cursor. Or calling |LanguageClient#textDocument_hover()|
-again just after opening the floating window moves the cursor into the window.
-It is useful when documentation is longer and you need to scroll down or you
-want to yank some text in the documentation.
-
 ==============================================================================
 2. Configuration                                 *LanguageClientConfiguration*
 
@@ -412,6 +405,12 @@ For Denite users, a source with name 'contextMenu' is provided.
 Signature: LanguageClient#textDocument_hover(...)
 
 Show type info (and short doc) of identifier under cursor.
+
+If you're using Neovim 0.4.0 or later, this function opens documentation in a
+floating window. The window is automatically closed when you move the cursor.
+Or calling this function again just after opening the floating window moves
+the cursor into the window. It is useful when documentation is longer and you
+need to scroll down or you want to yank some text in the documentation.
 
 *LanguageClient#textDocument_definition()*
 *LanguageClient_textDocument_definition()*

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -63,6 +63,12 @@ accessed by regular quickfix/location list operations.
 To use the language server with Vim's formatting operator |gq|, set 'formatexpr': >
     set formatexpr=LanguageClient#textDocument_rangeFormatting_sync()
 <
+If you're using Neovim 0.4.0 or later, |LanguageClient#textDocument_hover()|
+opens documentation in a floating window. The window is automatically closed
+when you move the cursor. Or calling |LanguageClient#textDocument_hover()|
+again just after opening the floating window moves the cursor into the window.
+It is useful when documentation is longer and you need to scroll down or you
+want to yank some text in the documentation.
 
 ==============================================================================
 2. Configuration                                 *LanguageClientConfiguration*

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -633,6 +633,13 @@ Signature: LanguageClient#debugInfo(...)
 
 Print out debug info.
 
+*LanguageClient#openHoverInSeparateWindow*
+Signature: LanguageClient#openHoverInSeparateWindow()
+
+When a hover is open in floating window, calling this function reopens the
+content in a separate preview window. This function is useful when you want to
+keep it open.
+
 ==============================================================================
 5. Events                                               *LanguageClientEvents*
 

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -860,27 +860,12 @@ impl LanguageClient {
         D: ToDisplay + ?Sized,
     {
         let bufname = "__LanguageClient__";
-
-        let cmd = "silent! pedit! +setlocal\\ buftype=nofile\\ nobuflisted\\ noswapfile\\ nonumber";
-        let cmd = if let Some(ref ft) = to_display.vim_filetype() {
-            format!("{}\\ filetype={} {}", cmd, ft, bufname)
-        } else {
-            format!("{} {}", cmd, bufname)
-        };
-        self.vim()?.command(cmd)?;
-
+        let filetype = &to_display.vim_filetype();
         let lines = to_display.to_display();
-        if self.get(|state| state.is_nvim)? {
-            let bufnr: u64 = serde_json::from_value(self.vim()?.rpcclient.call("bufnr", bufname)?)?;
-            self.vim()?
-                .rpcclient
-                .notify("nvim_buf_set_lines", json!([bufnr, 0, -1, 0, lines]))?;
-        } else {
-            self.vim()?
-                .rpcclient
-                .notify("setbufline", json!([bufname, 1, lines]))?;
-            // TODO: removing existing bottom lines.
-        }
+
+        self.vim()?
+            .rpcclient
+            .notify("s:OpenHoverPreview", json!([bufname, lines, filetype]))?;
 
         Ok(())
     }

--- a/tests/LanguageClient_test.py
+++ b/tests/LanguageClient_test.py
@@ -333,29 +333,3 @@ def test_textDocument_hover_float_window_move_cursor_into_window(nvim):
     # Check float window buffer was closed by :close in the window
     assert all(
         b for b in nvim.buffers if not b.name.endswith("__LanguageClient__"))
-
-
-def test_textDocument_hover_float_window_reopen_in_preview_window(nvim):
-    if not nvim.funcs.exists("*nvim_open_win"):
-        pytest.skip("Neovim 0.3.0 or earlier does not support floating window")
-
-    nvim.command("edit! {}".format(PATH_INDEXJS))
-    time.sleep(1)
-
-    _open_float_window(nvim)
-
-    try:
-        nvim.call("LanguageClient#reopenHoverInSeparateWindow")
-        preview_buf = next(
-            b for b in nvim.buffers if b.name.endswith("__LanguageClient__"))
-
-        winnr = nvim.funcs.bufwinnr(preview_buf.number)
-        assert winnr > 0
-
-        win_id = nvim.funcs.win_getid(winnr)
-        assert win_id > 0
-
-        assert nvim.api.win_get_option(win_id, 'previewwindow') == 1
-        assert nvim.api.buf_get_option(preview_buf, 'filetype') == 'markdown'
-    finally:
-        nvim.api.win_close(win_id, True)

--- a/tests/LanguageClient_test.py
+++ b/tests/LanguageClient_test.py
@@ -345,7 +345,7 @@ def test_textDocument_hover_float_window_reopen_in_preview_window(nvim):
     _open_float_window(nvim)
 
     try:
-        nvim.call("LanguageClient#openHoverInSeparateWindow")
+        nvim.call("LanguageClient#reopenHoverInSeparateWindow")
         preview_buf = next(
             b for b in nvim.buffers if b.name.endswith("__LanguageClient__"))
 

--- a/tests/LanguageClient_test.py
+++ b/tests/LanguageClient_test.py
@@ -309,3 +309,27 @@ def test_textDocument_hover_float_window_closed_on_switching_to_buffer(nvim):
             if not b.name.endswith("__LanguageClient__"))
     finally:
         nvim.command("bdelete! {}".format(another_bufnr))
+
+
+def test_textDocument_hover_float_window_move_cursor_into_window(nvim):
+    if not nvim.funcs.exists("*nvim_open_win"):
+        pytest.skip("Neovim 0.3.0 or earlier does not support floating window")
+
+    nvim.command("edit! {}".format(PATH_INDEXJS))
+    time.sleep(1)
+
+    prev_bufnr = nvim.current.buffer.number
+
+    _open_float_window(nvim)
+
+    # Moves cursor into floating window
+    nvim.funcs.LanguageClient_textDocument_hover()
+    assert nvim.current.buffer.name.endswith("__LanguageClient__")
+
+    # Close the window
+    nvim.command('close')
+    assert nvim.current.buffer.number == prev_bufnr
+
+    # Check float window buffer was closed by :close in the window
+    assert all(
+        b for b in nvim.buffers if not b.name.endswith("__LanguageClient__"))

--- a/tests/LanguageClient_test.py
+++ b/tests/LanguageClient_test.py
@@ -210,26 +210,27 @@ def test_languageClient_registerHandlers(nvim):
 #     assertRetry(lambda: len(nvim.funcs.getqflist()) == 0)
 
 
-def test_textDocument_hover_float_window(nvim):
-    if not nvim.funcs.exists('*nvim_open_win'):
-        pytest.skip('Neovim 0.3.0 or earlier does not support floating window')
+def _open_float_window(nvim):
+    nvim.funcs.cursor(13, 19)
+    pos = nvim.funcs.getpos('.')
+    nvim.funcs.LanguageClient_textDocument_hover()
+    time.sleep(1)
+    return pos
 
-    def _open_float_window():
-        nvim.funcs.cursor(13, 19)
-        pos = nvim.funcs.getpos('.')
-        nvim.funcs.LanguageClient_textDocument_hover()
-        time.sleep(1)
-        return pos
+
+def test_textDocument_hover_float_window_closed_on_cursor_moved(nvim):
+    if not nvim.funcs.exists("*nvim_open_win"):
+        pytest.skip("Neovim 0.3.0 or earlier does not support floating window")
 
     nvim.command("edit! {}".format(PATH_INDEXJS))
     time.sleep(1)
 
     buf = nvim.current.buffer
 
-    pos = _open_float_window()
+    pos = _open_float_window(nvim)
 
     float_buf = next(
-        b for b in nvim.buffers if b.name.endswith('__LanguageClient__'))
+        b for b in nvim.buffers if b.name.endswith("__LanguageClient__"))
 
     # Check if float window is open
     float_winnr = nvim.funcs.bufwinnr(float_buf.number)
@@ -237,25 +238,74 @@ def test_textDocument_hover_float_window(nvim):
 
     # Check if cursor is not moved
     assert buf.number == nvim.current.buffer.number
-    assert pos == nvim.funcs.getpos('.')
+    assert pos == nvim.funcs.getpos(".")
 
     # Move cursor to left
     nvim.funcs.cursor(13, 17)
 
     # Check float window buffer was closed by CursorMoved
     assert all(
-        b for b in nvim.buffers if not b.name.endswith('__LanguageClient__'))
+        b for b in nvim.buffers if not b.name.endswith("__LanguageClient__"))
+
+
+def test_textDocument_hover_float_window_closed_on_entering_window(nvim):
+    if not nvim.funcs.exists("*nvim_open_win"):
+        pytest.skip("Neovim 0.3.0 or earlier does not support floating window")
+
+    nvim.command("edit! {}".format(PATH_INDEXJS))
+    time.sleep(1)
 
     win_id = nvim.funcs.win_getid()
-    nvim.command('split')
-    assert win_id != nvim.funcs.win_getid()
+    nvim.command("split")
+    try:
+        assert win_id != nvim.funcs.win_getid()
 
-    _open_float_window()
+        _open_float_window(nvim)
+        assert win_id != nvim.funcs.win_getid()
 
-    # Move to another window
-    nvim.funcs.win_gotoid(win_id)
-    assert win_id == nvim.funcs.win_getid()
+        # Move to another window
+        nvim.funcs.win_gotoid(win_id)
+        assert win_id == nvim.funcs.win_getid()
 
-    # Check float window buffer was closed by WinEnter
-    assert all(
-        b for b in nvim.buffers if not b.name.endswith('__LanguageClient__'))
+        # Check float window buffer was closed by BufEnter
+        assert all(
+            b for b in nvim.buffers
+            if not b.name.endswith("__LanguageClient__"))
+    finally:
+        nvim.command("close!")
+
+
+def test_textDocument_hover_float_window_closed_on_switching_to_buffer(nvim):
+    if not nvim.funcs.exists("*nvim_open_win"):
+        pytest.skip("Neovim 0.3.0 or earlier does not support floating window")
+
+    # Create a new buffer
+    nvim.command("enew!")
+
+    another_bufnr = nvim.current.buffer.number
+
+    try:
+        nvim.command("edit! {}".format(PATH_INDEXJS))
+        time.sleep(1)
+
+        source_bufnr = nvim.current.buffer.number
+
+        _open_float_window(nvim)
+
+        float_buf = next(
+            b for b in nvim.buffers if b.name.endswith("__LanguageClient__"))
+        float_winnr = nvim.funcs.bufwinnr(float_buf.number)
+        assert float_winnr > 0
+
+        assert nvim.current.buffer.number == source_bufnr
+
+        # Move to another buffer within the same window
+        nvim.command("buffer {}".format(another_bufnr))
+        assert nvim.current.buffer.number == another_bufnr
+
+        # Check float window buffer was closed by BufEnter
+        assert all(
+            b for b in nvim.buffers
+            if not b.name.endswith("__LanguageClient__"))
+    finally:
+        nvim.command("bdelete! {}".format(another_bufnr))


### PR DESCRIPTION
Hi,

I have experimentally reimplemented a hover window for `LanguageClient#textDocument_hover()` with [Neovim's new floating window feature](https://github.com/neovim/neovim/pull/6619).

Here is a screencast with Neovim 0.4.0-dev and macOS 10.12:

![test](https://user-images.githubusercontent.com/823277/54224373-bcd5e700-453c-11e9-979a-f0de122ee1d1.gif)

This PR is still work in progress. I have not added any tests yet and I think there are some discussion points as follows:

- There is no way to move cursor into float window so user cannot scroll the contents. Some mappings might be needed.
- There is no way to close float window by user (No command like `:pclose` is not provided at this point). I added functionality to close the floating window automatically when cursor is moved. But I'm not sure this behavior makes all users happy
- Some people may prefer preview window. Using floating window might be opt-in or opt-out
- `CursorLine` is used for highlighting the floating window, but I'm not sure it is a good choice to modify background color slightly for every colorscheme. The highlight color might be customizable