### PR TITLE
Fix codeAction error where it failed to accept `null`

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1372,7 +1372,8 @@ impl LanguageClient {
             },
         )?;
 
-        let response: CodeActionResponse = serde_json::from_value(result.clone())?;
+        let response: Option<CodeActionResponse> = serde_json::from_value(result.clone())?;
+        let response = response.unwrap_or_else(|| vec![]);
 
         // Convert any Commands into CodeActions, so that the remainder of the handling can be
         // shared.


### PR DESCRIPTION
Fixes an issue where a valid `textDocument/codeAction` response of `null` would fail to deserialize.

According to the spec, the response of `textDocument/codeAction` is either a list of actions/commands or null (https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_codeAction).

So the response should be deserialized into `Option<CodeLensResponse>` instead of `CodeLensResponse`. This could be seen as a fix to be made in `lsp-types`, but it seems like it was the intended design, as many other responses are treated the same.

Not fixing this causes some errors to display for example with `gopls`, where if no codeActions are available it will return null.