### PR TITLE
Add stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,13 @@
+daysUntilStale: 60
+daysUntilClose: 7
+exemptLabels:
+  - feature-request
+  - help-wanted
+  - bug
+
+staleLabel: stale
+
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.


### PR DESCRIPTION
This PR adds the configuration for stale bot, to mark old issues as stale and eventually  close them automatically, as there are quite a few issues that have been abandoned or solved and not marked as such.

I added the labels `feature-request`, `help-wanted` and `bug` to the exempt list as to avoid marking issues with those labels as stale, as we probably want to keep those around to eventually find a solution.

This requires to enable the stale app first, which can be done here: https://github.com/apps/stale