### PR TITLE
Implement codeLens

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -122,7 +122,11 @@ function! s:useVirtualText() abort
         return l:use
     endif
 
-    return exists('*nvim_buf_set_virtual_text')
+    if exists('*nvim_buf_set_virtual_text')
+        return 'All'
+    else
+        return 'No'
+    endif
 endfunction
 
 function! s:IsTrue(v) abort
@@ -1296,7 +1300,7 @@ function! LanguageClient#java_classFileContents(...) abort
     return LanguageClient#Call('java/classFileContents', l:params, l:Callback)
 endfunction
 
-function! LanguageClient#codeLensAction(...) abort
+function! LanguageClient#handleCodeLensAction(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
@@ -1304,7 +1308,7 @@ function! LanguageClient#codeLensAction(...) abort
                 \ 'character': LSP#character(),
                 \ }
     call extend(l:params, get(a:000, 0, {}))
-    return LanguageClient#Call('LanguageClient_CodeLensAction', l:params, l:Callback)
+    return LanguageClient#Call('LanguageClient/handleCodeLensAction', l:params, l:Callback)
 endfunction
 
 function! LanguageClient_contextMenuItems() abort

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -119,7 +119,7 @@ endfunction
 function! s:useVirtualText() abort
     let l:use = s:GetVar('LanguageClient_useVirtualText')
     if l:use isnot v:null
-        return !!l:use
+        return l:use
     endif
 
     return exists('*nvim_buf_set_virtual_text')
@@ -816,11 +816,23 @@ function! LanguageClient#workspace_symbol(...) abort
     return LanguageClient#Call('workspace/symbol', l:params, l:Callback)
 endfunction
 
-function! LanguageClient#textDocument_codeAction(...) abort
+function! LanguageClient#textDocument_codeLens(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
                 \ 'text': LSP#text(),
+                \ 'line': LSP#line(),
+                \ 'character': LSP#character(),
+                \ 'handle': s:IsFalse(l:Callback),
+                \ }
+    call extend(l:params, get(a:000, 0, {}))
+    return LanguageClient#Call('textDocument/codeLens', l:params, l:Callback)
+endfunction
+
+function! LanguageClient#textDocument_codeAction(...) abort
+    let l:Callback = get(a:000, 1, v:null)
+    let l:params = {
+                \ 'filename': LSP#filename(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
                 \ 'handle': s:IsFalse(l:Callback),
@@ -1282,6 +1294,17 @@ function! LanguageClient#java_classFileContents(...) abort
     let l:params = get(a:000, 0, {})
     let l:Callback = get(a:000, 1, v:null)
     return LanguageClient#Call('java/classFileContents', l:params, l:Callback)
+endfunction
+
+function! LanguageClient#codeLensAction(...) abort
+    let l:Callback = get(a:000, 1, v:null)
+    let l:params = {
+                \ 'filename': LSP#filename(),
+                \ 'line': LSP#line(),
+                \ 'character': LSP#character(),
+                \ }
+    call extend(l:params, get(a:000, 0, {}))
+    return LanguageClient#Call('LanguageClient_CodeLensAction', l:params, l:Callback)
 endfunction
 
 function! LanguageClient_contextMenuItems() abort

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -344,7 +344,7 @@ Default: >
 
 Specify whether to use virtual text to display diagnostics.
 
-Default: "CodeLens" whenever virtual text is supported.
+Default: "All" whenever virtual text is supported.
 Valid Options: "All" | "No" | "CodeLens" | "Diagnostics"
 
 2.26 g:LanguageClient_useFloatingHover *g:LanguageClient_useFloatingHover*
@@ -487,7 +487,7 @@ Computes and displays the codeLens for the currently open file.
 *LanguageClient_textDocument_codeLensAction()*
 Signature: LanguageClient#textDocument_codeLensAction(...)
 
-Runs the action associated with the codeLens at the current line. If does
+Runs the action associated with the codeLens at the current line. It does
 nothing if the codeLens is not actionable.
 
 *LanguageClient#textDocument_documentSymbol()*

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -344,8 +344,8 @@ Default: >
 
 Specify whether to use virtual text to display diagnostics.
 
-Default: 1 whenever virtual text is supported.
-Valid Options: 1 | 0
+Default: "CodeLens" whenever virtual text is supported.
+Valid Options: "All" | "No" | "CodeLens" | "Diagnostics"
 
 2.26 g:LanguageClient_useFloatingHover *g:LanguageClient_useFloatingHover*
 
@@ -476,6 +476,19 @@ Example bindings combining with tpope/vim-abolish:
     noremap <leader>ru :call LanguageClient#textDocument_rename(
                 \ {'newName': Abolish.uppercase(expand('<cword>'))})<CR>
 <
