### PR TITLE
Show relatedInformation in explainErrorAtPoint

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2747,6 +2747,7 @@ impl LanguageClient {
 
         let mut explanation = diag.message;
         if let Some(related_information) = diag.related_information {
+            explanation = format!("{}\n", explanation);
             for ri in related_information {
                 let prefix = format!("{}/", rootUri);
                 let uri = if ri.location.uri.as_str().starts_with(prefix.as_str()) {


### PR DESCRIPTION
The LSP spec allows for relatedInformation on a diagnostic, which is how
VS Code shows error messages that look like this:

<img width="584" alt="Screen Shot 2019-09-25 at 6 30 11 PM" src="https://user-images.githubusercontent.com/5544532/65651380-0fe82680-dfc3-11e9-84b7-751638845509.png">

This change implements similar logic for explainErrorAtPoint by looping
over the relatedInformation fields and concatenating them together.
Here's what it looks like in my Vim setup:

<img width="635" alt="Screen Shot 2019-09-26 at 10 13 45 AM" src="https://user-images.githubusercontent.com/5544532/65709729-621e5b80-e046-11e9-937c-60f1b98fea42.png">

Before this change, it looked like this:

<img width="580" alt="Screen Shot 2019-09-25 at 6 35 17 PM" src="https://user-images.githubusercontent.com/5544532/65651436-40c85b80-dfc3-11e9-82a9-989e3e7a2f31.png">

