### PR TITLE
Add default root path implementation for Go

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,6 +63,7 @@ pub fn get_rootPath<'a>(
         "scala" => traverse_up(path, |dir| dir.join("build.sbt").exists()),
         "haskell" => traverse_up(path, |dir| dir.join("stack.yaml").exists())
             .or_else(|_| traverse_up(path, |dir| dir.join(".cabal").exists())),
+        "go" => traverse_up(path, |dir| dir.join("go.mod").exists()),
         _ => Err(format_err!("Unknown languageId: {}", languageId)),
     }
     .or_else(|_| {


### PR DESCRIPTION
When inside a go mod, the root of the project is wherever the go.mod file is. Right now the language server fails to initialize if the module is in a subfolder of your source repository.