### PR TITLE
Remove unnecessary closures

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2675,11 +2675,7 @@ impl LanguageClient {
             buf += "Idle";
         } else {
             // For RLS this can be "Build" or "Diagnostics" or "Indexing".
-            buf += params
-                .title
-                .as_ref()
-                .map(|title| title.as_ref())
-                .unwrap_or("Busy");
+            buf += params.title.as_ref().map(AsRef::as_ref).unwrap_or("Busy");
 
             // For RLS this is the crate name, present only if the progress isn't known.
             if let Some(message) = params.message {

--- a/src/types.rs
+++ b/src/types.rs
@@ -673,7 +673,7 @@ impl ToString for Hover {
             HoverContents::Scalar(ref ms) => ms.to_string(),
             HoverContents::Array(ref vec) => vec
                 .iter()
-                .map(|i| i.to_string())
+                .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join("\n"),
             HoverContents::Markup(ref mc) => mc.to_string(),
@@ -712,7 +712,7 @@ impl ToDisplay for lsp::MarkedString {
             MarkedString::String(ref s) => s,
             MarkedString::LanguageString(ref ls) => &ls.value,
         };
-        s.lines().map(|i| i.to_string()).collect()
+        s.lines().map(String::from).collect()
     }
 
     fn vim_filetype(&self) -> Option<String> {
@@ -747,7 +747,7 @@ impl ToDisplay for Hover {
                         let mut buf = Vec::new();
 
                         buf.push(format!("```{}", ls.language));
-                        buf.extend(ls.value.lines().map(|i| i.to_string()));
+                        buf.extend(ls.value.lines().map(String::from));
                         buf.push("```".to_string());
 
                         buf
@@ -771,7 +771,7 @@ impl ToDisplay for Hover {
 
 impl ToDisplay for str {
     fn to_display(&self) -> Vec<String> {
-        self.lines().map(|s| s.to_string()).collect()
+        self.lines().map(String::from).collect()
     }
 }
 
@@ -798,7 +798,7 @@ impl LinesLen for Hover {
     fn lines_len(&self) -> usize {
         match self.contents {
             HoverContents::Scalar(ref c) => c.lines_len(),
-            HoverContents::Array(ref arr) => arr.iter().map(|i| i.lines_len()).sum(),
+            HoverContents::Array(ref arr) => arr.iter().map(LinesLen::lines_len).sum(),
             HoverContents::Markup(ref c) => c.lines_len(),
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -140,12 +140,12 @@ pub fn apply_TextEdits(lines: &[String], edits: &[TextEdit]) -> Fallible<Vec<Str
 
         let start = lines[..std::cmp::min(start_line, lines.len())]
             .iter()
-            .map(|l| l.len())
+            .map(String::len)
             .fold(0, |acc, l| acc + l + 1 /*line ending*/)
             + start_character;
         let end = lines[..std::cmp::min(end_line, lines.len())]
             .iter()
-            .map(|l| l.len())
+            .map(String::len)
             .fold(0, |acc, l| acc + l + 1 /*line ending*/)
             + end_character;
         edits_by_index.push((start, end, &edit.new_text));
@@ -158,7 +158,7 @@ pub fn apply_TextEdits(lines: &[String], edits: &[TextEdit]) -> Fallible<Vec<Str
         text = String::new() + &text[..start] + new_text + &text[end..];
     }
 
-    Ok(text.lines().map(|l| l.to_owned()).collect())
+    Ok(text.lines().map(ToOwned::to_owned).collect())
 }
 
 #[test]


### PR DESCRIPTION
For less complexity, you can remove unnecessary closures and simply pass in the function itself