### PR TITLE
Add support for the proposed Semantic Highlighting Protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +380,7 @@ dependencies = [
  "jsonrpc-core 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lsp-types 0.60.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lsp-types 0.68.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -448,9 +453,10 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.60.0"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1014,6 +1020,7 @@ dependencies = [
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "b548a4ee81fccb95919d4e22cfea83c7693ebfd78f0495493178db20b3139da7"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
@@ -1057,7 +1064,7 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 "checksum log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "100052474df98158c0738a7d3f4249c99978490178b5f9f68cd835ac57adbd1b"
-"checksum lsp-types 0.60.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe3edefcd66dde1f7f1df706f46520a3c93adc5ca4bc5747da6621195e894efd"
+"checksum lsp-types 0.68.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19b79f72914b929daa263483134b8974962cdebc731593b11508afb7f9acec80"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
  "jsonrpc-core 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lsp-types 0.68.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lsp-types 0.70.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.68.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1064,7 +1064,7 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 "checksum log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "100052474df98158c0738a7d3f4249c99978490178b5f9f68cd835ac57adbd1b"
-"checksum lsp-types 0.68.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19b79f72914b929daa263483134b8974962cdebc731593b11508afb7f9acec80"
+"checksum lsp-types 0.70.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef197b24cb3f12fc3984667a505691fec9d683204ddff56f12b2d1940e09a988"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1"
 serde_json = "1"
 crossbeam = "0.7.3"
 jsonrpc-core = "12"
-lsp-types = "0.60"
+lsp-types = { version = "0.68.1", features = ["proposed"] }
 url = "2"
 pathdiff = "0"
 diff = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1"
 serde_json = "1"
 crossbeam = "0.7.3"
 jsonrpc-core = "12"
-lsp-types = { version = "0.68.1", features = ["proposed"] }
+lsp-types = { version = "0.70.0", features = ["proposed"] }
 url = "2"
 pathdiff = "0"
 diff = "0"

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1386,7 +1386,7 @@ function! LanguageClient_contextMenu() abort
     return LanguageClient_handleContextMenuItem(l:options[l:selection - 1])
 endfunction
 
-function! LanguageClient_semanticScopes(...) abort
+function! LanguageClient_showSemanticScopes(...) abort
     let l:params = get(a:000, 0, {})
     let l:Callback = get(a:000, 1, function('s:print_semantic_scopes'))
 
@@ -1420,8 +1420,11 @@ function! LanguageClient#showSemanticHighlightSymbols(...) abort
     return LanguageClient#Call('languageClient/showSemanticHighlightSymbols', l:params, l:Callback)
 endfunction
 
-function! LanguageClient_showCursorSemanticHighlightSymbols() abort
-    return LanguageClient#showSemanticHighlightSymbols({}, function('s:print_cursor_semantic_symbol'))
+function! LanguageClient_showCursorSemanticHighlightSymbols(...) abort
+    let l:params = get(a:000, 0, {})
+    let l:Callback = get(a:000, 1, function('s:print_cursor_semantic_symbol'))
+
+    return LanguageClient#showSemanticHighlightSymbols(l:params, l:Callback)
 endfunction
 
 function! s:print_cursor_semantic_symbol(response) abort

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1393,7 +1393,7 @@ function! LanguageClient_semanticScopes(...) abort
     return LanguageClient#Call('languageClient/semanticScopes', l:params, l:Callback)
 endfunction
 
-function! s:print_semantic_scopes(response)
+function! s:print_semantic_scopes(response) abort
     let l:scope_mappings = a:response.result
 
     let l:msg = ''

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -251,6 +251,16 @@ function! s:MatchDelete(ids) abort
     endfor
 endfunction
 
+function! s:ApplySemanticHighlights(bufnr, ns_id, clears, highlights) abort
+    for clear in a:clears
+        call nvim_buf_clear_namespace(a:bufnr, a:ns_id, clear.line_start, clear.line_end)
+    endfor
+
+    for hl in a:highlights
+        call nvim_buf_add_highlight(a:bufnr, a:ns_id, hl.group, hl.line, hl.character_start, hl.character_end)
+    endfor
+endfunction
+
 " Batch version of nvim_buf_add_highlight
 function! s:AddHighlights(source, highlights) abort
     for hl in a:highlights
@@ -1374,6 +1384,67 @@ function! LanguageClient_contextMenu() abort
     endif
 
     return LanguageClient_handleContextMenuItem(l:options[l:selection - 1])
+endfunction
+
+function! LanguageClient_semanticScopes(...) abort
+    let l:params = get(a:000, 0, {})
+    let l:Callback = get(a:000, 1, function('s:print_semantic_scopes'))
+
+    return LanguageClient#Call('languageClient/semanticScopes', l:params, l:Callback)
+endfunction
+
+function! s:print_semantic_scopes(response)
+    let l:scope_mappings = a:response.result
+
+    let l:msg = ''
+    for mapping in l:scope_mappings
+        let l:msg .= "Highlight Group:\n"
+        let l:msg .= ' ' . l:mapping.hl_group . "\n"
+
+        let l:msg .= "Semantic Scope:\n"
+        let l:spaces = ' '
+        for l:scope_name in l:mapping.scope
+            let l:msg .= l:spaces . l:scope_name . "\n"
+            let l:spaces .= ' '
+        endfor
+        let l:msg .= "\n"
+    endfor
+
+    echo l:msg
+endfunction
+
+function! LanguageClient#showSemanticHighlightSymbols(...) abort
+    let l:params = get(a:000, 0, {})
+    let l:Callback = get(a:000, 1, v:null)
+
+    return LanguageClient#Call('languageClient/showSemanticHighlightSymbols', l:params, l:Callback)
+endfunction
+
+function! LanguageClient_showCursorSemanticHighlightSymbols() abort
+    return LanguageClient#showSemanticHighlightSymbols({}, function('s:print_cursor_semantic_symbol'))
+endfunction
+
+function! s:print_cursor_semantic_symbol(response) abort
+    let l:symbols = a:response.result
+    let l:lines = []
+
+    for symbol in l:symbols
+        if l:symbol.line + 1 == line('.') &&
+                    \ symbol.character_start < col('.') &&
+                    \ col('.') <= symbol.character_end
+            let l:spaces = ''
+            for scope_name in l:symbol.scope
+                call add(l:lines, l:spaces . l:scope_name)
+                let l:spaces .= ' '
+            endfor
+        endif
+    endfor
+
+    if len(l:lines) > 0
+        call s:OpenHoverPreview('SemanticScopes', l:lines, 'text')
+    else
+        call s:Echowarn('No Symbol Under Cursor or No Semantic Highlighting')
+    endif
 endfunction
 
 function! LanguageClient#debugInfo(...) abort

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -400,6 +400,124 @@ the root of a project is detected using g:LanguageClient_rootMarkers.
 Default: 1 to display the messages
 Valid options: 1 | 0
 
+2.30 g:LanguageClient_semanticHighlightMaps   *g:LanguageClient_semanticHighlightMaps*
+
+String to list/map map. Defines the mapping of semantic highlighting "scopes" to
+highlight groups. This depends on the LSP server supporting the proposed
+semantic highlighting protocol, see:
+
+https://github.com/microsoft/language-server-protocol/issues/18
+https://github.com/microsoft/vscode-languageserver-node/issues/368
+
+
+Like |g:LanguageClient_serverCommands| this is a map where the keys are
+filetypes. However the value at each key can be either:
+
+1. A map of highlight group name (see |highlight-groups|) => list of strings:
+>
+    let g:LanguageClient_semanticHighlightMaps = {
+        \ 'java': {
+        \   "Function": ['entity.name.function.java', '**'],
+        \   "Type": ['entity.name.type.class.java', '**'],
+        \ }
+        \ }
+
+2. A list of maps from #1, this is to allow for multiple patterns for the same
+   highlight group.
+>
+    let g:LanguageClient_semanticHighlightMaps = {
+        \ 'java': [
+        \   {"Function": ['entity.name.function.java', '**']},
+        \   {"Type": ['entity.name.type.class.java', '**']},
+        \   {"Function": ['*', 'entity.name.function.java', '**']},
+        \   {"Type": ['*', 'entity.name.type.class.java', '**']},
+        \ ]
+        \ }
+
+The maps associate the highlight group with a semantic scope matching pattern.
+Any symbols that have a scope that matches the pattern will be highlighted
+wtih that highlight group.
+
+There are a fixed set of semantic scopes defined by the LSP server on startup.
+These can be viewed by calling |LanguageClient_semanticScopes| which will
+show all the semantic scopes and their currently mapped highlight group for
+the currently open buffer's filetype.
+>
+     call LanguageClient_semanticScopes()
+
+     == Output from eclipse.jdt.ls ==
+
+     Highlight Group:
+      None
+     Semantic Scope:
+      invalid.deprecated.java
+       meta.class.java
+        source.java
+
+     Highlight Group:
+      None
+     Semantic Scope:
+      variable.other.autoboxing.java
+       meta.method.body.java
+        meta.method.java
+         meta.class.body.java
+          meta.class.java
+           source.java
+
+     ...
+
+Like the patterns, the semantic scope is a list of strings. They are printed
+with increasing indent to make it easier to read. For example the first scope
+is:
+>
+     ['invalid.deprecated.java', 'meta.class.java', 'source.java']
+
+It is currently isn't mapped to any highlight group as indicated by the None.
+
+Often its more useful to find what semantic scope corresponds to a piece of
+text. This can be done by calling |LanguageClient_showCursorSemanticHighlightSymbols|
+while hovering over the text of interest.
+>
+     call LanguageClient_showCursorSemanticHighlightSymbols()
+
+In order for a pattern to match a semantic scope the lists must fully match
+in length and list items.
+>
+     ['x', 'y', 'z'] == ['x', 'y', 'z']
+
+To make this easier two special strings '*' and '**' were added:
+
+Any ('*'):
+When a '*' is present it can match any SINGLE string at that position.
+>
+     ['x', '*', 'z'] == ['x', 'y', 'z']
+     ['x', '*', 'z'] != ['x', 'abc', 'y', 'z']
+
+Glob ('**'):
+When a '**' is present at the beginning and/or the end of the list it matches
+an arbitrary number of strings in its place. Currently, putting '**' in the
+middle is not implemented.
+>
+     ['x', 'y', '**'] == ['x', 'y', 'z', '1', '2', '3']
+     ['**', '123', '**'] == ['x', 'y', 'z', '123', '1', '2', '3']
+     ['**', 'y', 'z'] != ['x', 'y', 'z', '1', '2', '3']
+
+
+Example configuration for eclipse.jdt.ls:
+>
+     let g:LanguageClient_semanticHighlightMaps = {}
+     let g:LanguageClient_semanticHighlightMaps['java'] = [
+                 \ {"JavaStaticMemberFunction": ['storage.modifier.static.java', 'entity.name.function.java', '**']},
+                 \ {"JavaMemberVariable": ['meta.definition.variable.java', 'meta.class.body.java', 'meta.class.java', '**']},
+                 \ {"Function": ['entity.name.function.java', '**']},
+                 \ {"Function": ['*', 'entity.name.function.java', '**']},
+                 \ {"Type": ['entity.name.type.class.java', '**']},
+                 \ {"Type": ['*', 'entity.name.type.class.java', '**']},
+                 \ ]
+
+     highlight! JavaStaticMemberFunction ctermfg=Green cterm=none guifg=Green gui=none
+     highlight! JavaMemberVariable ctermfg=White cterm=italic guifg=White gui=italic
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 
@@ -677,6 +795,18 @@ Call $cquery/vars.
 Signature: LanguageClient#java_classFileContents(...)
 
 Call java/classFileContents.
+
+*LanguageClient_semanticScopes*
+Signature: LanguageClient_semanticScopes(...)
+
+Get all Semantic Scopes and their associated highlight groups for the current
+filetype (filetype of the currently open buffer) and print them.
+
+*LanguageClient_showCursorSemanticHighlightSymbols*
+Signature: LanguageClient_showCursorSemanticHighlightSymbols()
+
+Get the Semantic Scope of the symbol currently under the cursor.
+The result gets displayed in a popup.
 
 *LanguageClient#explainErrorAtPoint*
 Signature: LanguageClient#explainErrorAtPoint(...)

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -411,19 +411,8 @@ https://github.com/microsoft/vscode-languageserver-node/issues/368
 
 
 Like |g:LanguageClient_serverCommands| this is a map where the keys are
-filetypes. However the value at each key can be either:
-
-1. A map of highlight group name (see |highlight-groups|) => list of strings:
->
-    let g:LanguageClient_semanticHighlightMaps = {
-        \ 'java': {
-        \   "Function": ['entity.name.function.java', '**'],
-        \   "Type": ['entity.name.type.class.java', '**'],
-        \ }
-        \ }
-
-2. A list of maps from #1, this is to allow for multiple patterns for the same
-   highlight group.
+filetypes. However in this case the values are a list of maps that map
+highlight group names (see |highlight-groups|) to a lists of strings.
 >
     let g:LanguageClient_semanticHighlightMaps = {
         \ 'java': [
@@ -436,14 +425,14 @@ filetypes. However the value at each key can be either:
 
 The maps associate the highlight group with a semantic scope matching pattern.
 Any symbols that have a scope that matches the pattern will be highlighted
-wtih that highlight group.
+with that highlight group.
 
 There are a fixed set of semantic scopes defined by the LSP server on startup.
-These can be viewed by calling |LanguageClient_semanticScopes| which will
+These can be viewed by calling |LanguageClient_showSemanticScopes| which will
 show all the semantic scopes and their currently mapped highlight group for
 the currently open buffer's filetype.
 >
-     call LanguageClient_semanticScopes()
+     call LanguageClient_showSemanticScopes()
 
      == Output from eclipse.jdt.ls ==
 
@@ -483,24 +472,24 @@ while hovering over the text of interest.
 In order for a pattern to match a semantic scope the lists must fully match
 in length and list items.
 >
-     ['x', 'y', 'z'] == ['x', 'y', 'z']
+     ['x', 'y', 'z'] matches ['x', 'y', 'z']
 
 To make this easier two special strings '*' and '**' were added:
 
 Any ('*'):
 When a '*' is present it can match any SINGLE string at that position.
 >
-     ['x', '*', 'z'] == ['x', 'y', 'z']
-     ['x', '*', 'z'] != ['x', 'abc', 'y', 'z']
+     ['x', '*', 'z'] matches ['x', 'y', 'z']
+     ['x', '*', 'z'] does not match ['x', 'abc', 'y', 'z']
 
 Glob ('**'):
 When a '**' is present at the beginning and/or the end of the list it matches
 an arbitrary number of strings in its place. Currently, putting '**' in the
 middle is not implemented.
 >
-     ['x', 'y', '**'] == ['x', 'y', 'z', '1', '2', '3']
-     ['**', '123', '**'] == ['x', 'y', 'z', '123', '1', '2', '3']
-     ['**', 'y', 'z'] != ['x', 'y', 'z', '1', '2', '3']
+     ['x', 'y', '**'] matches ['x', 'y', 'z', '1', '2', '3']
+     ['**', '123', '**'] matches ['x', 'y', 'z', '123', '1', '2', '3']
+     ['**', 'y', 'z'] does not match ['x', 'y', 'z', '1', '2', '3']
 
 
 Example configuration for eclipse.jdt.ls:
@@ -796,14 +785,14 @@ Signature: LanguageClient#java_classFileContents(...)
 
 Call java/classFileContents.
 
-*LanguageClient_semanticScopes*
-Signature: LanguageClient_semanticScopes(...)
+*LanguageClient_showSemanticScopes*
+Signature: LanguageClient_showSemanticScopes(...)
 
 Get all Semantic Scopes and their associated highlight groups for the current
 filetype (filetype of the currently open buffer) and print them.
 
 *LanguageClient_showCursorSemanticHighlightSymbols*
-Signature: LanguageClient_showCursorSemanticHighlightSymbols()
+Signature: LanguageClient_showCursorSemanticHighlightSymbols(...)
 
 Get the Semantic Scope of the symbol currently under the cursor.
 The result gets displayed in a popup.

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -411,22 +411,23 @@ https://github.com/microsoft/vscode-languageserver-node/issues/368
 
 
 Like |g:LanguageClient_serverCommands| this is a map where the keys are
-filetypes. However in this case the values are a list of maps that map
-highlight group names (see |highlight-groups|) to a lists of strings.
+filetypes. However each submap has |regexp| keys and highlight group names
+as values (see |highlight-groups|).
 >
     let g:LanguageClient_semanticHighlightMaps = {
-        \ 'java': [
-        \   {"Function": ['entity.name.function.java', '**']},
-        \   {"Type": ['entity.name.type.class.java', '**']},
-        \   {"Function": ['*', 'entity.name.function.java', '**']},
-        \   {"Type": ['*', 'entity.name.type.class.java', '**']},
-        \ ]
+        \ 'java': {
+        \   '^entity.name.function.java': 'Function',
+        \   '^entity.name.type.class.java': 'Type',
+        \   '^[^:]*entity.name.function.java': 'Function',
+        \   '^[^:]entity.name.type.class.java': 'Type'
+        \ }
         \ }
 
-The maps associate the highlight group with a semantic scope matching pattern.
-Any symbols that have a scope that matches the pattern will be highlighted
-with that highlight group. They will match in the order they are listed (first
-to last), the first matched pattern's highlight group will be used.
+The |regexp| in the keys will be used to match semantic scopes. Then any symbols
+that have a semantic scope that matches the key will be highlighted with the
+associated highlight group value. Currently there is no defined order if a
+semantic scope can match multiple keys, so it is recommended to make the keys
+more specific to only match the desired scope(s).
 
 There are a fixed set of semantic scopes defined by the LSP server on startup.
 These can be viewed by calling |LanguageClient_showSemanticScopes| which will
@@ -456,9 +457,8 @@ the currently open buffer's filetype.
 
      ...
 
-Like the patterns, the semantic scope is a list of strings. They are printed
-with increasing indent to make it easier to read. For example the first scope
-is:
+Each semantic scope is a list of strings. They are printed with increasing
+indent to make it easier to read. For example the first scope is:
 >
      ['invalid.deprecated.java', 'meta.class.java', 'source.java']
 
@@ -470,40 +470,32 @@ while hovering over the text of interest.
 >
      call LanguageClient_showCursorSemanticHighlightSymbols()
 
-In order for a pattern to match a semantic scope the lists must fully match
-in length and list items.
+When matching the semantic scopes to keys in |LanguageClient_semanticHighlightMaps|,
+the scopes are concatentated using |LanguageClient_semanticScopeSeparator|
+which is set to the string |':'| by default. For the previous example the
+semantic scope would have this string form using the default separator:
 >
-     ['x', 'y', 'z'] matches ['x', 'y', 'z']
+     invalid.deprecated.java:meta.class.java:source.java
 
-To make this easier two special strings '*' and '**' were added:
-
-Any ('*'):
-When a '*' is present it can match any SINGLE string at that position.
+Here are a couple of example |regexp| keys that can/cannot match this scope:
 >
-     ['x', '*', 'z'] matches ['x', 'y', 'z']
-     ['x', '*', 'z'] does not match ['x', 'abc', 'y', 'z']
-
-Glob ('**'):
-When a '**' is present at the beginning and/or the end of the list it matches
-an arbitrary number of strings in its place. Currently, putting '**' in the
-middle is not implemented.
->
-     ['x', 'y', '**'] matches ['x', 'y', 'z', '1', '2', '3']
-     ['**', '123', '**'] matches ['x', 'y', 'z', '123', '1', '2', '3']
-     ['**', 'y', 'z'] does not match ['x', 'y', 'z', '1', '2', '3']
-
+     'meta.class.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
+     '^meta.class.java' !~ 'invalid.deprecated.java:meta.class.java:source.java'
+     '^invalid.deprecated.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
+     'source.java$' =~ 'invalid.deprecated.java:meta.class.java:source.java'
+     'meta.class.java:source.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
+     'invalid.deprecated.java:.*:source.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
 
 Example configuration for eclipse.jdt.ls:
 >
      let g:LanguageClient_semanticHighlightMaps = {}
-     let g:LanguageClient_semanticHighlightMaps['java'] = [
-                 \ {"JavaStaticMemberFunction": ['storage.modifier.static.java', 'entity.name.function.java', '**']},
-                 \ {"JavaMemberVariable": ['meta.definition.variable.java', 'meta.class.body.java', 'meta.class.java', '**']},
-                 \ {"Function": ['entity.name.function.java', '**']},
-                 \ {"Function": ['**', 'entity.name.function.java', '**']},
-                 \ {"Type": ['entity.name.type.class.java', '**']},
-                 \ {"Type": ['**', 'entity.name.type.class.java', '**']},
-                 \ ]
+     let g:LanguageClient_semanticHighlightMaps['java'] = {
+       \ '^storage.modifier.static.java:entity.name.function.java': 'JavaStaticMemberFunction',
+       \ '^meta.definition.variable.java:meta.class.body.java:meta.class.java': 'JavaMemberVariable',
+       \ '^entity.name.function.java': 'Function',
+       \ '^[^:]*entity.name.function.java': 'Function',
+       \ '^[^:]*entity.name.type.class.java': 'Type',
+       \ }
 
      highlight! JavaStaticMemberFunction ctermfg=Green cterm=none guifg=Green gui=none
      highlight! JavaMemberVariable ctermfg=White cterm=italic guifg=White gui=italic

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -425,7 +425,8 @@ highlight group names (see |highlight-groups|) to a lists of strings.
 
 The maps associate the highlight group with a semantic scope matching pattern.
 Any symbols that have a scope that matches the pattern will be highlighted
-with that highlight group.
+with that highlight group. They will match in the order they are listed (first
+to last), the first matched pattern's highlight group will be used.
 
 There are a fixed set of semantic scopes defined by the LSP server on startup.
 These can be viewed by calling |LanguageClient_showSemanticScopes| which will

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -499,9 +499,9 @@ Example configuration for eclipse.jdt.ls:
                  \ {"JavaStaticMemberFunction": ['storage.modifier.static.java', 'entity.name.function.java', '**']},
                  \ {"JavaMemberVariable": ['meta.definition.variable.java', 'meta.class.body.java', 'meta.class.java', '**']},
                  \ {"Function": ['entity.name.function.java', '**']},
-                 \ {"Function": ['*', 'entity.name.function.java', '**']},
+                 \ {"Function": ['**', 'entity.name.function.java', '**']},
                  \ {"Type": ['entity.name.type.class.java', '**']},
-                 \ {"Type": ['*', 'entity.name.type.class.java', '**']},
+                 \ {"Type": ['**', 'entity.name.type.class.java', '**']},
                  \ ]
 
      highlight! JavaStaticMemberFunction ctermfg=Green cterm=none guifg=Green gui=none

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -2,6 +2,10 @@ if !exists('g:LanguageClient_serverCommands')
     let g:LanguageClient_serverCommands = {}
 endif
 
+if !exists('g:LanguageClient_semanticHighlightMaps')
+    let g:LanguageClient_semanticHighlightMaps = {}
+endif
+
 function! LanguageClient_textDocument_hover(...)
     return call('LanguageClient#textDocument_hover', a:000)
 endfunction

--- a/src/language_client.rs
+++ b/src/language_client.rs
@@ -3,6 +3,7 @@ use crate::vim::Vim;
 use std::ops::DerefMut;
 
 pub struct LanguageClient {
+    pub version: Arc<String>,
     pub state_mutex: Arc<Mutex<State>>,
     pub clients_mutex: Arc<Mutex<HashMap<LanguageId, Arc<Mutex<()>>>>>,
 }

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -218,37 +218,37 @@ impl LanguageClient {
             let mut mapping_pairs = Vec::new();
             match v {
                 Value::Object(mapping) => {
-                    mapping_pairs.extend(
-                        mapping.into_iter()
-                            .map(|(hl_group, val)| (val, hl_group))
-                    );
-                },
+                    mapping_pairs
+                        .extend(mapping.into_iter().map(|(hl_group, val)| (val, hl_group)));
+                }
                 Value::Array(values) => {
                     for (idx, v2) in values.into_iter().enumerate() {
                         match v2 {
                             Value::Object(mapping) => {
                                 mapping_pairs.extend(
-                                    mapping.into_iter()
-                                        .map(|(hl_group, val)| (val, hl_group))
+                                    mapping.into_iter().map(|(hl_group, val)| (val, hl_group)),
                                 );
-                            },
+                            }
                             _ => {
                                 error!("Invalid SemanticHighlightMap for language ({}) at index ({}): {}",
                                     languageId, idx, v2);
                             }
                         }
                     }
-                },
+                }
                 _ => {
-                    error!("Invalid SemanticHighlightMap for language ({}): {}",
-                        languageId, v);
+                    error!(
+                        "Invalid SemanticHighlightMap for language ({}): {}",
+                        languageId, v
+                    );
                 }
             }
 
             semanticHighlightMaps.insert(languageId, mapping_pairs);
         }
 
