### PR TITLE
Don't highlight if diagnostic range end is character 0

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -609,7 +609,11 @@ impl LanguageClient {
                             let endLine =
                                 vec![dn.range.end.line + 1, 1, dn.range.end.character + 1];
                             middleLines.push(startLine);
-                            middleLines.push(endLine);
+                            // For a multi-ringe range ending at the exact start of the last line,
+                            // don't highlight the first character of the last line.
+                            if dn.range.end.character > 0 {
+                                middleLines.push(endLine);
+                            }
                             middleLines
                         }
                     })


### PR DESCRIPTION
This is helpful for ranges such as
`{start:{line:5,character:0},end:{line:6,character:0}}`

One reason a language server may use that type of range is
because it doesn't guarantee that it will keep the file contents in memory,
and doesn't track columns.
I do this in https://github.com/tysonandre/languageserver-phan-neovim

If I set up `highlight link ALEWarning todo` (etc):

- With this patch, the background of the characters in line 5
  are highlighted, as I'd expect.
- Without this patch, the whole line 5 is highlighted,
  plus the first character of line 6.

  I'd only expect highlights in line 6 for `end:{line:6,character:1}`