### PR TITLE
Add config value for preferred markup kind

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -400,7 +400,7 @@ the root of a project is detected using g:LanguageClient_rootMarkers.
 Default: 1 to display the messages
 Valid options: 1 | 0
 
-2.30 g:LanguageClient_semanticHighlightMaps   *g:LanguageClient_semanticHighlightMaps*
+2.32 g:LanguageClient_semanticHighlightMaps   *g:LanguageClient_semanticHighlightMaps*
 
 String to list/map map. Defines the mapping of semantic highlighting "scopes" to
 highlight groups. This depends on the LSP server supporting the proposed
@@ -501,12 +501,44 @@ Example configuration for eclipse.jdt.ls:
      highlight! JavaMemberVariable ctermfg=White cterm=italic guifg=White gui=italic
 
 
-2.31 g:LanguageClient_applyCompletionAdditionalTextEdits *g:LanguageClient__applyCompletionAdditionalTextEdits*
+2.33 g:LanguageClient_applyCompletionAdditionalTextEdits *g:LanguageClient__applyCompletionAdditionalTextEdits*
 
 Indicates whether completionItem additional text edits should be applied.
 
 Default: 1
 Valid options: 1 | 0
+
+2.34 g:LanguageClient_preferredMarkupKind *g:LanguageClient_preferredMarkupKind*
+
+Sets the preferred markup kind. This value is sent to the server and is
+normally used to decide whether to send plaintext or markdown in things like
+hover or completion items docunmentation.
+
+This should be set to an array of values with the preferred markup kinds in
+order of preferrence. Leaving this config unset, will send `null` to the
+server, effectively letting it decide which markup kind to use.
+
+Example setting 1. Set the preferred markup kind to `plaintext`
+  ```
+  let g:LanguageClient_preferredMarkupKind: ['plaintext']
+  ```
+
+Example setting 2. Set the preferred markup kind to `plaintext` and `markdown`
+as a fallback.
+
+  ```
+  let g:LanguageClient_preferredMarkupKind: ['plaintext', 'markdown']
+  ```
+
+Example setting 3. Set the preferred markup kind to `markdown`
+
+  ```
+  let g:LanguageClient_preferredMarkupKind: ['markdown']
+
+This setting may have no effect of the server decides not to honour it.
+
+Default: v:null
+Valid options: Array<String>
 
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -125,6 +125,7 @@ impl LanguageClient {
             semanticHighlightMaps,
             semanticScopeSeparator,
             applyCompletionAdditionalTextEdits,
+            preferred_markup_kind,
         ): (
             Option<u64>,
             String,
@@ -135,6 +136,7 @@ impl LanguageClient {
             HashMap<String, HashMap<String, String>>,
             String,
             u8,
+            Option<Vec<String>>,
         ) = self.vim()?.eval(
             [
                 "get(g:, 'LanguageClient_diagnosticsSignsMax', v:null)",
@@ -146,6 +148,7 @@ impl LanguageClient {
                 "s:GetVar('LanguageClient_semanticHighlightMaps', {})",
                 "s:GetVar('LanguageClient_semanticScopeSeparator', ':')",
                 "get(g:, 'LanguageClient_applyCompletionAdditionalTextEdits', 1)",
+                "get(g:, 'LanguageClient_preferredMarkupKind', v:null)",
             ]
             .as_ref(),
         )?;
@@ -223,6 +226,18 @@ impl LanguageClient {
         let semanticHlUpdateLanguageIds: Vec<String> =
             semanticHighlightMaps.keys().cloned().collect();
 
+        let preferred_markup_kind: Option<Vec<MarkupKind>> = if preferred_markup_kind.is_some() {
+            serde_json::from_value(Value::Array(
+                preferred_markup_kind
+                    .unwrap()
+                    .into_iter()
+                    .map(|x| Value::String(x))
+                    .collect(),
+            ))?
+        } else {
+            None
+        };
+
         self.update(|state| {
             state.autoStart = autoStart;
             state.semanticHighlightMaps = semanticHighlightMaps;
@@ -258,6 +273,7 @@ impl LanguageClient {
             state.loggingLevel = loggingLevel;
             state.serverStderr = serverStderr;
             state.is_nvim = is_nvim;
+            state.preferred_markup_kind = preferred_markup_kind;
             Ok(())
         })?;
 
@@ -1119,6 +1135,7 @@ impl LanguageClient {
         };
 
         let trace = self.get(|state| state.trace)?;
+        let preferred_markup_kind = self.get(|state| state.preferred_markup_kind.clone())?;
 
         let result: Value = self.get_client(&Some(languageId.clone()))?.call(
             lsp::request::Initialize::METHOD,
@@ -1138,13 +1155,14 @@ impl LanguageClient {
                         completion: Some(CompletionCapability {
                             completion_item: Some(CompletionItemCapability {
                                 snippet_support: Some(has_snippet_support),
+                                documentation_format: preferred_markup_kind.clone(),
                                 ..CompletionItemCapability::default()
                             }),
                             ..CompletionCapability::default()
                         }),
                         signature_help: Some(SignatureHelpCapability {
                             signature_information: Some(SignatureInformationSettings {
-                                documentation_format: None,
+                                documentation_format: preferred_markup_kind.clone(),
                                 parameter_information: Some(ParameterInformationSettings {
                                     label_offset_support: Some(true),
                                 }),
@@ -1179,6 +1197,10 @@ impl LanguageClient {
                                 semantic_highlighting: true,
                             },
                         ),
+                        hover: Some(HoverCapability {
+                            content_format: preferred_markup_kind,
+                            ..HoverCapability::default()
+                        }),
                         ..TextDocumentClientCapabilities::default()
                     }),
                     workspace: Some(WorkspaceClientCapabilities {

--- a/src/types.rs
+++ b/src/types.rs
@@ -186,6 +186,7 @@ pub struct State {
     pub serverStderr: Option<String>,
     #[serde(skip_serializing)]
     pub logger: log4rs::Handle,
+    pub preferred_markup_kind: Option<Vec<MarkupKind>>,
 }
 
 impl State {
@@ -265,6 +266,7 @@ impl State {
             loggingFile: None,
             loggingLevel: log::LevelFilter::Warn,
             serverStderr: None,
+            preferred_markup_kind: None,
 
             logger,
         })


### PR DESCRIPTION
This PR fixes #836 by setting `MarkupKind` to `MarkupKind::PlainText` everywhere that's possible. The current implementation results in the server choosing which format to use, and can result, for example, in this:

![Screenshot from 2020-02-10 20-30-32](https://user-images.githubusercontent.com/4250565/74187642-eca5d700-4c44-11ea-81fa-bf7dd1caaae3.png)

(Note that the documentation for the symbol is enclosed by backticks and includes the language as well.)

This PR will indicate the server that it prefers plain text over markup so it will result (in servers that choose to honor the `MarkupKind` sent by the client) in this:

![Screenshot from 2020-02-10 20-30-56](https://user-images.githubusercontent.com/4250565/74187734-15c66780-4c45-11ea-90ff-d25e711a011e.png)

An improvement over this could be to make this a setting, and have the user choose it's `MarkupKind` for each server (or as client-level option if we wanted something simpler), but given that markup support in vim is rather poor, I think this would fit most of the users.

**EDIT**:

Updated this. Now it includes a config variable LanguageClient_preferredMarkupKind which is an array of strings which can be plaintext or markdown. The default value is v:null, which will let the server decide what to use as a markup kind.
