### PR TITLE
[#835] Set hover window as modifiable

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -370,7 +370,7 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
         wincmd P
     endif
 
-    setlocal buftype=nofile nobuflisted bufhidden=wipe nonumber norelativenumber signcolumn=no
+    setlocal buftype=nofile nobuflisted bufhidden=wipe nonumber norelativenumber signcolumn=no modifiable
 
     if a:filetype isnot v:null
         let &filetype = a:filetype


### PR DESCRIPTION
If it's not set as modifiable and the preview window was already open as
nomodifiable (by the same function), then it fails setting the window text.

Fixes #835.