### PR TITLE
Try to prepare sha256 and use it on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,18 +11,21 @@ name=languageclient
 
 try_curl() {
     command -v curl > /dev/null && \
-        curl --fail --location "$1" --output bin/$name
+        curl --fail --location "$1" --output bin/$name && \
+        curl --fail --location "$1.sha256" --output bin/$name.sha256
 }
 
 try_wget() {
     command -v wget > /dev/null && \
-        wget --output-document=bin/$name "$1"
+        wget --output-document=bin/$name "$1" && \
+        wget --output-document=bin/$name.sha256 "$1.sha256"
 }
 
 download() {
     echo "Downloading bin/${name}..."
     url=https://github.com/autozimu/LanguageClient-neovim/releases/download/$version/${1}
     if (try_curl "$url" || try_wget "$url"); then
+        sha256sum -c "bin/$name.sha256" || (echo "bin/$name.sha256 file checksum does not match exiting." && exit 1)
         chmod a+x bin/$name
         return
     else


### PR DESCRIPTION
Hi, I would like to prepare and use a `release-exe.sha256` file for each release and use it to check the checksum on the `install.sh`; I'm not sure about the result file and deploy process so maybe its a good template if its interesting for you ? cheers and thanks for this project!