### PR TITLE
add new root marker for python projects: pyproject.toml

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,6 +51,7 @@ pub fn get_rootPath<'a>(
             dir.join("setup.py").exists()
                 || dir.join("Pipfile").exists()
                 || dir.join("requirements.txt").exists()
+                || dir.join("pyproject.toml").exists()
         }),
         "c" | "cpp" => traverse_up(path, |dir| dir.join("compile_commands.json").exists()),
         "cs" => traverse_up(path, is_dotnet_root),


### PR DESCRIPTION
As defined per https://www.python.org/dev/peps/pep-0518/
`pyproject.toml` is a file that could be used to define a python project.

It is already used by some popular tools like [poetry](https://poetry.eustace.io/)
or [black](https://black.readthedocs.io/en/stable/)