### PR TITLE
Fix install fails

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-$version = '0.1.153'
+$version = 'v0.1.153'
 $name = 'languageclient'
 $url = "https://github.com/autozimu/LanguageClient-neovim/releases/download/$version/$name-$version-"
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -o nounset    # error when referencing undefined variable
 set -o errexit    # exit when command fails
 
-version=0.1.153
+version=v0.1.153
 name=languageclient
 
 try_curl() {


### PR DESCRIPTION
Because the built binary download URL is different from that of [releases](https://github.com/autozimu/LanguageClient-neovim/releases)