### PR TITLE
Add client-side support for "rust-analyzer.applySourceChange" 

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# defaults are great :)

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1296,12 +1296,10 @@ impl LanguageClient {
             None => return Ok(result),
             Some(response) => match response {
                 CodeActionResponse::Commands(commands) => commands,
-                CodeActionResponse::Actions(actions) => {
-                    actions
-                        .into_iter()
-                        .filter_map(|action| action.command)
-                        .collect()
-                }
+                CodeActionResponse::Actions(actions) => actions
+                    .into_iter()
+                    .filter_map(|action| action.command)
+                    .collect(),
             },
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,7 +55,10 @@ pub const NOTIFICATION__WindowProgress: &str = "window/progress";
 pub const NOTIFICATION__LanguageStatus: &str = "language/status";
 pub const REQUEST__ClassFileContents: &str = "java/classFileContents";
 
-pub const CommandsClient: &[&str] = &["java.apply.workspaceEdit"];
+pub const CommandsClient: &[&str] = &[
+    "java.apply.workspaceEdit",
+    "rust-analyzer.applySourceChange",
+];
 
 // Vim variable names
 pub const VIM__ServerStatus: &str = "g:LanguageClient_serverStatus";


### PR DESCRIPTION
The [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer) language server requires the clients to implement a custom source change operation.

This is similar to the already existing "java.apply.workspaceEdit" functionality in this language client.

This feature can be removed once rust-analyzer [supports `workspace/executeCommand`](https://github.com/rust-analyzer/rust-analyzer/issues/1232).

This also adds support for the `CreateFile` operation in `apply_WorkspaceEdit`, and makes sure `textDocument_codeAction` handles [all possible response values](https://github.com/gluon-lang/lsp-types/blob/d78071ae83367dda76c674e392a16268fe41e843/src/request.rs#L413).