### PR TITLE
Add hideVirtualTextsOnInsert option

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -542,12 +542,19 @@ This setting may have no effect of the server decides not to honour it.
 Default: v:null
 Valid options: Array<String>
 
-2.34 g:LanguageClient_floatingWindowStyle  *g:LanguageClient_floatingWindowStyle*
+2.35 g:LanguageClient_floatingWindowStyle  *g:LanguageClient_floatingWindowStyle*
 
 Style of opened Neovim floating window.
 
 Default: 'minimal'
 Valid options: 'minimal'
+
+2.36 g:LanguageClient_hideVirtualTextsOnInsert *g:LanguageClient_hideVirtualTextsOnInsert*
+
+Hides all virtual texts for the current buffer while editing in insert mode.
+
+Default: 0
+Valid options: 1 | 0
 
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*

--- a/src/types.rs
+++ b/src/types.rs
@@ -200,6 +200,7 @@ pub struct State {
     pub completion_prefer_text_edit: bool,
     pub apply_completion_additional_text_edits: bool,
     pub use_virtual_text: UseVirtualText,
+    pub hide_virtual_texts_on_insert: bool,
     pub echo_project_root: bool,
 
     pub server_stderr: Option<String>,
@@ -279,6 +280,7 @@ impl State {
             completion_prefer_text_edit: false,
             apply_completion_additional_text_edits: true,
             use_virtual_text: UseVirtualText::All,
+            hide_virtual_texts_on_insert: true,
             echo_project_root: true,
             server_stderr: None,
             preferred_markup_kind: None,

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -23,6 +23,43 @@ pub fn try_get<R: DeserializeOwned>(key: &str, params: &Value) -> Fallible<Optio
     }
 }
 
+#[derive(PartialEq)]
+pub enum Mode {
+    Normal,
+    Insert,
+    Replace,
+    Visual,
+    VisualLine,
+    VisualBlock,
+    Command,
+    Select,
+    SelectLine,
+    SelectBlock,
+    Terminal,
+}
+
+impl From<&str> for Mode {
+    fn from(mode: &str) -> Self {
+        match mode {
+            "n" => Mode::Normal,
+            "i" => Mode::Insert,
+            "R" => Mode::Replace,
+            "v" => Mode::Visual,
+            "V" => Mode::VisualLine,
+            "<C-v>" => Mode::VisualBlock,
+            "c" => Mode::Command,
+            "s" => Mode::Select,
+            "S" => Mode::SelectLine,
+            "<C-s>" => Mode::SelectBlock,
+            "t" => Mode::Terminal,
+            m => {
+                error!("unknown mode {}, falling back to Mode::Normal", m);
+                Mode::Normal
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Vim {
     pub rpcclient: Arc<RpcClient>,
@@ -34,6 +71,11 @@ impl Vim {
     }
 
     /// Fundamental functions.
+
+    pub fn get_mode(&self) -> Fallible<Mode> {
+        let mode: String = self.rpcclient.call("mode", json!([]))?;
+        Ok(Mode::from(mode.as_str()))
+    }
 
     pub fn command(&self, cmds: impl Serialize) -> Fallible<()> {
         self.rpcclient.notify("s:command", &cmds)


### PR DESCRIPTION
Closed #896 in favor of this one, which is now rebased to `next`, as I had deleted the fork in which that branch was :sweat_smile: .

Basically, this PR adds an option (LanguageClient_hideVirtualTextsOnInsert) to hide diagnostics in virtual texts while typing (insert mode). As it stands `1` is it's default value, but we can change it if this is not the desired default behaviour.

Same comment as in the last one, redrawing virtual texts only happens after a cursor move, so leaving insert mode is not enough to draw the hidden virtual texts back. If we wanted to enable this we should be able to do so by calling `set_virtual_texts` on `didSave`.

Fixes #816 and closes #981.

![Peek 2020-03-04 23-45](https://user-images.githubusercontent.com/4250565/75934005-4334b880-5e73-11ea-8efc-342811973ed3.gif)
