### PR TITLE
Add highlight symbol under cursor feature

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -894,6 +894,21 @@ function! LanguageClient#textDocument_rangeFormatting(...) abort
     return LanguageClient#Call('textDocument/rangeFormatting', l:params, l:Callback)
 endfunction
 
+function! LanguageClient#highlightSymbol() abort
+    let l:Callback = get(a:000, 1, v:null)
+    let l:params = {
+                \ 'filename': LSP#filename(),
+                \ 'text': LSP#text(),
+                \ 'line': LSP#line(),
+                \ 'character': LSP#character(),
+                \ 'range_start_line': LSP#range_start_line(),
+                \ 'range_end_line': LSP#range_end_line(),
+                \ 'handle': s:IsFalse(l:Callback),
+                \ }
+    call extend(l:params, get(a:000, 0, {}))
+    return LanguageClient#Call('languageClient/highlightSymbol', l:params, l:Callback)
+endfunction
+
 function! LanguageClient#completionItem_resolve(completion_item, ...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
@@ -1076,11 +1091,7 @@ endfunction
 let s:last_cursor_line = -1
 function! LanguageClient#handleCursorMoved() abort
     let l:cursor_line = getcurpos()[1] - 1
-    if l:cursor_line == s:last_cursor_line
-        return
-    endif
     let s:last_cursor_line = l:cursor_line
-
     try
         call LanguageClient#Notify('languageClient/handleCursorMoved', {
                     \ 'buftype': &buftype,

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -386,6 +386,13 @@ Maximum severity to show diagnostic messages.
 Default: "Hint"
 Valid options: "Error" | "Warning" | "Information" | "Hint"
 
+2.29 g:LanguageClient_highlightSymbolUnderCursor *g:LanguageClient_highlightSymbolUnderCursor*
+
+Highlights the symbol under the cursor after `updatetime`.
+
+Default: 1
+Valid options: 0 | 1
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 
@@ -660,6 +667,11 @@ Show detailed error under cursor.
 Signature: LanguageClient#debugInfo(...)
 
 Print out debug info.
+
+*LanguageClient#highlightSymbolUnderCursor*
+Signature: LanguageClient#highlightSymbolUnderCursor(...)
+
+Highlights the references of the symbol under the cursor.
 
 ==============================================================================
 5. Events                                               *LanguageClientEvents*

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -125,6 +125,9 @@ augroup languageClient
         autocmd TextChangedP * call LanguageClient#handleTextChanged()
     endif
     autocmd CursorMoved * call LanguageClient#handleCursorMoved()
+    if get(g:, 'LanguageClient_highlightSymbolUnderCursor', 1) && has('nvim')
+      autocmd CursorHold * call LanguageClient#highlightSymbol()
+    endif
     autocmd VimLeavePre * call LanguageClient#handleVimLeavePre()
 
     autocmd CompleteDone * call LanguageClient#handleCompleteDone()

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -98,6 +98,7 @@ impl LanguageClient {
             REQUEST__OmniComplete => self.languageClient_omniComplete(&params),
             REQUEST__ClassFileContents => self.java_classFileContents(&params),
             REQUEST__DebugInfo => self.debug_info(&params),
+            REQUEST__HighlightSymbol => self.highlight_symbol(&params),
 
             _ => {
                 let languageId_target = if languageId.is_some() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,6 +32,7 @@ pub const REQUEST__NCM2OnComplete: &str = "LanguageClient_NCM2OnComplete";
 pub const REQUEST__ExplainErrorAtPoint: &str = "languageClient/explainErrorAtPoint";
 pub const REQUEST__FindLocations: &str = "languageClient/findLocations";
 pub const REQUEST__DebugInfo: &str = "languageClient/debugInfo";
+pub const REQUEST__HighlightSymbol: &str = "languageClient/highlightSymbol";
 pub const NOTIFICATION__HandleBufNewFile: &str = "languageClient/handleBufNewFile";
 pub const NOTIFICATION__HandleFileType: &str = "languageClient/handleFileType";
 pub const NOTIFICATION__HandleTextChanged: &str = "languageClient/handleTextChanged";
@@ -158,6 +159,7 @@ pub struct State {
     pub completionPreferTextEdit: bool,
     pub use_virtual_text: bool,
     pub echo_project_root: bool,
+    pub highlight_symbol_under_cursor: bool,
 
     pub loggingFile: Option<String>,
     pub loggingLevel: log::LevelFilter,
@@ -233,6 +235,7 @@ impl State {
             completionPreferTextEdit: false,
             use_virtual_text: true,
             echo_project_root: true,
+            highlight_symbol_under_cursor: true,
             loggingFile: None,
             loggingLevel: log::LevelFilter::Warn,
             serverStderr: None,


### PR DESCRIPTION
First of all, apologies for sending a PR for an unsolicited feature, but I figured I'd try implementing it instead of asking for someone to implement it. If this feature is decidedly not wanted, that's ok, I learned something in the process anyway.

Having made my apology: This PR adds a function, `LanguageClient#highlightSymbolUnderCursor` to highlight references of the symbol under the cursor. It also adds a trigger for `CursorHold` to fire this new function when the user hasn't moved the cursor for `updatetime`.
The feature can be turned off or on by setting the `LanguageClient_highlightSymbolUnderCursor` option, which is set to 1 by default.

The drawback of having this enabled is that it has to call `nvim_buf_clear_highlight` on each `CursorMoved` trigger, as to clear any possible highlighted references caused by this new feature.

<img src="https://user-images.githubusercontent.com/4250565/71771583-5a1f6300-2f35-11ea-8fdf-5f14765c0832.gif" width="350"/>
