### PR TITLE
Fix Makefile to work with CARGO_TARGET_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,9 @@ vint:
 
 release:
 	cargo build --release
-	cp -f target/release/languageclient bin/
+	[ -z "${CARGO_TARGET_DIR}" ] && \
+		cp -f target/release/languageclient bin/ || \
+		cp -f ${CARGO_TARGET_DIR}/release/languageclient bin/
 	chmod a+x bin/languageclient
 
 bump-version:


### PR DESCRIPTION
Cargo allows users to set an environment variable, `CARGO_TARGET_DIR`, to customize the target directory of builds (see [here] for more info). If set, build artifacts show up in `CARGO_TARGET_DIR` instead of `./target/`. 

So currently, `make release` doesn't work if you have this environment variable set (due to the `cp -f target/release/languageclient bin/` line). 

This small change fixes the `Makefile` so that builds work for users who have `CARGO_TARGET_DIR` set.

[here]: https://doc.rust-lang.org/cargo/reference/environment-variables.html