### PR TITLE
Add support for `rust-anaylzer.selectAndApplySourceChange`

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -847,6 +847,23 @@ impl LanguageClient {
                     }
                 }
             }
+            "rust-analyzer.selectAndApplySourceChange" => {
+                if let Some(ref edits) = cmd.arguments {
+                    for edit in edits {
+                        let workspace_edits: Vec<WorkspaceEditWithCursor> =
+                            serde_json::from_value(edit.clone())?;
+                        for edit in workspace_edits {
+                            self.apply_WorkspaceEdit(&edit.workspaceEdit)?;
+                            if let Some(cursorPosition) = edit.cursorPosition {
+                                self.vim()?.cursor(
+                                    cursorPosition.position.line + 1,
+                                    cursorPosition.position.character + 1,
+                                )?;
+                            }
+                        }
+                    }
+                }
+            }
             "rust-analyzer.applySourceChange" => {
                 if let Some(ref edits) = cmd.arguments {
                     for edit in edits {


### PR DESCRIPTION
This PR fixes #963 by adding support for `rust-analyzer`'s `selectAndApplySourceChange` command, which is needed for the newly introduced `auto import` feature.