### PR TITLE
Sort diagnostics by line number to prevent stale signs

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2536,6 +2536,7 @@ impl LanguageClient {
                         diag.severity.unwrap_or(DiagnosticSeverity::Hint),
                     )
                 })
+                .sorted_by_key(|(line, _)| *line)
                 .group_by(|(line, _)| *line)
                 .into_iter()
                 .filter_map(|(_, group)| group.min_by_key(|(_, severity)| *severity))


### PR DESCRIPTION
Some signs would not be removed from the sign column when their
diagnostic was fixed.

Debugging revealed that signs_to_add would include two signs for the
same line. `state.signs`is keyed by line number so the second sign for
a line will overwrite the first when signs_to_add is recorded in state.
The first sign's id is lost when it's overwritten so it can't be
removed.

signs_to_add included two signs for the same line because itertools
`group_by` only groups consecutive runs (it's more efficient, you only
need to remember the current group and can flush it when the key
changes).

This quick fix sorts diagnostics by line number so that group_by gives
us one group per line number.

fixes #952