### PR TITLE
Ignore bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-doc/tags
-__pycache__
-.pytest_cache
 .idea
-target
+.pytest_cache
+__pycache__
+bin
+doc/tags
 rplugin/python3/tests
+target
 tests/data/.vim/plugged


### PR DESCRIPTION
I added bin directory to ignore. This is useful for users who use native package manager. I also sorted ignored list alphabetically.