### PR TITLE
Clear previous diagnostics in case if LanguageClient_diagnosticsList …

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1938,6 +1938,12 @@ impl LanguageClient {
         );
 
         self.update(|state| {
+            match state.diagnosticsList {
+                DiagnosticsList::Location => {
+                    state.diagnostics.clear();
+                },
+                _ => {}
+            };
             state
                 .diagnostics
                 .insert(filename.clone(), diagnostics.clone());


### PR DESCRIPTION
If g:LanguageClient_diagnosticsList = 'Location' we have to clear previous diagnostic results.
As a result, we will have diagnostics only for a current buffer in case if 'Location' is set.

Fixes:
https://github.com/autozimu/LanguageClient-neovim/issues/763