### PR TITLE
init b:LanguageClient_isServerRunning only when it is not defined yet.

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1050,7 +1050,10 @@ function! LanguageClient#handleBufNewFile() abort
 endfunction
 
 function! LanguageClient#handleBufEnter() abort
-    let b:LanguageClient_isServerRunning = 0
+    if !exists('b:LanguageClient_isServerRunning')
+      let b:LanguageClient_isServerRunning = 0
+    endif
+
     if !exists('b:LanguageClient_statusLineDiagnosticsCounts')
       let b:LanguageClient_statusLineDiagnosticsCounts = {}
     endif


### PR DESCRIPTION
This is related with my merged pull request #1003 .
In that pull request, I init `b:LanguageClient_isServerRunning` all time BufEnter, so I changed it to be init only when this valiable is not defined yet.