### PR TITLE
Do not apply additional text edits if completionPreferTextEdit is set to 0

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -500,6 +500,14 @@ Example configuration for eclipse.jdt.ls:
      highlight! JavaStaticMemberFunction ctermfg=Green cterm=none guifg=Green gui=none
      highlight! JavaMemberVariable ctermfg=White cterm=italic guifg=White gui=italic
 
+
+2.31 g:LanguageClient_applyCompletionAdditionalTextEdits *g:LanguageClient__applyCompletionAdditionalTextEdits*
+
+Indicates whether completionItem additional text edits should be applied.
+
+Default: 1
+Valid options: 1 | 0
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -177,6 +177,7 @@ pub struct State {
     pub wait_output_timeout: Duration,
     pub hoverPreview: HoverPreviewOption,
     pub completionPreferTextEdit: bool,
+    pub applyCompletionAdditionalTextEdits: bool,
     pub use_virtual_text: UseVirtualText,
     pub echo_project_root: bool,
 
@@ -258,6 +259,7 @@ impl State {
             wait_output_timeout: Duration::from_secs(10),
             hoverPreview: HoverPreviewOption::default(),
             completionPreferTextEdit: false,
+            applyCompletionAdditionalTextEdits: true,
             use_virtual_text: UseVirtualText::All,
             echo_project_root: true,
             loggingFile: None,


### PR DESCRIPTION
This PR adds a `LanguageClient_applyCompletionAdditionalTextEdits` flag which can take a value of `0` or `1`. If `1`, it will apply additional text edits for completion items on `completionItem/resolve`, otherwise it won't apply them.

The flag's default value is `1`.


Closes #977.