### PR TITLE
WIP: rust-analyzer/inlayHints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod language_client;
 mod language_server_protocol;
 mod logger;
 mod rpchandler;
+mod rust_analyser;
 mod sign;
 mod viewport;
 mod vim;

--- a/src/rust_analyser.rs
+++ b/src/rust_analyser.rs
@@ -1,0 +1,29 @@
+use crate::lsp::request::Request;
+use crate::lsp::{Range, TextDocumentIdentifier};
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlayHintsParams {
+    pub text_document: TextDocumentIdentifier,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub enum InlayKind {
+    TypeHint,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct InlayHint {
+    pub range: Range,
+    pub kind: InlayKind,
+    pub label: String,
+}
+
+#[derive(Debug)]
+pub enum InlayHintRequest {}
+
+impl Request for InlayHintRequest {
+    type Params = InlayHintsParams;
+    type Result = Option<Vec<InlayHint>>;
+    const METHOD: &'static str = "rust-analyser/inlayHints";
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::rpcclient::RpcClient;
+use crate::rust_analyser::InlayHint;
 use crate::sign::Sign;
 use crate::vim::Vim;
 use std::collections::BTreeMap;
@@ -46,6 +47,7 @@ pub const NOTIFICATION__ServerExited: &str = "$languageClient/serverExited";
 pub const NOTIFICATION__ClearDocumentHighlight: &str = "languageClient/clearDocumentHighlight";
 
 // Extensions by language servers.
+pub const REQUEST__InlayHints: &str = "rust-analyzer/inlayHints";
 pub const NOTIFICATION__RustBeginBuild: &str = "rustDocument/beginBuild";
 pub const NOTIFICATION__RustDiagnosticsBegin: &str = "rustDocument/diagnosticsBegin";
 pub const NOTIFICATION__RustDiagnosticsEnd: &str = "rustDocument/diagnosticsEnd";
@@ -124,6 +126,8 @@ pub struct State {
     pub diagnostics: HashMap<String, Vec<Diagnostic>>,
     // filename => codeLens.
     pub code_lens: HashMap<String, Vec<CodeLens>>,
+    // filename => codeLens.
+    pub inlay_hints: HashMap<String, Vec<InlayHint>>,
     #[serde(skip_serializing)]
     pub line_diagnostics: HashMap<(String, u64), String>,
     pub sign_next_id: u64,
@@ -205,6 +209,7 @@ impl State {
             text_documents: HashMap::new(),
             text_documents_metadata: HashMap::new(),
             code_lens: HashMap::new(),
+            inlay_hints: HashMap::new(),
             diagnostics: HashMap::new(),
             line_diagnostics: HashMap::new(),
             sign_next_id: 75_000,


### PR DESCRIPTION
Putting this here merely for reference. WIth @martskins implementing code lens, I was looking in how rust-analyzer implements those nice type hints as described in https://github.com/autozimu/LanguageClient-neovim/issues/934

The type hints can be requested with `rust-analyzer/inlayHints`. This PR displays the hints just on the end of the line as virtual text as there is probably no nice solution (yet) to display virtual text within the line.

I also don't know whether we want a custom request for a specific language server.