### PR TITLE
Add support for codeActions in ranges

### DIFF
--- a/autoload/LSP.vim
+++ b/autoload/LSP.vim
@@ -52,8 +52,46 @@ function! LSP#viewport() abort
 endfunction
 
 function! LSP#position() abort
+  return s:get_position()
+endfunction
+
+function! LSP#range(mode) abort
+  if a:mode ==# 'v'
+    return s:get_visual_selection()
+  endif
+
+  return {
+    \ 'start': s:get_position(),
+    \ 'end': s:get_position(),
+    \ }
+endfunction
+
+function! s:get_position() abort
 	return {
 		\ 'line': LSP#line(),
 		\ 'character': LSP#character(),
 		\ }
+endfunction
+
+function! s:get_visual_selection() abort
+    let [line_start, column_start] = getpos("'<")[1:2]
+    let [line_end, column_end] = getpos("'>")[1:2]
+    let lines = getline(line_start, line_end)
+    if len(lines) == 0
+        echohl Error | echom '[LC] No lines found in range.' | echohl None
+        return ''
+    endif
+    let lines[-1] = lines[-1][: column_end - 2]
+    let lines[0] = lines[0][column_start - 1:]
+
+    return {
+      \ 'start': {
+        \ 'line': line_start - 1,
+        \ 'character': column_start - 1,
+        \ },
+      \ 'end': {
+        \ 'line': line_end - 1,
+        \ 'character': column_end - 1,
+        \ }
+      \ }
 endfunction

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -861,16 +861,25 @@ function! LanguageClient#textDocument_codeLens(...) abort
     return LanguageClient#Call('textDocument/codeLens', l:params, l:Callback)
 endfunction
 
-function! LanguageClient#textDocument_codeAction(...) abort
-    let l:Callback = get(a:000, 1, v:null)
+function! s:do_codeAction(mode, ...) abort
+    let l:Callback = get(a:000, 2, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
                 \ 'handle': s:IsFalse(l:Callback),
+                \ 'range': LSP#range(a:mode),
                 \ }
-    call extend(l:params, get(a:000, 0, {}))
+    call extend(l:params, get(a:000, 1, {}))
     return LanguageClient#Call('textDocument/codeAction', l:params, l:Callback)
+endfunction
+
+function! LanguageClient#textDocument_visualCodeAction(...) abort
+  call s:do_codeAction('v', a:000)
+endfunction
+
+function! LanguageClient#textDocument_codeAction(...) abort
+  call s:do_codeAction('n', a:000)
 endfunction
 
 function! LanguageClient#textDocument_completion(...) abort

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -678,6 +678,12 @@ prompt, selecting one of the entry will then goto the reference location.
 
 For Denite users, a source with name 'references' is provided.
 
+*LanguageClient#textDocument_visualCodeAction()*
+*LanguageClient_textDocument_visualCodeAction()*
+Signature: LanguageClient#textDocument_visualCodeAction(...)
+
+Show code actions at current visual selection.
+
 *LanguageClient#textDocument_codeAction()*
 *LanguageClient_textDocument_codeAction()*
 Signature: LanguageClient#textDocument_codeAction(...)

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -35,7 +35,7 @@ function! LanguageClient_textDocument_references(...)
 endfunction
 
 function! LanguageClient_textDocument_codeAction(...)
-    return call('LanguageClient#textDocument_codeAction', a:000)
+    return call('LanguageClient#textDocument_codeAction', 'n', a:000)
 endfunction
 
 function! LanguageClient_textDocument_codeLens(...)

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1551,7 +1551,7 @@ impl LanguageClient {
         info!("Begin {}", lsp::request::CodeActionRequest::METHOD);
         let filename = self.vim()?.get_filename(params)?;
         let languageId = self.vim()?.get_languageId(&filename, params)?;
-        let position = self.vim()?.get_position(params)?;
+        let range: Range = serde_json::from_value(params["range"].clone())?;
 
         // Unify filename.
         let filename = filename.canonicalize();
@@ -1562,7 +1562,7 @@ impl LanguageClient {
                 .get(&filename)
                 .unwrap_or(&vec![])
                 .iter()
-                .filter(|dn| position >= dn.range.start && position < dn.range.end)
+                .filter(|dn| range.start >= dn.range.start && range.start < dn.range.end)
                 .cloned()
                 .collect()
         })?;
@@ -1573,10 +1573,7 @@ impl LanguageClient {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
                 },
-                range: Range {
-                    start: position,
-                    end: position,
-                },
+                range,
                 context: CodeActionContext {
                     diagnostics,
                     only: None,


### PR DESCRIPTION
This PR adds support for codeActions in visual ranges.

It basically adds a `LanguageClient#textDocument_visualCodeAction` function that uses the current range in the call to the code actions rust handler.

I'm not sure where the best place to document how this should be used is, as the user should use different mappings for each of the code actions functions.

```
vnoremap  ga :call LanguageClient#textDocument_visualCodeAction()<CR>
nnoremap  ga :call LanguageClient#textDocument_codeAction()<CR>
```

Closes #1016