### PR TITLE
new function LanguageClient#isServerRunning() for statusline integration

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1050,6 +1050,7 @@ function! LanguageClient#handleBufNewFile() abort
 endfunction
 
 function! LanguageClient#handleBufEnter() abort
+    let b:LanguageClient_isServerRunning = 0
     try
         call LanguageClient#Notify('languageClient/handleBufEnter', {
                     \ 'filename': LSP#filename(),
@@ -1299,11 +1300,8 @@ function! LanguageClient#serverStatusMessage() abort
     return g:LanguageClient_serverStatusMessage
 endfunction
 
-" Set to 1 when the language server is running for current buffer
-let g:LanguageClient_isServerRunning = 0
-
 function! LanguageClient#isServerRunning() abort
-    return g:LanguageClient_isServerRunning
+    return b:LanguageClient_isServerRunning
 endfunction
 
 " Example function usable for status line.

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1289,6 +1289,13 @@ function! LanguageClient#serverStatusMessage() abort
     return g:LanguageClient_serverStatusMessage
 endfunction
 
+" Set to 1 when the language server is running for current buffer
+let g:LanguageClient_isServerRunning = 0
+
+function! LanguageClient#isServerRunning() abort
+    return g:LanguageClient_isServerRunning
+endfunction
+
 " Example function usable for status line.
 function! LanguageClient#statusLine() abort
     if g:LanguageClient_serverStatusMessage ==# ''

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1049,6 +1049,16 @@ function! LanguageClient#handleBufNewFile() abort
     endtry
 endfunction
 
+function! LanguageClient#handleBufEnter() abort
+    try
+        call LanguageClient#Notify('languageClient/handleBufEnter', {
+                    \ 'filename': LSP#filename(),
+                    \ })
+    catch
+        call s:Debug('LanguageClient caught exception: ' . string(v:exception))
+    endtry
+endfunction
+
 function! LanguageClient#handleFileType() abort
     try
         if s:Debounce(2, 'LanguageClient#handleFileType')

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -789,6 +789,13 @@ Signature: LanguageClient#serverStatusMessage()
 
 Get a detail message of server status.
 
+*LanguageClient#isServerRunning()*
+*LanguageClient_isServerRunning()*
+Signature: LanguageClient#isServerRunning()
+
+Get wheter if language server is running for current buffer. 0 for server not working for current buffer file
+type. 1 for working.
+
 *LanguageClient#statusLine()*
 *LanguageClient_statusLine()*
 Signature: LanguageClient#statusLine()

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -98,6 +98,10 @@ function! LanguageClient_serverStatusMessage(...)
     return call('LanguageClient#serverStatusMessage', a:000)
 endfunction
 
+function! LanguageClient_isServerRunning(...)
+    return call('LanguageClient#isServerRunning', a:000)
+endfunction
+
 function! LanguageClient_statusLine(...)
     return call('LanguageClient#statusLine', a:000)
 endfunction

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -129,6 +129,7 @@ augroup languageClient
     autocmd!
     autocmd FileType * call LanguageClient#handleFileType()
     autocmd BufNewFile * call LanguageClient#handleBufNewFile()
