### PR TITLE
rangeFormatting does not properly transmit range

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -831,8 +831,8 @@ function! LanguageClient#textDocument_rangeFormatting(...) abort
                 \ 'text': LSP#text(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
-                \ 'LSP#range_start_line()': LSP#range_start_line(),
-                \ 'LSP#range_end_line()': LSP#range_end_line(),
+                \ 'range_start_line': LSP#range_start_line(),
+                \ 'range_end_line': LSP#range_end_line(),
                 \ 'handle': s:IsFalse(l:Callback),
                 \ }
     call extend(l:params, get(a:000, 0, {}))


### PR DESCRIPTION
rangeFormatting does not work for me, as the parameters use a different syntax when parsed in the rust client: https://github.com/autozimu/LanguageClient-neovim/blob/next/src/language_server_protocol.rs#L1455

Fix attached