-        let semanticHlUpdateLanguageIds : Vec<String> = semanticHighlightMaps.keys().cloned().collect();
+        let semanticHlUpdateLanguageIds: Vec<String> =
+            semanticHighlightMaps.keys().cloned().collect();
 
         self.update(|state| {
             state.autoStart = autoStart;
@@ -879,7 +879,9 @@ impl LanguageClient {
 
         if let Some(capability) = result.capabilities.semantic_highlighting {
             self.update(|state| {
-                state.semantic_scopes.insert(languageId.into(), capability.scopes.unwrap_or_default());
+                state
+                    .semantic_scopes
+                    .insert(languageId.into(), capability.scopes.unwrap_or_default());
                 Ok(())
             })?;
         }
@@ -888,7 +890,10 @@ impl LanguageClient {
         Ok(())
     }
 
-    fn buildSemanticHighlightMatchers(all_scope_names: HashSet<String>, user_mapping: &[(Value, String)]) -> Vec<(SemanticHighlightMatcher, String)> {
+    fn buildSemanticHighlightMatchers(
+        all_scope_names: HashSet<String>,
+        user_mapping: &[(Value, String)],
+    ) -> Vec<(SemanticHighlightMatcher, String)> {
         let mut highlight_mappings = Vec::new();
 
         for (mapping_type, highlight_group) in user_mapping.iter() {
@@ -905,10 +910,12 @@ impl LanguageClient {
                                     warn!("Invalid Semantic Highlight Scope: {}", s);
                                     break;
                                 }
-                            },
+                            }
                             _ => {
-                                warn!("Invalid Semantic Highlighting Mapping: {} -> {}",
-                                    highlight_group, mapping_type);
+                                warn!(
+                                    "Invalid Semantic Highlighting Mapping: {} -> {}",
+                                    highlight_group, mapping_type
+                                );
                                 break;
                             }
                         }
@@ -916,39 +923,44 @@ impl LanguageClient {
 
                     if scopes.len() == arr.len() {
                         highlight_mappings.push((
-                                match (scopes.first().map(|s| &s[..]), scopes.last().map(|s| &s[..])) {
-                                    (Some("**"), Some("**")) => {
-                                        scopes.pop();
-                                        scopes.remove(0);
-                                        SemanticHighlightMatcher::ArrayContains(scopes)
-                                    },
-                                    (_, Some("**")) => {
-                                        scopes.pop();
-                                        SemanticHighlightMatcher::ArrayStart(scopes)
-                                    },
-                                    (Some("**"), _) => {
-                                        scopes.remove(0);
-                                        SemanticHighlightMatcher::ArrayEnd(scopes)
-                                    },
-                                    (_, _) => SemanticHighlightMatcher::Array(scopes)
-                                },
-                                highlight_group.clone()
+                            match (
+                                scopes.first().map(|s| &s[..]),
+                                scopes.last().map(|s| &s[..]),
+                            ) {
+                                (Some("**"), Some("**")) => {
+                                    scopes.pop();
+                                    scopes.remove(0);
+                                    SemanticHighlightMatcher::ArrayContains(scopes)
+                                }
+                                (_, Some("**")) => {
+                                    scopes.pop();
+                                    SemanticHighlightMatcher::ArrayStart(scopes)
+                                }
+                                (Some("**"), _) => {
+                                    scopes.remove(0);
+                                    SemanticHighlightMatcher::ArrayEnd(scopes)
+                                }
+                                (_, _) => SemanticHighlightMatcher::Array(scopes),
+                            },
+                            highlight_group.clone(),
                         ));
                     }
-                },
+                }
                 Value::String(s) => {
                     if all_scope_names.contains(s) {
                         highlight_mappings.push((
-                                SemanticHighlightMatcher::Str(s.clone()),
-                                highlight_group.clone()
+                            SemanticHighlightMatcher::Str(s.clone()),
+                            highlight_group.clone(),
                         ));
                     } else {
                         warn!("Invalid Semantic Highlight Scope: {}", s);
                     }
-                },
+                }
                 _ => {
-                    warn!("Invalid Semantic Highlighting Mapping: {} -> {}",
-                        highlight_group, mapping_type);
+                    warn!(
+                        "Invalid Semantic Highlighting Mapping: {} -> {}",
+                        highlight_group, mapping_type
+                    );
                 }
             }
         }
