### PR TITLE
fix diagnostic sign issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,11 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "either"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +306,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +347,7 @@ dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -973,6 +987,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646"
@@ -990,6 +1005,7 @@ dependencies = [
 "checksum inotify 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b54539f3910d6f84fbf9a643efd6e3aa6e4f001426c0329576128255994718"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc15eef5f8b6bef5ac5f7440a957ff95d036e2f98706947741bfc93d1976db4c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 failure = "0"
+itertools = "0.8"
 log = "0.4"
 log4rs = "0"
 structopt = "0"

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2250,9 +2250,7 @@ impl LanguageClient {
                 .into_iter()
                 .filter_map(|(_, group)| group.min_by_key(|(_, severity)| *severity))
                 .take(limit)
-                .map(|(line, severity)| {
-                    Sign::new(line, format!("LanguageClient{:?}", severity))
-                })
+                .map(|(line, severity)| Sign::new(line, format!("LanguageClient{:?}", severity)))
                 .collect())
         })?;
         let signs_prev: Vec<_> = self.update(|state| {
@@ -2260,7 +2258,7 @@ impl LanguageClient {
                 .signs
                 .entry(filename.clone())
                 .or_default()
-                .range(viewport.start..viewport.end)
+                .iter()
                 .map(|(_, sign)| sign.clone())
                 .collect())
         })?;

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -7,6 +7,7 @@ use crate::lsp::request::Request;
 use crate::rpcclient::RpcClient;
 use crate::sign::Sign;
 use failure::err_msg;
+use itertools::Itertools;
 use notify::Watcher;
 use std::sync::mpsc;
 use vim::try_get;
@@ -2226,22 +2227,31 @@ impl LanguageClient {
         let bufnr = self.vim()?.get_bufnr(&filename, params)?;
         let viewport = self.vim()?.get_viewport(params)?;
 
+        // use the most severe diagnostic of each line as the sign
         let signs_next: Vec<_> = self.update(|state| {
+            let limit = if let Some(n) = state.diagnosticsSignsMax {
+                n as usize
+            } else {
+                usize::max_value()
+            };
             Ok(state
                 .diagnostics
                 .entry(filename.clone())
                 .or_default()
                 .iter()
-                .filter_map(|diag| {
-                    if viewport.overlaps(diag.range) {
-                        let name = format!(
-                            "LanguageClient{:?}",
-                            diag.severity.unwrap_or(DiagnosticSeverity::Hint)
-                        );
-                        Some(Sign::new(diag.range.start.line, name))
-                    } else {
-                        None
-                    }
+                .filter(|diag| viewport.overlaps(diag.range))
+                .map(|diag| {
+                    (
+                        diag.range.start.line,
+                        diag.severity.unwrap_or(DiagnosticSeverity::Hint),
+                    )
+                })
+                .group_by(|(line, _)| *line)
+                .into_iter()
+                .filter_map(|(_, group)| group.min_by_key(|(_, severity)| *severity))
+                .take(limit)
+                .map(|(line, severity)| {
+                    Sign::new(line, format!("LanguageClient{:?}", severity))
                 })
                 .collect())
         })?;
@@ -2280,11 +2290,13 @@ impl LanguageClient {
             .set_signs(&filename, &signs_to_add, &signs_to_delete)?;
         self.update(|state| {
             let signs = state.signs.entry(filename.clone()).or_default();
-            for sign in signs_to_add {
-                signs.insert(sign.line, sign);
-            }
+            // signs might be deleted AND added in the same line to change severity,
+            // so deletions must be before additions
             for sign in signs_to_delete {
                 signs.remove(&sign.line);
+            }
+            for sign in signs_to_add {
+                signs.insert(sign.line, sign);
             }
             Ok(())
         })?;


### PR DESCRIPTION
This PR should fix two diagnostic signs related issues:
* #758 If multiple diagnostic messages were reported on a single line, multiple signs would be added but only one of them would be removed after the errors were resolved. I think we can just use the most severe one and drop the others  on one line.
* #765 Limitation on number of signs was dropped.

@mhuttner @PierreLeidbring @mburakov Mind helping verify if is this fix you issues?