### PR TITLE
Fix: install compare with the binary's version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,7 @@ try_build() {
 
 bin=bin/languageclient
 if [ -f "$bin" ]; then
-    installed_version=0.1.154
+    installed_version=$($bin -V)
     case "${installed_version}" in
         *${version}*) echo "Version is equal to ${version}, skip install." ; exit 0 ;;
         *) rm -f "$bin" ;;


### PR DESCRIPTION
the `installed_version` should be fetched from the binary, not the given one.