### PR TITLE
Add missing range argument to visualCodeAction function

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -884,7 +884,7 @@ function! s:do_codeAction(mode, ...) abort
     return LanguageClient#Call('textDocument/codeAction', l:params, l:Callback)
 endfunction
 
-function! LanguageClient#textDocument_visualCodeAction(...) abort
+function! LanguageClient#textDocument_visualCodeAction(...) range abort
   call s:do_codeAction('v', a:000)
 endfunction
 


### PR DESCRIPTION
This PR adds the missing `range` argument to the `visualCodeAction` function.

The effect of this missing was that when selection a range that spans multiple lines, the function would be called once per line in that range, which is not what we want.