### PR TITLE
Generate binary sha256 file on before deploy

### DIFF
--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -7,6 +7,7 @@ package() {
     fi
 
     cp -f target/$TARGET/release/$BIN_NAME bin/$BIN_NAME_TAG
+    sha256sum "bin/$BIN_NAME_TAG" | tee "bin/$BIN_NAME_TAG.sha256"
 }
 
 release_tag() {


### PR DESCRIPTION
ref https://github.com/autozimu/LanguageClient-neovim/pull/801#discussion_r281427642

Split generate and use of sha256 to avoid erroneous install.sh before file generated