### PR TITLE
Add hideVirtualTextsOnInsert option

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -374,6 +374,13 @@ Maximum severity to show diagnostic messages.
 Default: "Hint"
 Valid options: "Error" | "Warning" | "Information" | "Hint"
 
+2.29 g:LanguageClient_hideVirtualTextsOnInsert *g:LanguageClient_hideVirtualTextsOnInsert*
+
+Hides all virtual texts for the current buffer while editing in insert mode.
+
+Default: 1
+Valid options: 1 | 0
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2471,8 +2471,8 @@ impl LanguageClient {
             let namespace_id = self.get_or_create_namespace()?;
             let mut virtual_texts = vec![];
 
-            // leave `virtual_texts` empty if hideVirtualTextsOnInsert unless
-            // hideVirtualTextsOnInsert is set to `false` or we are not in insert mode
+            // leave `virtual_texts` empty unless hideVirtualTextsOnInsert is set to `false` or we
+            // are not in insert mode
             if !self.get(|state| state.hideVirtualTextsOnInsert)?
                 || self.vim()?.get_mode()? != Mode::Insert
             {

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,6 +139,7 @@ pub struct State {
     pub viewports: HashMap<String, Viewport>,
 
     // User settings.
+    pub hideVirtualTextsOnInsert: bool,
     pub serverCommands: HashMap<String, Vec<String>>,
     pub autoStart: bool,
     pub selectionUI: SelectionUI,
@@ -215,6 +216,7 @@ impl State {
             stashed_codeAction_actions: vec![],
             viewports: HashMap::new(),
 
+            hideVirtualTextsOnInsert: true,
             serverCommands: HashMap::new(),
             autoStart: true,
             selectionUI: SelectionUI::LocationList,

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -13,6 +13,43 @@ pub fn try_get<R: DeserializeOwned>(key: &str, params: &Value) -> Fallible<Optio
     }
 }
 
+#[derive(PartialEq)]
+pub enum Mode {
+    Normal,
+    Insert,
+    Replace,
+    Visual,
+    VisualLine,
+    VisualBlock,
+    Command,
+    Select,
+    SelectLine,
+    SelectBlock,
+    Terminal,
+}
+
+impl From<&str> for Mode {
+    fn from(mode: &str) -> Self {
+        match mode {
+            "n" => Mode::Normal,
+            "i" => Mode::Insert,
+            "R" => Mode::Replace,
+            "v" => Mode::Visual,
+            "V" => Mode::VisualLine,
+            "<C-v>" => Mode::VisualBlock,
+            "c" => Mode::Command,
+            "s" => Mode::Select,
+            "S" => Mode::SelectLine,
+            "<C-s>" => Mode::SelectBlock,
+            "t" => Mode::Terminal,
+            m => {
+                error!("unknown mode {}, falling back to Mode::Normal", m);
+                Mode::Normal
+            }
+        }
+    }
+}
+
 #[derive(Clone, Serialize)]
 pub struct Vim {
     pub rpcclient: RpcClient,
@@ -198,5 +235,10 @@ impl Vim {
             "s:set_signs",
             json!([filename, signs_to_add, signs_to_delete]),
         )
+    }
+
+    pub fn get_mode(&self) -> Fallible<Mode> {
+        let mode: String = self.rpcclient.call("mode", json!([]))?;
+        Ok(Mode::from(mode.as_str()))
     }
 }


### PR DESCRIPTION
This pull request fixes #816 by adding an option (`LanguageClient_hideVirtualTextsOnInsert`) to hide diagnostics in virtual texts while typing (insert mode) and setting `1` as a default value for it.

Here's what the end result looks like:

![recording-2019-09-26_07 57 56](https://user-images.githubusercontent.com/4250565/65683522-c71c8600-e033-11e9-91fc-51aab3403cfb.gif)

