### PR TITLE
Fix a race condition when setting diagnostic signs

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2516,49 +2516,47 @@ impl LanguageClient {
                 .map(|(line, severity)| Sign::new(line, format!("LanguageClient{:?}", severity)))
                 .collect())
         })?;
-        let signs_prev: Vec<_> = self.update(|state| {
-            Ok(state
+        self.update(|state| {
+            let signs_prev: Vec<_> = state
                 .signs
                 .entry(filename.clone())
                 .or_default()
                 .iter()
                 .map(|(_, sign)| sign.clone())
-                .collect())
-        })?;
-        let mut signs_to_add = vec![];
-        let mut signs_to_delete = vec![];
-        let diffs = diff::slice(&signs_next, &signs_prev);
-        for diff in diffs {
-            match diff {
-                diff::Result::Left(s) => {
-                    signs_to_add.push(s.clone());
+                .collect();
+            let mut signs_to_add = vec![];
+            let mut signs_to_delete = vec![];
+            let diffs = diff::slice(&signs_next, &signs_prev);
+            for diff in diffs {
+                match diff {
+                    diff::Result::Left(s) => {
+                        signs_to_add.push(s.clone());
+                    }
+                    diff::Result::Right(s) => {
+                        signs_to_delete.push(s.clone());
+                    }
+                    _ => {}
                 }
-                diff::Result::Right(s) => {
-                    signs_to_delete.push(s.clone());
-                }
-                _ => {}
             }
-        }
-        for sign in &mut signs_to_add {
-            if sign.id == 0 {
-                sign.id = self.update(|state| {
+            for sign in &mut signs_to_add {
+                if sign.id == 0 {
                     state.sign_next_id += 1;
-                    Ok(state.sign_next_id)
-                })?;
+                    sign.id = state.sign_next_id;
+                }
             }
-        }
-        self.vim()?
-            .set_signs(&filename, &signs_to_add, &signs_to_delete)?;
-        self.update(|state| {
+
             let signs = state.signs.entry(filename.clone()).or_default();
             // signs might be deleted AND added in the same line to change severity,
             // so deletions must be before additions
-            for sign in signs_to_delete {
+            for sign in &signs_to_delete {
                 signs.remove(&sign.line);
             }
-            for sign in signs_to_add {
-                signs.insert(sign.line, sign);
+            for sign in &signs_to_add {
+                signs.insert(sign.line, sign.clone());
             }
+            state
+                .vim
+                .set_signs(&filename, &signs_to_add, &signs_to_delete)?;
             Ok(())
         })?;
 


### PR DESCRIPTION
I believe that this will fix #927

I was seeing an issue where the gutter diagnostic signs would often stick around even after the errors had been cleared.

The issue was that our order of operations was to
1) Fetch the current state of signs
https://github.com/autozimu/LanguageClient-neovim/blob/90e49e587fc700c81cd21529e773b7f863dfc958/src/language_server_protocol.rs#L2519
2) Calculate the diff between old signs and new signs
https://github.com/autozimu/LanguageClient-neovim/blob/90e49e587fc700c81cd21529e773b7f863dfc958/src/language_server_protocol.rs#L2528-L2529
3) Send the signs diff to vim
https://github.com/autozimu/LanguageClient-neovim/blob/90e49e587fc700c81cd21529e773b7f863dfc958/src/language_server_protocol.rs#L2550-L2551
4) Apply the signs diff to the state
https://github.com/autozimu/LanguageClient-neovim/blob/90e49e587fc700c81cd21529e773b7f863dfc958/src/language_server_protocol.rs#L2552

The update is calculated from the state read in step 1, but only applied in step 4. And it's sent to vim in between. So if there are two threads that run as follows:
```
Thread A: 1---2---3---4
Thread B: --1---2---3---4
```
Thread B will calculate a diff that doesn't take into account the operations from Thread A. They will both send signs to vim, and both try to store their signs in the state. Vim stores those signs by ID, but the state stores them by line number. If two of these new signs have the same line number, only one of them will end up in the state, effectively leaking the other sign.

My fix is to move all of these steps into a single `self.update` block, so that it's all one atomic operation. Since we're reading and updating as a single transaction, it should be impossible to get into a bad state now.

This made the most sense to me, but I'm not sure if it's the right approach. Happy to refactor if there's a better way to fix it :)