### PR TITLE
Refactor 6d85c80, prevent stale signs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,11 +185,6 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "either"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,14 +325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +358,6 @@ dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1028,7 +1014,6 @@ dependencies = [
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8c63033fcba1f51ef744505b3cad42510432b904c062afa67ad7ece008429d"
@@ -1046,7 +1031,6 @@ dependencies = [
 "checksum inotify 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b54539f3910d6f84fbf9a643efd6e3aa6e4f001426c0329576128255994718"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jsonrpc-core 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "288dca7f9713710a29e485076b9340156cb701edb46a881f5d0c31aa4f5b9143"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ tag-name = "{{version}}"
 
 [dependencies]
 failure = "0"
-itertools = "0.8"
 log = "0.4"
 log4rs = "0"
 structopt = "0"

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -8,8 +8,8 @@ use crate::rpcclient::RpcClient;
 use crate::sign::Sign;
 use failure::err_msg;
 use notify::Watcher;
-use std::sync::mpsc;
 use std::cmp;
+use std::sync::mpsc;
 use vim::try_get;
 
 impl LanguageClient {
@@ -2540,15 +2540,16 @@ impl LanguageClient {
             // find the most severe diagnostic on each line
             let mut signs = BTreeMap::new();
             for (line, severity) in diagnostics_in_view {
-                signs.entry(line)
-                    .and_modify(|s| { *s = cmp::min(*s, severity) })
+                signs
+                    .entry(line)
+                    .and_modify(|s| *s = cmp::min(*s, severity))
                     .or_insert(severity);
             }
             Ok(signs
-               .iter()
-               .take(limit)
-               .map(|(line, severity)| Sign::new(*line, format!("LanguageClient{:?}", severity)))
-               .collect())
+                .iter()
+                .take(limit)
+                .map(|(line, severity)| Sign::new(*line, format!("LanguageClient{:?}", severity)))
+                .collect())
         })?;
         self.update(|state| {
             let signs_prev: Vec<_> = state

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case, non_upper_case_globals)]
 #![deny(clippy::option_unwrap_used)]
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs::{read_to_string, File};
 use std::io::prelude::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -127,7 +127,7 @@ pub struct State {
     #[serde(skip_serializing)]
     pub line_diagnostics: HashMap<(String, u64), String>,
     pub sign_next_id: u64,
-    /// Active signs.
+    /// Active signs. Filename -> line number, Sign.
     pub signs: HashMap<String, BTreeMap<u64, Sign>>,
     pub namespace_id: Option<i64>,
     pub highlight_source: Option<u64>,


### PR DESCRIPTION
My previous commit fixed an issue that caused stale signs.

The root cause is `state.signs` was a map of line number to sign, and
some faulty code that allowed a set of signs that included two signs
with for the same line to be recorded in vim. State would track the
final sign for a line and loose the reference to the previous signs.
Without a reference the signs cannot be removed.

My previous fix addressed the second level bug, two signs for the same
line in the set of next signs, by sorting the diagnostics by line number
before using `group_by`. Sorting is compute (n log(n)) and memory
(collects the entire iterator into a vec) expensive so this commit
replaces `sorted_by_key` and `group_by` with a loop that accumulates
signs into a map.

This commit also fixes the root cause by changing `state.signs` to a map
by sign id instead of by line.