+    autocmd BufEnter * call LanguageClient#handleBufEnter()
     autocmd BufWritePost * call LanguageClient#handleBufWritePost()
     autocmd BufDelete * call LanguageClient#handleBufDelete()
     autocmd TextChanged * call LanguageClient#handleTextChanged()

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2818,9 +2818,8 @@ impl LanguageClient {
         let languageId = self.vim()?.get_languageId(&filename, params)?;
 
         if self.get(|state| state.clients.contains_key(&Some(languageId.clone())))? {
-            self.vim()?.command(vec![
-                format!("let {}=1", VIM__IsServerRunning),
-            ])?;
+            self.vim()?
+                .command(vec![format!("let {}=1", VIM__IsServerRunning)])?;
 
             self.textDocument_didOpen(params)?;
 
@@ -2838,14 +2837,12 @@ impl LanguageClient {
                 let ret = self.languageClient_startServer(params);
                 // This is triggered from autocmd, silent all errors.
                 if let Err(err) = ret {
-                    self.vim()?.command(vec![
-                        format!("let {}=0", VIM__IsServerRunning),
-                    ])?;
+                    self.vim()?
+                        .command(vec![format!("let {}=0", VIM__IsServerRunning)])?;
                     warn!("Failed to start language server automatically. {}", err);
-                }else {
-                    self.vim()?.command(vec![
-                        format!("let {}=1", VIM__IsServerRunning),
-                    ])?;
+                } else {
+                    self.vim()?
+                        .command(vec![format!("let {}=1", VIM__IsServerRunning)])?;
                 }
             }
         }

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2818,6 +2818,10 @@ impl LanguageClient {
         let languageId = self.vim()?.get_languageId(&filename, params)?;
 
         if self.get(|state| state.clients.contains_key(&Some(languageId.clone())))? {
+            self.vim()?.command(vec![
+                format!("let {}=1", VIM__IsServerRunning),
+            ])?;
+
             self.textDocument_didOpen(params)?;
 
             if let Some(diagnostics) =
@@ -2834,7 +2838,14 @@ impl LanguageClient {
                 let ret = self.languageClient_startServer(params);
                 // This is triggered from autocmd, silent all errors.
                 if let Err(err) = ret {
+                    self.vim()?.command(vec![
+                        format!("let {}=0", VIM__IsServerRunning),
+                    ])?;
                     warn!("Failed to start language server automatically. {}", err);
+                }else {
+                    self.vim()?.command(vec![
+                        format!("let {}=1", VIM__IsServerRunning),
+                    ])?;
                 }
             }
         }

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -167,6 +167,7 @@ impl LanguageClient {
             // Extensions.
             NOTIFICATION__HandleFileType => self.languageClient_handleFileType(&params)?,
             NOTIFICATION__HandleBufNewFile => self.languageClient_handleBufNewFile(&params)?,
+            NOTIFICATION__HandleBufEnter => self.languageClient_handleBufEnter(&params)?,
             NOTIFICATION__HandleTextChanged => self.languageClient_handleTextChanged(&params)?,
             NOTIFICATION__HandleBufWritePost => self.languageClient_handleBufWritePost(&params)?,
             NOTIFICATION__HandleBufDelete => self.languageClient_handleBufDelete(&params)?,

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,7 +62,7 @@ pub const REQUEST__ClassFileContents: &str = "java/classFileContents";
 // Vim variable names
 pub const VIM__ServerStatus: &str = "g:LanguageClient_serverStatus";
 pub const VIM__ServerStatusMessage: &str = "g:LanguageClient_serverStatusMessage";
-pub const VIM__IsServerRunning: &str = "g:LanguageClient_isServerRunning";
+pub const VIM__IsServerRunning: &str = "LanguageClient_isServerRunning";
 
 /// Thread safe read.
 pub trait SyncRead: BufRead + Sync + Send + Debug {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,7 @@ pub const REQUEST__SemanticScopes: &str = "languageClient/semanticScopes";
 pub const REQUEST__ShowSemanticHighlightSymbols: &str =
     "languageClient/showSemanticHighlightSymbols";
 pub const NOTIFICATION__HandleBufNewFile: &str = "languageClient/handleBufNewFile";
+pub const NOTIFICATION__HandleBufEnter: &str = "languageClient/handleBufEnter";
 pub const NOTIFICATION__HandleFileType: &str = "languageClient/handleFileType";
 pub const NOTIFICATION__HandleTextChanged: &str = "languageClient/handleTextChanged";
 pub const NOTIFICATION__HandleBufWritePost: &str = "languageClient/handleBufWritePost";

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,7 @@ pub const REQUEST__ClassFileContents: &str = "java/classFileContents";
 // Vim variable names
 pub const VIM__ServerStatus: &str = "g:LanguageClient_serverStatus";
 pub const VIM__ServerStatusMessage: &str = "g:LanguageClient_serverStatusMessage";
+pub const VIM__IsServerRunning: &str = "g:LanguageClient_isServerRunning";
 
 /// Thread safe read.
 pub trait SyncRead: BufRead + Sync + Send + Debug {}


### PR DESCRIPTION
As written in issue #993 #742, many users including me want the feature that indicates whether language server is running for current buffer or not in purpose of displaying status in their statusline.

A new function 'LanguageClient#isServerRunning()' which I implemented enables users to display LSP status to their statusline.

For example in lightline.vim,
```vim
function! LangugeServerStatus() abort
  let l:errors = 0
  let l:warnings = 0
  for item in getqflist()
      if item["type"] == "E"
          let l:errors += 1
      else 
        if item["type"] == "W"
          let l:warnings += 1
        endif
      endif
  endfor
  if LanguageClient#isServerRunning() == 0
    return 'not working!'
  endif
  return l:errors + l:warnings == 0 ? "✔ " : "✖ :" . l:errors . " " . "⚠ :" . l:warnings
endfunction

```
.vim file, no language server

![Screenshot from 2020-04-04 14-28-28](https://user-images.githubusercontent.com/28981383/78419476-23b2ca80-7681-11ea-8b50-cb8228ea49c0.png)

.go file, gopls is working!
![Screenshot from 2020-04-04 14-29-50](https://user-images.githubusercontent.com/28981383/78419482-29101500-7681-11ea-8092-43c191bca84b.png)