@@ -961,9 +973,12 @@ impl LanguageClient {
     /// ScopeIndex -> Option<HighlightGroup>
     fn updateSemanticHighlightTables(&self, languageId: &str) -> Fallible<()> {
         info!("Begin updateSemanticHighlightTables");
-        let (opt_scopes, opt_hl_map) = self.get(|state|
-            (state.semantic_scopes.get(languageId).cloned(), state.semanticHighlightMaps.get(languageId).cloned())
-        )?;
+        let (opt_scopes, opt_hl_map) = self.get(|state| {
+            (
+                state.semantic_scopes.get(languageId).cloned(),
+                state.semanticHighlightMaps.get(languageId).cloned(),
+            )
+        })?;
 
         if let (Some(semantic_scopes), Some(semanticHighlightMap)) = (opt_scopes, opt_hl_map) {
             let mut all_scope_names = HashSet::new();
@@ -975,21 +990,26 @@ impl LanguageClient {
                 });
             });
 
-            let matchers = Self::buildSemanticHighlightMatchers(
-                all_scope_names, &semanticHighlightMap);
+            let matchers =
+                Self::buildSemanticHighlightMatchers(all_scope_names, &semanticHighlightMap);
 
-            let table: Vec<Option<String>> = semantic_scopes.iter()
+            let table: Vec<Option<String>> = semantic_scopes
+                .iter()
                 .map(|scope_arr| {
-                    matchers.iter()
-                        .find_map(|(matcher, hl_group)| {
-                            if matcher.matches(scope_arr) { Some(hl_group.clone()) }
-                            else { None }
-                        })
+                    matchers.iter().find_map(|(matcher, hl_group)| {
+                        if matcher.matches(scope_arr) {
+                            Some(hl_group.clone())
+                        } else {
+                            None
+                        }
+                    })
                 })
                 .collect();
 
             self.update(|state| {
-                state.semantic_scope_to_hl_group_table.insert(languageId.into(), table);
+                state
+                    .semantic_scope_to_hl_group_table
+                    .insert(languageId.into(), table);
                 Ok(())
             })?;
         } else {
@@ -1240,9 +1260,11 @@ impl LanguageClient {
                         code_lens: Some(GenericCapability {
                             dynamic_registration: Some(true),
                         }),
-                        semantic_highlighting_capabilities: Some(SemanticHighlightingClientCapability {
-                            semantic_highlighting: true
-                        }),
+                        semantic_highlighting_capabilities: Some(
+                            SemanticHighlightingClientCapability {
+                                semantic_highlighting: true,
+                            },
+                        ),
                         ..TextDocumentClientCapabilities::default()
                     }),
                     workspace: Some(WorkspaceClientCapabilities {
@@ -1988,7 +2010,7 @@ impl LanguageClient {
             ExecuteCommandParams {
                 command,
                 arguments,
-                work_done_progress_params: WorkDoneProgressParams::default()
+                work_done_progress_params: WorkDoneProgressParams::default(),
             },
         )?;
         info!("End {}", lsp::request::ExecuteCommand::METHOD);
@@ -2088,7 +2110,7 @@ impl LanguageClient {
                         uri: filename.to_url()?,
                     },
                     work_done_progress_params: WorkDoneProgressParams::default(),
-                    partial_result_params: PartialResultParams::default()
+                    partial_result_params: PartialResultParams::default(),
                 };
 
                 let results: Value = client.call(lsp::request::CodeLensRequest::METHOD, &input)?;
@@ -2343,7 +2365,12 @@ impl LanguageClient {
         let mut params: SemanticHighlightingParams = params.clone().to_lsp()?;
 
         // TODO: Do we need to handle the versioning of the file?
-        let mut filename = params.text_document.uri.filepath()?.to_string_lossy().into_owned();
+        let mut filename = params
+            .text_document
+            .uri
+            .filepath()?
+            .to_string_lossy()
+            .into_owned();
         // Workaround bug: remove first '/' in case of '/C:/blabla'.
         if filename.chars().nth(0) == Some('/') && filename.chars().nth(2) == Some(':') {
             filename.remove(0);
@@ -2352,7 +2379,12 @@ impl LanguageClient {
         let filename = filename.canonicalize();
         let languageId = self.vim()?.get_languageId(&filename, &Value::Null)?;
 
-        let opt_hl_table = self.get(|state| state.semantic_scope_to_hl_group_table.get(&languageId).cloned())?;
+        let opt_hl_table = self.get(|state| {
+            state
+                .semantic_scope_to_hl_group_table
+                .get(&languageId)
+                .cloned()
+        })?;
 
         // Sort lines in ascending order
         params.lines.sort_by(|a, b| a.line.cmp(&b.line));
@@ -2363,12 +2395,15 @@ impl LanguageClient {
             let buffer = self.vim()?.get_bufnr(&filename, &Value::Null)?;
 
             if buffer == -1 {
-                error!("Received Semantic Highlighting for non-open buffer: {}", filename);
+                error!(
+                    "Received Semantic Highlighting for non-open buffer: {}",
+                    filename
+                );
                 return Ok(());
             }
 
             let mut highlights = Vec::new();
-            let mut clears : Vec<ClearNamespace> = Vec::new();
+            let mut clears: Vec<ClearNamespace> = Vec::new();
 
             for line in &params.lines {
                 if line.line < 0 {
@@ -2407,7 +2442,7 @@ impl LanguageClient {
                                     line_end: line.line as u64 + 1,
                                 });
                             }
-                        },
+                        }
                         None => {
                             clears.push(ClearNamespace {
                                 line_start: line.line as u64,
@@ -2422,15 +2457,17 @@ impl LanguageClient {
             let num_new_semantic_hls = highlights.len();
 
             self.update(|state| {
-                state.semantic_highlights_syms.insert(languageId.clone(), params.lines);
+                state
+                    .semantic_highlights_syms
+                    .insert(languageId.clone(), params.lines);
 
                 state.vim.rpcclient.notify(
                     "s:ApplySemanticHighlights",
-                    json!([buffer, ns_id, clears, highlights])
+                    json!([buffer, ns_id, clears, highlights]),
                 )?;
 
-
-                let mut old_semantic_hls = state.semantic_highlights
+                let mut old_semantic_hls = state
+                    .semantic_highlights
                     .insert(languageId.clone(), Vec::new())
                     .unwrap_or_default();
 
@@ -2453,9 +2490,13 @@ impl LanguageClient {
                             use std::cmp::Ordering;
 
                             match existing_hl.line.cmp(&new_hl.line) {
-                                Ordering::Less => { semantic_hls.push(existing_hls.next().expect("unreachable")); },
-                                Ordering::Greater => { semantic_hls.push(new_hls.next().expect("unreachable")); },
-                                Ordering::Equal => { 
+                                Ordering::Less => {
+                                    semantic_hls.push(existing_hls.next().expect("unreachable"));
+                                }
+                                Ordering::Greater => {
+                                    semantic_hls.push(new_hls.next().expect("unreachable"));
+                                }
+                                Ordering::Equal => {
                                     // existing highlight on same line as new, it gets cleared
                                     existing_hls.next();
                                 }
@@ -2478,11 +2519,15 @@ impl LanguageClient {
                 Ok(())
             })?;
 
-            info!("Applied Semantic Highlighting for {} Symbols ({} new)",
-                num_semantic_hls, num_new_semantic_hls)
+            info!(
+                "Applied Semantic Highlighting for {} Symbols ({} new)",
+                num_semantic_hls, num_new_semantic_hls
+            )
         } else {
             self.update(|state| {
-                state.semantic_highlights_syms.insert(languageId.clone(), params.lines);
+                state
+                    .semantic_highlights_syms
+                    .insert(languageId.clone(), params.lines);
                 Ok(())
             })?;
         }
@@ -3239,10 +3284,20 @@ impl LanguageClient {
         let filename = self.vim()?.get_filename(params)?;
         let languageId = self.vim()?.get_languageId(&filename, params)?;
 
-        let (scopes, mut scope_mapping) = self.get(|state| (
-                state.semantic_scopes.get(&languageId).cloned().unwrap_or_default(),
-                state.semantic_scope_to_hl_group_table.get(&languageId).cloned().unwrap_or_default()
-        ))?;
+        let (scopes, mut scope_mapping) = self.get(|state| {
+            (
+                state
+                    .semantic_scopes
+                    .get(&languageId)
+                    .cloned()
+                    .unwrap_or_default(),
+                state
+                    .semantic_scope_to_hl_group_table
+                    .get(&languageId)
+                    .cloned()
+                    .unwrap_or_default(),
+            )
+        })?;
 
         let mut semantic_scopes = Vec::new();
 
@@ -3272,9 +3327,12 @@ impl LanguageClient {
         let filename = self.vim()?.get_filename(params)?;
         let languageId = self.vim()?.get_languageId(&filename, params)?;
 
-        let (opt_scopes, opt_syms) = self.get(|state|
-            (state.semantic_scopes.get(&languageId).cloned(), state.semantic_highlights_syms.get(&languageId).cloned())
-        )?;
+        let (opt_scopes, opt_syms) = self.get(|state| {
+            (
+                state.semantic_scopes.get(&languageId).cloned(),
+                state.semantic_highlights_syms.get(&languageId).cloned(),
+            )
+        })?;
 
         if let (Some(scopes), Some(syms)) = (opt_scopes, opt_syms) {
             let mut symbols = Vec::new();

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -870,53 +870,6 @@ impl LanguageClient {
         Ok(())
     }
 
-    fn buildSemanticHighlightMatchers(
-        all_scope_names: HashSet<String>,
-        user_mapping: &[(Vec<String>, String)],
-    ) -> Vec<(SemanticHighlightMatcher, String)> {
-        let mut highlight_mappings = Vec::new();
-
-        for (scope_arr, highlight_group) in user_mapping {
-            let mut scopes = Vec::new();
-
-            for s in scope_arr {
-                if all_scope_names.contains(s) {
-                    scopes.push(s.clone());
-                } else {
-                    warn!("Invalid Semantic Highlight Scope: {}", s);
-                    break;
-                }
-            }
-
-            if scopes.len() == scope_arr.len() {
-                highlight_mappings.push((
-                    match (
-                        scopes.first().map(|s| &s[..]),
-                        scopes.last().map(|s| &s[..]),
-                    ) {
-                        (Some("**"), Some("**")) => {
-                            scopes.pop();
-                            scopes.remove(0);
-                            SemanticHighlightMatcher::ArrayContains(scopes)
-                        }
-                        (_, Some("**")) => {
-                            scopes.pop();
-                            SemanticHighlightMatcher::ArrayStart(scopes)
-                        }
-                        (Some("**"), _) => {
-                            scopes.remove(0);
-                            SemanticHighlightMatcher::ArrayEnd(scopes)
-                        }
-                        (_, _) => SemanticHighlightMatcher::Array(scopes),
-                    },
-                    highlight_group.clone(),
-                ));
-            }
-        }
-
-        highlight_mappings
-    }
-
     /// Build the Semantic Highlight Lookup Table of
     ///
     /// ScopeIndex -> Option<HighlightGroup>
@@ -939,8 +892,7 @@ impl LanguageClient {
                 });
             });
 
-            let matchers =
-                Self::buildSemanticHighlightMatchers(all_scope_names, &semanticHighlightMap);
+            let matchers = buildSemanticHighlightMatchers(all_scope_names, &semanticHighlightMap);
 
             let table: Vec<Option<String>> = semantic_scopes
                 .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn main() -> Fallible<()> {
 
     let (tx, rx) = crossbeam::channel::unbounded();
     let language_client = language_client::LanguageClient {
+        version: Arc::new(version),
         state_mutex: Arc::new(Mutex::new(State::new(tx)?)),
         clients_mutex: Arc::new(Mutex::new(HashMap::new())),
     };

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -100,6 +100,8 @@ impl LanguageClient {
             REQUEST__ClassFileContents => self.java_classFileContents(&params),
             REQUEST__DebugInfo => self.debug_info(&params),
             REQUEST__CodeLensAction => self.languageClient_handleCodeLensAction(&params),
+            REQUEST__SemanticScopes => self.languageClient_semanticScopes(&params),
+            REQUEST__ShowSemanticHighlightSymbols => self.languageClient_semanticHlSyms(&params),
 
             _ => {
                 let languageId_target = if languageId.is_some() {
@@ -155,6 +157,9 @@ impl LanguageClient {
             }
             lsp::notification::PublishDiagnostics::METHOD => {
                 self.textDocument_publishDiagnostics(&params)?
+            }
+            lsp::notification::SemanticHighlighting::METHOD => {
+                self.textDocument_semanticHighlight(&params)?
             }
             lsp::notification::LogMessage::METHOD => self.window_logMessage(&params)?,
             lsp::notification::ShowMessage::METHOD => self.window_showMessage(&params)?,

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,7 +157,8 @@ pub struct State {
 
     // User settings.
     pub serverCommands: HashMap<String, Vec<String>>,
-    pub semanticHighlightMaps: HashMap<String, Vec<(Value, String)>>,
+    // languageId => (scope1 => hlgroup1, scope2 => hlgroup2, ...)
+    pub semanticHighlightMaps: HashMap<String, Vec<(Vec<String>, String)>>,
     pub autoStart: bool,
     pub selectionUI: SelectionUI,
     pub selectionUI_autoOpen: bool,
@@ -475,8 +476,6 @@ pub struct ClearNamespace {
 /// Helper type for semantic highlighting
 #[derive(Debug)]
 pub enum SemanticHighlightMatcher {
-    /// Check if the array contains the string
-    Str(String),
     /// Checks that the entire array matches (same length)
     Array(Vec<String>),
     /// Checks that the array starts with this
@@ -492,7 +491,6 @@ impl SemanticHighlightMatcher {
         use SemanticHighlightMatcher::*;
 
         match self {
-            Str(s) => scope_arr.contains(s),
             Array(match_arr) => Self::slices_match(match_arr, scope_arr),
             ArrayStart(match_arr) => {
                 if scope_arr.len() >= match_arr.len() {
@@ -540,21 +538,6 @@ impl SemanticHighlightMatcher {
             false
         }
     }
-}
-
-#[test]
-fn test_semantic_hl_matcher_str() {
-    let matcher = SemanticHighlightMatcher::Str("Hello".into());
-
-    assert!(matcher.matches(&vec!["Hello".into()]));
-    assert!(matcher.matches(&vec![
-        "X".into(),
-        "HELLO".into(),
-        "Hello".into(),
-        "ABCD".into()
-    ]));
-    assert!(matcher.matches(&vec!["Hello".into(), "ABCD".into(), "X".into()]));
-    assert!(!matcher.matches(&vec!["ABCD".into(), "X".into()]));
 }
 
 #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,7 +34,8 @@ pub const REQUEST__FindLocations: &str = "languageClient/findLocations";
 pub const REQUEST__DebugInfo: &str = "languageClient/debugInfo";
 pub const REQUEST__CodeLensAction: &str = "LanguageClient/handleCodeLensAction";
 pub const REQUEST__SemanticScopes: &str = "languageClient/semanticScopes";
-pub const REQUEST__ShowSemanticHighlightSymbols: &str = "languageClient/showSemanticHighlightSymbols";
+pub const REQUEST__ShowSemanticHighlightSymbols: &str =
+    "languageClient/showSemanticHighlightSymbols";
 pub const NOTIFICATION__HandleBufNewFile: &str = "languageClient/handleBufNewFile";
 pub const NOTIFICATION__HandleFileType: &str = "languageClient/handleFileType";
 pub const NOTIFICATION__HandleTextChanged: &str = "languageClient/handleTextChanged";
@@ -499,18 +500,21 @@ impl SemanticHighlightMatcher {
                 } else {
                     false
                 }
-            },
+            }
             ArrayEnd(match_arr) => {
                 if scope_arr.len() >= match_arr.len() {
                     Self::slices_match(match_arr, &scope_arr[scope_arr.len() - match_arr.len()..])
                 } else {
                     false
                 }
-            },
+            }
             ArrayContains(match_arr) => {
                 if scope_arr.len() >= match_arr.len() {
                     for offset in 0..=(scope_arr.len() - match_arr.len()) {
-                        if Self::slices_match(match_arr, &scope_arr[offset..offset + match_arr.len()]) {
+                        if Self::slices_match(
+                            match_arr,
+                            &scope_arr[offset..offset + match_arr.len()],
+                        ) {
                             return true;
                         }
                     }
@@ -543,7 +547,12 @@ fn test_semantic_hl_matcher_str() {
     let matcher = SemanticHighlightMatcher::Str("Hello".into());
 
     assert!(matcher.matches(&vec!["Hello".into()]));
-    assert!(matcher.matches(&vec!["X".into(), "HELLO".into(), "Hello".into(), "ABCD".into()]));
+    assert!(matcher.matches(&vec![
+        "X".into(),
+        "HELLO".into(),
+        "Hello".into(),
+        "ABCD".into()
+    ]));
     assert!(matcher.matches(&vec!["Hello".into(), "ABCD".into(), "X".into()]));
     assert!(!matcher.matches(&vec!["ABCD".into(), "X".into()]));
 }
@@ -562,7 +571,12 @@ fn test_semantic_hl_matcher_array() {
     let t4 = vec!["A".into(), "B".into(), "CC".into(), "D".into()];
 
     let do_matches = |v: &[String]| -> (bool, bool, bool, bool) {
-        (arr.matches(v), arr_s.matches(v), arr_e.matches(v), arr_c.matches(v))
+        (
+            arr.matches(v),
+            arr_s.matches(v),
+            arr_e.matches(v),
+            arr_c.matches(v),
+        )
     };
 
     assert_eq!(do_matches(&t1), (true, true, true, true));
@@ -585,7 +599,12 @@ fn test_semantic_hl_matcher_array_glob() {
     let t4 = vec!["A".into(), "B".into(), "CC".into(), "D".into()];
 
     let do_matches = |v: &[String]| -> (bool, bool, bool, bool) {
-        (arr.matches(v), arr_s.matches(v), arr_e.matches(v), arr_c.matches(v))
+        (
+            arr.matches(v),
+            arr_s.matches(v),
+            arr_e.matches(v),
+            arr_c.matches(v),
+        )
     };
 
     assert_eq!(do_matches(&t1), (true, true, true, true));

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,9 +125,8 @@ pub struct State {
     pub text_documents_metadata: HashMap<String, TextDocumentItemMetadata>,
     pub semantic_scopes: HashMap<String, Vec<Vec<String>>>,
     pub semantic_scope_to_hl_group_table: HashMap<String, Vec<Option<String>>>,
-    // filename => semantic highlights.
-    pub semantic_highlights_syms: HashMap<String, Vec<SemanticHighlightingInformation>>,
-    pub semantic_highlights: HashMap<String, Vec<Highlight>>,
+    // filename => semantic highlight state
+    pub semantic_highlights: HashMap<String, TextDocumentSemanticHighlightState>,
     // filename => diagnostics.
     pub diagnostics: HashMap<String, Vec<Diagnostic>>,
     // filename => codeLens.
@@ -216,7 +215,6 @@ impl State {
             text_documents_metadata: HashMap::new(),
             semantic_scopes: HashMap::new(),
             semantic_scope_to_hl_group_table: HashMap::new(),
-            semantic_highlights_syms: HashMap::new(),
             semantic_highlights: HashMap::new(),
             code_lens: HashMap::new(),
             diagnostics: HashMap::new(),
@@ -449,6 +447,13 @@ impl DocumentHighlightDisplay {
         );
         map
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextDocumentSemanticHighlightState {
+    pub last_version: Option<i64>,
+    pub symbols: Vec<SemanticHighlightingInformation>,
+    pub highlights: Option<Vec<Highlight>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -465,121 +465,38 @@ pub fn decode_parameterLabel(
     }
 }
 
-pub fn buildSemanticHighlightMatchers(
-    all_scope_names: HashSet<String>,
-    user_mapping: &[(Vec<String>, String)],
-) -> Vec<(SemanticHighlightMatcher, String)> {
-    let mut highlight_mappings = Vec::new();
+/// Given a string, convert it into a string for vimscript
+/// The string gets surrounded by single quotes.
+///
+/// Existing single quotes will get escaped by inserting
+/// another single quote in place.
+///
+/// E.g.
+/// abcdefg -> 'abcdefg'
+/// abdcef'g -> 'abcdef''g'
+pub fn convert_to_vim_str(s: &str) -> String {
+    let mut vs = String::with_capacity(s.len());
 
-    for (scope_arr, highlight_group) in user_mapping {
-        let mut scopes = Vec::new();
+    vs.push('\'');
 
-        for s in scope_arr {
-            if all_scope_names.contains(s) {
-                scopes.push(s.clone());
-            } else {
-                warn!("Invalid Semantic Highlight Scope: {}", s);
-                break;
-            }
+    for i in s.chars() {
+        if i == '\'' {
+            vs.push(i);
         }
 
-        if scopes.len() == scope_arr.len() {
-            highlight_mappings.push((
-                match (
-                    scopes.first().map(|s| &s[..]),
-                    scopes.last().map(|s| &s[..]),
-                ) {
-                    (Some("**"), Some("**")) => {
-                        scopes.pop();
-                        scopes.remove(0);
-                        SemanticHighlightMatcher::ArrayContains(scopes)
-                    }
-                    (_, Some("**")) => {
-                        scopes.pop();
-                        SemanticHighlightMatcher::ArrayStart(scopes)
-                    }
-                    (Some("**"), _) => {
-                        scopes.remove(0);
-                        SemanticHighlightMatcher::ArrayEnd(scopes)
-                    }
-                    (_, _) => SemanticHighlightMatcher::Array(scopes),
-                },
-                highlight_group.clone(),
-            ));
-        }
+        vs.push(i);
     }
 
-    highlight_mappings
+    vs.push('\'');
+
+    vs
 }
 
 #[test]
-fn test_buildMatchers() {
-    let all_scope_names = ["**", "*", "X", "Y", "Z"]
-        .into_iter()
-        .map(|s| (*s).into())
-        .collect();
-
-    let mappings: Vec<_> = [
-        (vec!["X", "Y", "Z"], "HL1"),
-        (vec!["X", "*", "Z"], "HL2"),
-        (vec!["X", "*", "Z", "**"], "HL3"),
-        (vec!["**", "X", "*", "Z"], "HL4"),
-        (vec!["**", "X", "*", "Z", "**"], "HL5"),
-    ]
-    .into_iter()
-    .map(|(v, hl)| (v.into_iter().map(|s| (*s).into()).collect(), (*hl).into()))
-    .collect();
-
-    let matchers = buildSemanticHighlightMatchers(all_scope_names, &mappings);
-
-    let mut it = matchers.iter();
-    match it.next().map(|(m, hl)| (m, &hl[..])) {
-        Some((SemanticHighlightMatcher::Array(arr), "HL1")) => {
-            assert_eq!(
-                *arr,
-                vec![String::from("X"), String::from("Y"), String::from("Z")]
-            );
-        }
-        _ => panic!("HL1 does not match!"),
-    };
-
-    match it.next().map(|(m, hl)| (m, &hl[..])) {
-        Some((SemanticHighlightMatcher::Array(arr), "HL2")) => {
-            assert_eq!(
-                *arr,
-                vec![String::from("X"), String::from("*"), String::from("Z")]
-            );
-        }
-        _ => panic!("HL2 does not match!"),
-    };
-
-    match it.next().map(|(m, hl)| (m, &hl[..])) {
-        Some((SemanticHighlightMatcher::ArrayStart(arr), "HL3")) => {
-            assert_eq!(
-                *arr,
-                vec![String::from("X"), String::from("*"), String::from("Z")]
-            );
-        }
-        _ => panic!("HL3 does not match!"),
-    };
-
-    match it.next().map(|(m, hl)| (m, &hl[..])) {
-        Some((SemanticHighlightMatcher::ArrayEnd(arr), "HL4")) => {
-            assert_eq!(
-                *arr,
-                vec![String::from("X"), String::from("*"), String::from("Z")]
-            );
-        }
-        _ => panic!("HL4 does not match!"),
-    };
-
-    match it.next().map(|(m, hl)| (m, &hl[..])) {
-        Some((SemanticHighlightMatcher::ArrayContains(arr), "HL5")) => {
-            assert_eq!(
-                *arr,
-                vec![String::from("X"), String::from("*"), String::from("Z")]
-            );
-        }
-        _ => panic!("HL5 does not match!"),
-    };
+fn test_convert_to_vim_str() {
+    assert_eq!(convert_to_vim_str("abcdefg"), "'abcdefg'");
+    assert_eq!(convert_to_vim_str("'abcdefg"), "'''abcdefg'");
+    assert_eq!(convert_to_vim_str("'x'x'x'x'"), "'''x''x''x''x'''");
+    assert_eq!(convert_to_vim_str("xyz'''ffff"), "'xyz''''''ffff'");
+    assert_eq!(convert_to_vim_str("'''"), "''''''''");
 }

--- a/src/vimext.rs
+++ b/src/vimext.rs
@@ -1,14 +1,17 @@
 use crate::language_client::LanguageClient;
+use crate::types::LCNamespace;
 use failure::Fallible;
 
 impl LanguageClient {
-    pub fn get_or_create_namespace(&self) -> Fallible<i64> {
-        if let Some(namespace_id) = self.get(|state| state.namespace_id)? {
+    pub fn get_or_create_namespace(&self, ns: &LCNamespace) -> Fallible<i64> {
+        let ns_name = ns.name();
+
+        if let Some(namespace_id) = self.get(|state| state.namespace_ids.get(&ns_name).cloned())? {
             Ok(namespace_id)
         } else {
-            let namespace_id = self.vim()?.create_namespace("LanguageClient")?;
+            let namespace_id = self.vim()?.create_namespace(&ns_name)?;
             self.update(|state| {
-                state.namespace_id = Some(namespace_id);
+                state.namespace_ids.insert(ns_name, namespace_id);
                 Ok(())
             })?;
             Ok(namespace_id)


### PR DESCRIPTION
Mostly done the initial implementation for supporting for the semantic highlighting protocol proposed by people from the vscode language server. As far as I know currently `clangd`  version 9 and `eclipse.jdt.ls` both have working implementations of this protocol.

This PR adds a new setting to configure semantic highlight `g:LanguageClient_semanticHighlightMaps`. Which is a per language map like `serverCommands` of mappings from semantic/textmate scopes to vim highlight groups.

Here are a couple of sample configurations and screenshots to go along.

Using `clangd` 9 for C++
```vim
let g:LanguageClient_semanticHighlightMaps['cpp'] = [
            \ {'Function': ['entity.name.function.cpp']},
            \ {'Function': ['entity.name.function.method.cpp']},
            \ {'CppNamespace': ['entity.name.namespace.cpp']},
            \ {'CppEnumConstant': ['variable.other.enummember.cpp']},
            \ {'CppMemberVariable': ['variable.other.field.cpp']},
            \ {'Type': ['entity.name.type.class.cpp']},
            \ {'Type': ['entity.name.type.enum.cpp']},
            \ {'Type': ['entity.name.type.template.cpp']},
            \ ]

hi! CppEnumConstant ctermfg=Magenta guifg=#AD7FA8 cterm=none gui=none
hi! CppNamespace ctermfg=Yellow guifg=#BBBB00 cterm=none gui=none
hi! CppMemberVariable ctermfg=White guifg=White
```

<span>
<img src="https://user-images.githubusercontent.com/4566209/72564210-1ea16480-3864-11ea-8011-2f47b1f59428.png" width="300">
<img src="https://user-images.githubusercontent.com/4566209/72564211-1f39fb00-3864-11ea-9994-13042afe8c64.png" width="300">
</span>
<br><br>


Using `eclipse.jdt.ls` for Java
```vim
let g:LanguageClient_semanticHighlightMaps['java'] = [
            \ {"JavaStaticMemberFunction": ['storage.modifier.static.java', 'entity.name.function.java', '**']},
            \ {"JavaMemberVariable": ['meta.definition.variable.java', 'meta.class.body.java', 'meta.class.java', '**']},
            \ {"Function": ['entity.name.function.java', '**']},
            \ {"Function": ['*', 'entity.name.function.java', '**']},
            \ {"Type": ['entity.name.type.class.java', '**']},
            \ {"Type": ['*', 'entity.name.type.class.java', '**']},
            \ ]

hi! JavaStaticMemberFunction ctermfg=Green cterm=none guifg=Green gui=none
hi! JavaMemberVariable ctermfg=White cterm=italic guifg=White gui=italic
```

<span>
<img src="https://user-images.githubusercontent.com/4566209/72564212-1f39fb00-3864-11ea-9fef-2764e2b77074.png" width="300">
<img src="https://user-images.githubusercontent.com/4566209/72564213-1f39fb00-3864-11ea-964f-d9cd57ad4ab5.png" width="300">
</span>
<br><br>

TODO:
- Support for `vim` 8.1 with `+textprop`
- Disable feature when the version of `vim` or `neovim` does not support the needed APIs
- More tests?

The PR is broken down into 2 commits since I had to upgrade the `lsp-types` crate to get the types needed for semantic highlighting.

Let me know what you think and if there are any improvements/fixes needed!

Related PRs/Issues:
#383
Microsoft/vscode-languageserver-node#367

Also see this document for exactly how the protocol works:
https://github.com/microsoft/vscode-languageserver-node/blob/5a9b33c23de84c3341e011e79221795a8059375b/protocol/src/protocol.semanticHighlighting.proposed.md