### PR TITLE
Expand tilde in linux and macos logger paths

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -14,13 +14,16 @@ fn create_config(path: &Option<String>, level: LevelFilter) -> Fallible<Config> 
 
     let mut root_builder = Root::builder();
     if let Some(path) = path {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let path = shellexpand::tilde(&path).to_string();
+
         // Ensure log file writable.
         {
             let mut f = std::fs::OpenOptions::new()
                 .create(true)
                 .write(true)
                 .truncate(true)
-                .open(path)
+                .open(&path)
                 .with_context(|err| format!("Failed to open file ({}): {}", path, err))?;
             #[allow(clippy::write_literal)]
             writeln!(


### PR DESCRIPTION
As it stands today, using tilde (`~`) in the `g:LanguageClient_loggingFile` path will break the server upon start. This PR adds a few lines to expand the tilde, for both linux and macos systems, using `shellexpand`, which was already included in the dependencies.