### PR TITLE
 Add LanguageClient_closeFloatingHover() 

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -324,6 +324,14 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
 
     let use_float_win = s:ShouldUseFloatWindow()
     if use_float_win
+        " When a language server takes a while to initialize and the user
+        " calls hover multiple times during that time (for example, via an
+        " automatic hover on cursor move setup), we will get a number of
+        " successive calls into this function resulting in many hover windows
+        " opened. This causes a number of issues, and we only really want one,
+        " so make sure that the previous hover window is closed.
+        call s:CloseFloatingHover()
+
         let pos = getpos('.')
 
         " Calculate width and height and give margin to lines

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -267,7 +267,20 @@ function! s:ShouldUseFloatWindow() abort
     return s:FLOAT_WINDOW_AVAILABLE && (use || use is v:null)
 endfunction
 
-function! s:CloseFloatingHoverOnCursorMove(win_id, opened) abort
+function! s:CloseFloatingHover() abort
+    if !exists('s:float_win_id')
+        return
+    endif
+
+    autocmd! plugin-LC-neovim-close-hover
+    let winnr = win_id2win(s:float_win_id)
+    if winnr == 0
+        return
+    endif
+    execute winnr . 'wincmd c'
+endfunction
+
+function! s:CloseFloatingHoverOnCursorMove(opened) abort
     if getpos('.') == a:opened
         " Just after opening floating window, CursorMoved event is run.
         " To avoid closing floating window immediately, check the cursor
@@ -275,15 +288,15 @@ function! s:CloseFloatingHoverOnCursorMove(win_id, opened) abort
         return
     endif
     autocmd! plugin-LC-neovim-close-hover
-    let winnr = win_id2win(a:win_id)
+    let winnr = win_id2win(s:float_win_id)
     if winnr == 0
         return
     endif
     execute winnr . 'wincmd c'
 endfunction
 
-function! s:CloseFloatingHoverOnBufEnter(win_id, bufnr) abort
-    let winnr = win_id2win(a:win_id)
+function! s:CloseFloatingHoverOnBufEnter(bufnr) abort
+    let winnr = win_id2win(s:float_win_id)
     if winnr == 0
         " Float window was already closed
         autocmd! plugin-LC-neovim-close-hover
@@ -353,7 +366,7 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
             let col = 1
         endif
 
-        let float_win_id = nvim_open_win(bufnr, v:true, {
+        let s:float_win_id = nvim_open_win(bufnr, v:true, {
         \   'relative': 'cursor',
         \   'anchor': vert . hor,
         \   'row': row,
@@ -384,8 +397,8 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
     if use_float_win
         " Unlike preview window, :pclose does not close window. Instead, close
         " hover window automatically when cursor is moved.
-        let call_after_move = printf('<SID>CloseFloatingHoverOnCursorMove(%d, %s)', float_win_id, string(pos))
-        let call_on_bufenter = printf('<SID>CloseFloatingHoverOnBufEnter(%d, %d)', float_win_id, bufnr)
+        let call_after_move = printf('<SID>CloseFloatingHoverOnCursorMove(%s)', string(pos))
+        let call_on_bufenter = printf('<SID>CloseFloatingHoverOnBufEnter(%d)', bufnr)
         augroup plugin-LC-neovim-close-hover
             execute 'autocmd CursorMoved,CursorMovedI,InsertEnter <buffer> call ' . call_after_move
             execute 'autocmd BufEnter * call ' . call_on_bufenter
@@ -687,6 +700,10 @@ function! LanguageClient#textDocument_hover(...) abort
                 \ }
     call extend(l:params, get(a:000, 0, {}))
     return LanguageClient#Call('textDocument/hover', l:params, l:Callback)
+endfunction
+
+function! LanguageClient#closeFloatingHover() abort
+    call s:CloseFloatingHover()
 endfunction
 
 " Meta methods to go to various places.

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -106,6 +106,10 @@ function! LanguageClient_cquery_vars(...)
     return call('LanguageClient#cquery_vars', a:000)
 endfunction
 
+function! LanguageClient_closeFloatingHover(...)
+    return call('LanguageClient#closeFloatingHover', a:000)
+endfunction
+
 command! -nargs=* LanguageClientStart :call LanguageClient#startServer(<f-args>)
 command! LanguageClientStop :call LanguageClient#exit()
 


### PR DESCRIPTION
My use-cases:

- I have automatic hover on CursorMove, and due to the order of autocmds, it's triggering before LanguageClient's autocmd has a chance to close the previous hover window, effectively only opening hover every other cursor move. Now I can close it manually before it's spawned again.

- Starting a visual selection while the hover window is shown and moving the cursor clears the visual selection (#864). By mapping visual selection keys to close the hover window right before starting the visual selection, that issue is effectively avoided.