### PR TITLE
Properly show signs on last line of viewport

### DIFF
--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -16,7 +16,7 @@ impl Viewport {
     }
 
     fn contains(&self, line: u64) -> bool {
-        line >= self.start && line < self.end
+        line >= self.start && line <= self.end
     }
 
     pub fn overlaps(&self, range: Range) -> bool {


### PR DESCRIPTION
`:echo line('w$')` will echo the line number **of the last visible**
line, not the line number after the last visible line.
(this can be seen by invoking this manually with line numbers on)

So this should be checking `<=` to be true for the last line number.

```
autoload/LSP.vim
function! LSP#viewport() abort
    return {
        \ 'start': line('w0') - 1,
        \ 'end': line('w$'),
        \ }
endfunction
```

**EDIT: The language server I'm using emits diagnostics with start: (line N, column 0), end: (line N+1, column 0). But that doesn't seem like it'd cause bugs in overlaps, anyway**