### PR TITLE
Use native CPU when building manually

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ vint:
 	vint autoload plugin
 
 release:
-	cargo build --release
+	RUSTFLAGS="-C target-cpu=native" cargo build --release
 	cp -f target/release/languageclient bin/
 	chmod a+x bin/languageclient
 


### PR DESCRIPTION
This should give a free speedup in the vast
majority of cases.