### PR TITLE
Fix WorkspaceEditWithCursor definition

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -841,10 +841,12 @@ impl LanguageClient {
                     for edit in edits {
                         let edit: WorkspaceEditWithCursor = serde_json::from_value(edit.clone())?;
                         self.apply_WorkspaceEdit(&edit.workspaceEdit)?;
-                        self.vim()?.cursor(
-                            edit.cursorPosition.position.line + 1,
-                            edit.cursorPosition.position.character + 1,
-                        )?;
+                        if let Some(cursorPosition) = edit.cursorPosition {
+                            self.vim()?.cursor(
+                                cursorPosition.position.line + 1,
+                                cursorPosition.position.character + 1,
+                            )?;
+                        }
                     }
                 }
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1037,5 +1037,5 @@ pub struct VirtualText {
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceEditWithCursor {
     pub workspaceEdit: WorkspaceEdit,
-    pub cursorPosition: TextDocumentPositionParams,
+    pub cursorPosition: Option<TextDocumentPositionParams>,
 }


### PR DESCRIPTION
I'm not sure if there's an open issue for this, but while working with rust-analyzer I got some errors while trying to run the `codeAction` command. Basically, I would get something like this when trying to run a codeAction that modified the current buffer:

![Screenshot from 2019-10-14 18-33-48](https://user-images.githubusercontent.com/4250565/66784728-a49ebf80-eeb1-11e9-83b6-ecb6a5f0e1b9.png)

Digging around I found that the definition of `WorkspaceEditWithCursor` expects a `TextDocumentPositionParams` in the field `cursorPosition`, but as I understand it, that field [should be optional](https://github.com/rust-analyzer/rust-analyzer/blob/05ed6c548a7672e2c9472276a652c374a5d2a212/editors/code/src/commands/apply_source_change.ts#L9).

This PR fixes the definition of `WorkspaceEditWithCursor`, making the `cursorPosition` optional, to properly handle the `applySourceChange` command from rust-analyzer.