### PR TITLE
Add examples about how to configure for Ruby

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,6 +73,7 @@ let g:LanguageClient_serverCommands = {
     \ 'javascript': ['/usr/local/bin/javascript-typescript-stdio'],
     \ 'javascript.jsx': ['tcp://127.0.0.1:2089'],
     \ 'python': ['/usr/local/bin/pyls'],
+    \ 'ruby': ['~/.rbenv/shims/solargraph', 'stdio'],
     \ }
 
 nnoremap <silent> K :call LanguageClient#textDocument_hover()<CR>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ let g:LanguageClient_serverCommands = {
     \ 'javascript': ['/usr/local/bin/javascript-typescript-stdio'],
     \ 'javascript.jsx': ['tcp://127.0.0.1:2089'],
     \ 'python': ['/usr/local/bin/pyls'],
+    \ 'ruby': ['~/.rbenv/shims/solargraph', 'stdio'],
     \ }
 
 nnoremap <F5> :call LanguageClient_contextMenu()<CR>


### PR DESCRIPTION
This adds an example about how to use LanguageClient-neovim with [Solargraph](https://github.com/castwide/solargraph) for Ruby.