### PR TITLE
Fix #914: Update cursor position after completion TextEdit

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2582,8 +2582,13 @@ impl LanguageClient {
         }
 
         self.apply_TextEdits(filename, &edits)?;
+        let updated_position = calc_cursorpos_after_TextEdits(position, &edits);
+        debug!(
+            "Update cursorpos after completion text edits: {:?} -> {:?}",
+            &position, updated_position
+        );
         self.vim()?
-            .cursor(position.line + 1, position.character + 1)
+            .cursor(updated_position.line + 1, updated_position.character + 1)
     }
 
     pub fn languageClient_FZFSinkLocation(&self, params: &Value) -> Fallible<()> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -214,7 +214,7 @@ fn test_apply_TextEdit_overlong_end() {
                 character: 0,
             },
             end: Position {
-                line: 99999999,
+                line: 99_999_999,
                 character: 0,
             },
         },


### PR DESCRIPTION
Accepting a completion item can lead to new lines and characters inserted by the language server. The language client should update the cursor position if the edit happens above or left to the cursor position.

Open questions:
- how should the cursor position be changed if the cursor is within the edit range? Current behavior in the PR: do not change cursor position.
- should the cursor be updated also after a `applyWorkspaceEdit`?

@ratheesh: could you please test whether this fixes your issues with clangd?

Bonus: fix a clippy warning about "unreadable literal".