### PR TITLE
Add g:LanguageClient_echoProjectRoot to docs

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -386,6 +386,14 @@ Maximum severity to show diagnostic messages.
 Default: "Hint"
 Valid options: "Error" | "Warning" | "Information" | "Hint"
 
+2.29 g:LanguageClient_echoProjectRoot  *g:LanguageClient_echoProjectRoot*
+
+Whether to echo messages in vim of the form: "Project root: /home/user/myproject" when
+the root of a project is detected using g:LanguageClient_rootMarkers.
+
+Default: 1 to display the messages
+Valid options: 1 | 0
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 


### PR DESCRIPTION
This commit adds the `g:LanguageClient_echoProjectRoot` to the docs. I've found this option by digging into the code. For me it's pretty annoying not to be able to disable it, as otherwise the "Project root" messages litter my vim console as I navigate from file to file.

Thanks for your work on this plugin! It's great - and for a moving target and something very new to nvim - very robust!