### PR TITLE
Fix deoplete unicode completion

### DIFF
--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -1,7 +1,7 @@
 from .base import Base
 
 
-CompleteOutputs = "g:LanguageClient_omniCompleteResults"
+COMPLETE_OUTPUTS = "g:LanguageClient_omniCompleteResults"
 
 
 class Source(Base):
@@ -18,8 +18,8 @@ class Source(Base):
 
     def gather_candidates(self, context):
         if context["is_async"]:
-            outputs = self.vim.eval(CompleteOutputs)
-            if len(outputs) != 0:
+            outputs = self.vim.eval(COMPLETE_OUTPUTS)
+            if outputs:
                 context["is_async"] = False
                 # TODO: error handling.
                 candidates = outputs[0].get("result", [])
@@ -27,7 +27,7 @@ class Source(Base):
                 return candidates
         else:
             context["is_async"] = True
-            self.vim.command("let {} = []".format(CompleteOutputs))
+            self.vim.command("let {} = []".format(COMPLETE_OUTPUTS))
             character = (context["complete_position"]
                          + len(context["complete_str"]))
             self.vim.funcs.LanguageClient_omniComplete({
@@ -35,11 +35,3 @@ class Source(Base):
                 "complete_position": context["complete_position"],
             })
         return []
-
-
-# f = open("/tmp/deoplete.log", "w")
-
-
-# def log(message):
-#     f.writelines([message])
-#     f.flush()

--- a/rplugin/python3/deoplete/sources/LanguageClientSource.py
+++ b/rplugin/python3/deoplete/sources/LanguageClientSource.py
@@ -14,11 +14,7 @@ class Source(Base):
         self.min_pattern_length = 1
         self.filetypes = vim.eval(
             "get(g:, 'LanguageClient_serverCommands', {})").keys()
-        self.input_pattern += r'(\.|::|->)\w*$'
-
-    def get_complete_position(self, context):
-        return self.vim.call(
-            'LanguageClient#get_complete_start', context['input'])
+        self.input_pattern = r'(\.|::|->)\w*$'
 
     def gather_candidates(self, context):
         if context["is_async"]:


### PR DESCRIPTION
* Passes the tests

tl;dr LanguageClient-neovim's Deoplete source caused completion failures when completing strings AFTER unicode characters had been entered earlier on the same line. This PR resolves the issue.

## Symptoms

I spent the weekend writing a language server for a writing project that I used with LanguageClient-neovim and Deoplete. This language server supplies me with string values with lots of Unicode special characters, which presents an interesting edge case for this LanguageClient.

Things worked fine as long as a line began with ASCII-like characters, but broke down once special unicode characters were present:

```txt
This line is totally fine, and words complete through the end :)

This līōn will stop completing correctly after the first līōn :(
```

## Cause

I'm not 100% certain about what was happening, but my strong hunch: VimL string functions historically operated on Bytes. The get_complete_position function implementation referenced a vimscript function that uses 'match', which is one-such function. See below:

```viml
function! LanguageClient#get_complete_start(input) abort
    " echomsg a:input
    return match(a:input, '\k*$')
endfunction
```

For ASCII-like strings, bytes can be treated identically to Vim characters. When we get to the broader Unicode universe, bytes and strings behave differently in VimL.

## Fix

Delete the overriding method.

Luckily, the Deoplete plugin provides a default implementation for get_complete_position that I believe is perfectly suitable for our use-cases. No need to re-invent the wheel unless we have to!

## Additional work

I did some minor tweaks to the Deoplete plugin, cleaning up the code. I've separated the changes into their own commits; please let me know if anything is unclear.