### PR TITLE
new function LanguageClient#statusLineDiagnosticsCounts

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1051,6 +1051,10 @@ endfunction
 
 function! LanguageClient#handleBufEnter() abort
     let b:LanguageClient_isServerRunning = 0
+    if !exists('b:LanguageClient_statusLineDiagnosticsCounts')
+      let b:LanguageClient_statusLineDiagnosticsCounts = {}
+    endif
+
     try
         call LanguageClient#Notify('languageClient/handleBufEnter', {
                     \ 'filename': LSP#filename(),
@@ -1311,6 +1315,10 @@ function! LanguageClient#statusLine() abort
     endif
 
     return '[' . g:LanguageClient_serverStatusMessage . ']'
+endfunction
+
+function! LanguageClient#statusLineDiagnosticsCounts() abort
+    return b:LanguageClient_statusLineDiagnosticsCounts
 endfunction
 
 function! LanguageClient#cquery_base(...) abort

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -802,6 +802,22 @@ Signature: LanguageClient#statusLine()
 
 Example status line making use of |LanguageClient_serverStatusMessage|.
 
+*LanguageClient#statusLineDiagnosticsCounts()*
+*LanguageClient_statusLineDiagnosticsCounts()*
+Signature: LanguageClient#statusLineDiagnosticsCounts()
+
+Get diagnostics of current buffer in dictionary.
+
+Example >
+    function! YourStatusLineMessage() abort
+      let l:diagnosticsDict = LanguageClient#statusLineDiagnosticsCounts()
+      let l:errors = get(l:diagnosticsDict,'E',0)
+      let l:warnings = get(l:diagnosticsDict,'W',0)
+      let l:informations = get(l:diagnosticsDict,'I',0)
+      let l:hints = get(l:diagnosticsDict,'H',0)
+      return l:errors + l:warnings + l:informations + l:hints == 0 ? "✔ " : "E:" . l:errors . " " . "W :" . l:warnings . "I:" . l:informations . " " . "H:" . l:hints
+    endfunction
+
 *LanguageClient#cquery_base*
 *LanguageClient_cquery_base*
 Signature: LanguageClient#cquery_base(...)

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -106,6 +106,10 @@ function! LanguageClient_statusLine(...)
     return call('LanguageClient#statusLine', a:000)
 endfunction
 
+function! LanguageClient_statusLineDiagnosticsCounts(...)
+    return call('LanguageClient#statusLineDiagnosticsCounts', a:000)
+endfunction
+
 function! LanguageClient_clearDocumentHighlight(...)
     return call('LanguageClient#clearDocumentHighlight', a:000)
 endfunction

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -9,7 +9,6 @@ use crate::sign::Sign;
 use failure::err_msg;
 use itertools::Itertools;
 use notify::Watcher;
-use std::collections::BTreeMap;
 use std::sync::mpsc;
 use vim::try_get;
 
@@ -2288,7 +2287,7 @@ impl LanguageClient {
         })?;
         self.update_quickfixlist()?;
 
-        let mut severityCount: BTreeMap<String, u64> = [
+        let mut severityCount: HashMap<String, u64> = [
             (
                 DiagnosticSeverity::Error
                     .to_quickfix_entry_type()

--- a/src/types.rs
+++ b/src/types.rs
@@ -64,6 +64,7 @@ pub const REQUEST__ClassFileContents: &str = "java/classFileContents";
 pub const VIM__ServerStatus: &str = "g:LanguageClient_serverStatus";
 pub const VIM__ServerStatusMessage: &str = "g:LanguageClient_serverStatusMessage";
 pub const VIM__IsServerRunning: &str = "LanguageClient_isServerRunning";
+pub const VIM__StatusLineDiagnosticsCounts: &str = "LanguageClient_statusLineDiagnosticsCounts";
 
 /// Thread safe read.
 pub trait SyncRead: BufRead + Sync + Send + Debug {}


### PR DESCRIPTION
This pull request is a solution of issue #1005 .

As autozimu said in issue #1005, for compatibility, I created new function named `LanguageClient#statusLineDiagnosticsCounts`.

This function returns current buffer's diagnostics dictionary.
Ex. 
```
{'E': 0, 'W': 0, 'H': 0, 'I': 0}
```

By using this function, many users can integrate this very awesome plugin into their status line.


For `main.go`, this function returns 4 errors.
![Screenshot from 2020-04-06 21-59-05](https://user-images.githubusercontent.com/28981383/78561109-23b5f480-7852-11ea-85d2-de3fadd8c1f3.png)

For `purchase.go`, returns 2 errors.
![Screenshot from 2020-04-06 21-58-59](https://user-images.githubusercontent.com/28981383/78561118-27497b80-7852-11ea-9819-530424417dd1.png)

This function will be more useful if my another pull request #1003 is merged.