### PR TITLE
Hide errors with ContentModified error code

### DIFF
--- a/src/rpcclient.rs
+++ b/src/rpcclient.rs
@@ -82,24 +82,7 @@ impl RpcClient {
         // TODO: duration from config.
         match rx.recv_timeout(Duration::from_secs(60))? {
             rpc::Output::Success(ok) => Ok(serde_json::from_value(ok.result)?),
-            rpc::Output::Failure(err) => {
-                // NOTE: Errors with code -32801 correspond to the protocol's ContentModified error,
-                // which we don't want to show to the user and should ignore, as the result of the
-                // request that triggered this error has been invalidated by changes to the state
-                // of the server.
-                if err.error.code.code() == -32801 {
-                    let val = serde_json::from_value(Value::Null);
-                    match val {
-                        Ok(val) => {
-                            return Ok(val);
-                        }
-                        // do not return deserialization errors, as to preserve the original error.
-                        Err(e) => error!("Failed to deserialize null into value: {} ", e),
-                    }
-                }
-
-                bail!("Error: {:?}", err)
-            }
+            rpc::Output::Failure(err) => bail!("Error: {:?}", err),
         }
     }
 

--- a/src/rpcclient.rs
+++ b/src/rpcclient.rs
@@ -82,7 +82,24 @@ impl RpcClient {
         // TODO: duration from config.
         match rx.recv_timeout(Duration::from_secs(60))? {
             rpc::Output::Success(ok) => Ok(serde_json::from_value(ok.result)?),
-            rpc::Output::Failure(err) => bail!("Error: {:?}", err),
+            rpc::Output::Failure(err) => {
+                // NOTE: Errors with code -32801 correspond to the protocol's ContentModified error,
+                // which we don't want to show to the user and should ignore, as the result of the
+                // request that triggered this error has been invalidated by changes to the state
+                // of the server.
+                if err.error.code.code() == -32801 {
+                    let val = serde_json::from_value(Value::Null);
+                    match val {
+                        Ok(val) => {
+                            return Ok(val);
+                        }
+                        // do not return deserialization errors, as to preserve the original error.
+                        Err(e) => error!("Failed to deserialize null into value: {} ", e),
+                    }
+                }
+
+                bail!("Error: {:?}", err)
+            }
         }
     }
 

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -3,12 +3,30 @@ use crate::language_client::LanguageClient;
 use crate::lsp::notification::Notification;
 use crate::lsp::request::Request;
 
+// NOTE: Errors with code -32801 correspond to the protocol's ContentModified error,
+// which we don't want to show to the user and should ignore, as the result of the
+// request that triggered this error has been invalidated by changes to the state
+// of the server.
+const CONTENT_MODIFIED_ERROR_CODE: i64 = -32801;
+
+fn is_content_modified_error(err: &failure::Error) -> bool {
+    let err = err.find_root_cause().downcast_ref::<jsonrpc_core::Error>();
+    match err {
+        Some(err) => err.code.code() == CONTENT_MODIFIED_ERROR_CODE,
+        None => false,
+    }
+}
+
 impl LanguageClient {
     pub fn handle_call(&self, msg: Call) -> Fallible<()> {
         match msg {
             Call::MethodCall(lang_id, method_call) => {
                 let result = self.handle_method_call(lang_id.as_deref(), &method_call);
                 if let Err(ref err) = result {
+                    if is_content_modified_error(err) {
+                        return Ok(());
+                    }
+
                     if err.find_root_cause().downcast_ref::<LCError>().is_none() {
                         error!(
                             "Error handling message: {}\n\nMessage: {}\n\nError: {:?}",
@@ -24,6 +42,10 @@ impl LanguageClient {
             Call::Notification(lang_id, notification) => {
                 let result = self.handle_notification(lang_id.as_deref(), &notification);
                 if let Err(ref err) = result {
+                    if is_content_modified_error(err) {
+                        return Ok(());
+                    }
+
                     if err.downcast_ref::<LCError>().is_none() {
                         error!(
                             "Error handling message: {}\n\nMessage: {}\n\nError: {:?}",


### PR DESCRIPTION
This PR ignores the errors with code `-32801` as suggested by the specification:

> if a server detects a state change that invalidates the result of a request in execution the server can error these requests with ContentModified. If clients receive a ContentModified error, it generally should not show it in the UI for the end-user. Clients can resend the request if appropriate.

Not ignoring this error causes the server to display an error to the user and fail to start under some circumstances and with certain servers (I have seen it mostly with `rust-analyzer`).

Sorry about not dropping a link to the doc, but the section in which that is (`Implementation considerations`) is not easily linkable.