### PR TITLE
Suppress compiler warnings about unused_parens

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1299,7 +1299,7 @@ impl LanguageClient {
                         flat.iter().map(QuickfixEntry::from_lsp).collect()
                     }
                     Some(lsp::DocumentSymbolResponse::Nested(nested)) => {
-                        <(Vec<QuickfixEntry>)>::from_lsp(&nested)
+                        <Vec<QuickfixEntry>>::from_lsp(&nested)
                     }
                     _ => Ok(Vec::new()),
                 };
@@ -1318,7 +1318,7 @@ impl LanguageClient {
                         flat.iter().map(QuickfixEntry::from_lsp).collect()
                     }
                     Some(lsp::DocumentSymbolResponse::Nested(nested)) => {
-                        <(Vec<QuickfixEntry>)>::from_lsp(&nested)
+                        <Vec<QuickfixEntry>>::from_lsp(&nested)
                     }
                     _ => Ok(Vec::new()),
                 };


### PR DESCRIPTION
Suppress the following compiler warnings (latest nightly):

```
warning: unnecessary parentheses around type
    --> src/language_server_protocol.rs:1302:26
     |
1302 |                         <(Vec<QuickfixEntry>)>::from_lsp(&nested)
     |                          ^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
     |
     = note: `#[warn(unused_parens)]` on by default

warning: unnecessary parentheses around type
    --> src/language_server_protocol.rs:1321:26
     |
1321 |                         <(Vec<QuickfixEntry>)>::from_lsp(&nested)
     |                          ^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses

    Finished release [optimized] target(s) in 1m 35s
```