### PR TITLE
Add missing space between severity, code, and message

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -487,12 +487,12 @@ impl LanguageClient {
             let line = entry.range.start.line;
             let mut msg = String::new();
             if let Some(severity) = entry.severity {
-                msg += &format!("[{:?}]", severity);
+                msg += &format!("[{:?}] ", severity);
             }
             if let Some(ref code) = entry.code {
                 let s = code.to_string();
                 if !s.is_empty() {
-                    msg += &format!("[{}]", s);
+                    msg += &format!("[{}] ", s);
                 }
             }
             msg += &entry.message;


### PR DESCRIPTION
Previously would render like “[ERROR]This is the error”, now renders like: “[ERROR] This is the error”.