+
+*LanguageClient#textDocument_codeLens()*
+*LanguageClient_textDocument_codeLens()*
+Signature: LanguageClient#textDocument_codeLens(...)
+
+Computes and displays the codeLens for the currently open file.
+
+*LanguageClient#textDocument_codeLensAction()*
+*LanguageClient_textDocument_codeLensAction()*
+Signature: LanguageClient#textDocument_codeLensAction(...)
+
+Runs the action associated with the codeLens at the current line. If does
+nothing if the codeLens is not actionable.
 
 *LanguageClient#textDocument_documentSymbol()*
 *LanguageClient_textDocument_documentSymbol()*

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -34,6 +34,10 @@ function! LanguageClient_textDocument_codeAction(...)
     return call('LanguageClient#textDocument_codeAction', a:000)
 endfunction
 
+function! LanguageClient_textDocument_codeLens(...)
+    return call('LanguageClient#textDocument_codeLens', a:000)
+endfunction
+
 function! LanguageClient_textDocument_completion(...)
     return call('LanguageClient#textDocument_completion', a:000)
 endfunction

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -78,6 +78,7 @@ impl LanguageClient {
             lsp::request::References::METHOD => self.textDocument_references(&params),
             lsp::request::Formatting::METHOD => self.textDocument_formatting(&params),
             lsp::request::RangeFormatting::METHOD => self.textDocument_rangeFormatting(&params),
+            lsp::request::CodeLensRequest::METHOD => self.textDocument_codeLens(&params),
             lsp::request::ResolveCompletionItem::METHOD => self.completionItem_resolve(&params),
             lsp::request::ExecuteCommand::METHOD => self.workspace_executeCommand(&params),
             lsp::request::ApplyWorkspaceEdit::METHOD => self.workspace_applyEdit(&params),
@@ -98,6 +99,7 @@ impl LanguageClient {
             REQUEST__OmniComplete => self.languageClient_omniComplete(&params),
             REQUEST__ClassFileContents => self.java_classFileContents(&params),
             REQUEST__DebugInfo => self.debug_info(&params),
+            REQUEST__CodeLensAction => self.languageClient_handleCodeLensAction(&params),
 
             _ => {
                 let languageId_target = if languageId.is_some() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,6 +32,7 @@ pub const REQUEST__NCM2OnComplete: &str = "LanguageClient_NCM2OnComplete";
 pub const REQUEST__ExplainErrorAtPoint: &str = "languageClient/explainErrorAtPoint";
 pub const REQUEST__FindLocations: &str = "languageClient/findLocations";
 pub const REQUEST__DebugInfo: &str = "languageClient/debugInfo";
+pub const REQUEST__CodeLensAction: &str = "LanguageClient_CodeLensAction";
 pub const NOTIFICATION__HandleBufNewFile: &str = "languageClient/handleBufNewFile";
 pub const NOTIFICATION__HandleFileType: &str = "languageClient/handleFileType";
 pub const NOTIFICATION__HandleTextChanged: &str = "languageClient/handleTextChanged";
@@ -94,6 +95,14 @@ pub struct HighlightSource {
     pub source: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum UseVirtualText {
+    Diagnostics,
+    CodeLens,
+    All,
+    No,
+}
+
 #[derive(Serialize)]
 pub struct State {
     // Program state.
@@ -113,6 +122,8 @@ pub struct State {
     pub text_documents_metadata: HashMap<String, TextDocumentItemMetadata>,
     // filename => diagnostics.
     pub diagnostics: HashMap<String, Vec<Diagnostic>>,
+    // filename => codeLens.
+    pub code_lens: HashMap<String, Vec<CodeLens>>,
     #[serde(skip_serializing)]
     pub line_diagnostics: HashMap<(String, u64), String>,
     pub sign_next_id: u64,
@@ -156,7 +167,7 @@ pub struct State {
     pub wait_output_timeout: Duration,
     pub hoverPreview: HoverPreviewOption,
     pub completionPreferTextEdit: bool,
-    pub use_virtual_text: bool,
+    pub use_virtual_text: UseVirtualText,
     pub echo_project_root: bool,
 
     pub loggingFile: Option<String>,
@@ -193,6 +204,7 @@ impl State {
             roots: HashMap::new(),
             text_documents: HashMap::new(),
             text_documents_metadata: HashMap::new(),
+            code_lens: HashMap::new(),
             diagnostics: HashMap::new(),
             line_diagnostics: HashMap::new(),
             sign_next_id: 75_000,
@@ -231,7 +243,7 @@ impl State {
             wait_output_timeout: Duration::from_secs(10),
             hoverPreview: HoverPreviewOption::default(),
             completionPreferTextEdit: false,
-            use_virtual_text: true,
+            use_virtual_text: UseVirtualText::CodeLens,
             echo_project_root: true,
             loggingFile: None,
             loggingLevel: log::LevelFilter::Warn,

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,7 +32,7 @@ pub const REQUEST__NCM2OnComplete: &str = "LanguageClient_NCM2OnComplete";
 pub const REQUEST__ExplainErrorAtPoint: &str = "languageClient/explainErrorAtPoint";
 pub const REQUEST__FindLocations: &str = "languageClient/findLocations";
 pub const REQUEST__DebugInfo: &str = "languageClient/debugInfo";
-pub const REQUEST__CodeLensAction: &str = "LanguageClient_CodeLensAction";
+pub const REQUEST__CodeLensAction: &str = "LanguageClient/handleCodeLensAction";
 pub const NOTIFICATION__HandleBufNewFile: &str = "languageClient/handleBufNewFile";
 pub const NOTIFICATION__HandleFileType: &str = "languageClient/handleFileType";
 pub const NOTIFICATION__HandleTextChanged: &str = "languageClient/handleTextChanged";
@@ -243,7 +243,7 @@ impl State {
             wait_output_timeout: Duration::from_secs(10),
             hoverPreview: HoverPreviewOption::default(),
             completionPreferTextEdit: false,
-            use_virtual_text: UseVirtualText::CodeLens,
+            use_virtual_text: UseVirtualText::All,
             echo_project_root: true,
             loggingFile: None,
             loggingLevel: log::LevelFilter::Warn,

--- a/tests/data/vimrc
+++ b/tests/data/vimrc
@@ -18,6 +18,7 @@ autocmd BufRead *.rs setlocal filetype=rust
 
 let g:LanguageClient_devel = 1
 let g:LanguageClient_loggingLevel = 'INFO'
+let g:LanguageClient_useVirtualText = 'CodeLens'
 let g:LanguageClient_loggingFile = expand('~/.local/share/nvim/LanguageClient.log')
 let g:LanguageClient_serverStderr = expand('~/.local/share/nvim/LanguageServer.log')
 let g:LanguageClient_serverCommands = {


### PR DESCRIPTION
Still some missing pieces, but thought I'd open a draft PR to get some feedback while I finish it.

Made some decisions that might need revisiting, like changing the type of the value of `LanguageClient_useVirtualText` from an int to a string with one of these values: All, CodeLens, Diagnostics, No. The default for this setting is `CodeLens`, which will show only codeLens in virtual texts, but can be changed to `All` which will show both CodeLens and Diagnostics in virtual text.

It supports running codeLens actions via a new function `LanguageClient#codeLensAction` which runs the action associated with the codeLens under the cursor. Only `rust-analyzer.runSingle` and `rust-analyzer.run` are handled now, which correspond to run a single test and run a binary respectively, and they are handled by running the corresponding command in a `neovim` terminal (`vim8` approach yet to be defined).

Not sure what to do about vim, as it doesn't support virtual text (afaik), and I doubt people are going to be triggering codeLens actions without visual feedback on where they are.

Here's what it looks like now:
 
![image](https://user-images.githubusercontent.com/4250565/71526823-7df8fe00-28d0-11ea-939e-1fb1f4ab53ad.png)
