### PR TITLE
Drop `OptionDeref` in favor of the now stable `Option::as_deref`

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.37-slim
+FROM rust:1.40-slim
 
 RUN echo 'deb http://deb.debian.org/debian stretch-backports main contrib non-free' >> /etc/apt/sources.list
 

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -1,4 +1,3 @@
-use super::types::OptionDeref;
 use super::*;
 use crate::language_client::LanguageClient;
 use crate::lsp::notification::Notification;
@@ -8,7 +7,7 @@ impl LanguageClient {
     pub fn handle_call(&self, msg: Call) -> Fallible<()> {
         match msg {
             Call::MethodCall(lang_id, method_call) => {
-                let result = self.handle_method_call(OptionDeref::as_deref(&lang_id), &method_call);
+                let result = self.handle_method_call(lang_id.as_deref(), &method_call);
                 if let Err(ref err) = result {
                     if err.find_root_cause().downcast_ref::<LCError>().is_none() {
                         error!(
@@ -23,8 +22,7 @@ impl LanguageClient {
                     .output(method_call.id.to_int()?, result)?;
             }
             Call::Notification(lang_id, notification) => {
-                let result =
-                    self.handle_notification(OptionDeref::as_deref(&lang_id), &notification);
+                let result = self.handle_notification(lang_id.as_deref(), &notification);
                 if let Err(ref err) = result {
                     if err.downcast_ref::<LCError>().is_none() {
                         error!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -956,16 +956,6 @@ impl Default for TextDocumentItemMetadata {
     }
 }
 
-pub trait OptionDeref<T: Deref> {
-    fn as_deref(&self) -> Option<&T::Target>;
-}
-
-impl<T: Deref> OptionDeref<T> for Option<T> {
-    fn as_deref(&self) -> Option<&T::Target> {
-        self.as_ref().map(Deref::deref)
-    }
-}
-
 pub trait ToLSP<T> {
     fn to_lsp(self) -> Fallible<T>;
 }

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -1,4 +1,3 @@
-use super::types::OptionDeref;
 use super::*;
 use crate::rpcclient::RpcClient;
 use crate::sign::Sign;
@@ -149,7 +148,7 @@ impl Vim {
 
     pub fn edit(&self, goto_cmd: &Option<String>, path: impl AsRef<Path>) -> Fallible<()> {
         let path = path.as_ref().to_string_lossy();
-        let goto = OptionDeref::as_deref(goto_cmd).unwrap_or("edit");
+        let goto = goto_cmd.as_deref().unwrap_or("edit");
         self.rpcclient.notify("s:Edit", json!([goto, path]))?;
         Ok(())
     }


### PR DESCRIPTION
Drop `OptionDeref` in favor of the new `Option::as_deref` stabilised in Rust 1.40