### PR TITLE
Add a clients_mutex for starting new language servers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,10 @@ fn main() -> Fallible<()> {
     let _ = args.get_matches();
 
     let (tx, rx) = crossbeam_channel::unbounded();
-    let language_client = language_client::LanguageClient(Arc::new(Mutex::new(State::new(tx)?)));
+    let language_client = language_client::LanguageClient {
+        state_mutex: Arc::new(Mutex::new(State::new(tx)?)),
+        clients_mutex: Arc::new(Mutex::new(HashMap::new())),
+    };
 
     language_client.loop_call(&rx)
 }


### PR DESCRIPTION
This prevents more than one language server from starting up at any
point in time.

Fixes #878