### PR TITLE
fix:  PathBuf can't be formatted with the default formatter

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -74,7 +74,7 @@ fn create_config(path: &Option<PathBuf>, level: LevelFilter) -> Fallible<Config>
                 .write(true)
                 .truncate(true)
                 .open(&path)
-                .with_context(|err| format!("Failed to open file ({}): {}", path, err))?;
+                .with_context(|err| format!("Failed to open file ({}): {}", path.display(), err))?;
             #[allow(clippy::write_literal)]
             writeln!(
                 f,


### PR DESCRIPTION
PathBuf/Path can't be formatted with `{}` (aka `Display` trait). This causes compilation error.
Solution: Convert PathBuf with PathBuf::display

More information: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.display