### PR TITLE
Use AtomicU64 for RpcClient::id counter

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc;
 use vim::try_get;
 
 impl LanguageClient {
-    pub fn get_client(&self, lang_id: &LanguageId) -> Fallible<RpcClient> {
+    pub fn get_client(&self, lang_id: &LanguageId) -> Fallible<Arc<RpcClient>> {
         self.get(|state| state.clients.get(lang_id).cloned())?
             .ok_or_else(|| {
                 LCError::ServerNotRunning {
@@ -3724,7 +3724,9 @@ impl LanguageClient {
             self.get(|state| state.tx.clone())?,
         )?;
         self.update(|state| {
-            state.clients.insert(Some(languageId.clone()), client);
+            state
+                .clients
+                .insert(Some(languageId.clone()), Arc::new(client));
             Ok(())
         })?;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,7 +113,7 @@ pub struct State {
     pub tx: crossbeam::channel::Sender<Call>,
 
     #[serde(skip_serializing)]
-    pub clients: HashMap<LanguageId, RpcClient>,
+    pub clients: HashMap<LanguageId, Arc<RpcClient>>,
 
     #[serde(skip_serializing)]
     pub vim: Vim,
@@ -194,13 +194,13 @@ impl State {
     pub fn new(tx: crossbeam::channel::Sender<Call>) -> Fallible<Self> {
         let logger = logger::init()?;
 
-        let client = RpcClient::new(
+        let client = Arc::new(RpcClient::new(
             None,
             BufReader::new(std::io::stdin()),
             BufWriter::new(std::io::stdout()),
             None,
             tx.clone(),
-        )?;
+        )?);
 
         Ok(Self {
             tx,

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -13,13 +13,13 @@ pub fn try_get<R: DeserializeOwned>(key: &str, params: &Value) -> Fallible<Optio
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone)]
 pub struct Vim {
-    pub rpcclient: RpcClient,
+    pub rpcclient: Arc<RpcClient>,
 }
 
 impl Vim {
-    pub fn new(rpcclient: RpcClient) -> Self {
+    pub fn new(rpcclient: Arc<RpcClient>) -> Self {
         Self { rpcclient }
     }
 


### PR DESCRIPTION
This PR changes the type of the `id` field in `RpcClient` from `Arc<Mutex<Id>>` to `AtomicU64` and moves the `Arc` to the `State`.