### PR TITLE
Use a minimal style for Neovim's floating window

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -420,6 +420,7 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
         \   'col': col,
         \   'width': width,
         \   'height': height,
+        \   'style': 'minimal',
         \ })
 
         execute 'noswapfile edit!' a:bufname


### PR DESCRIPTION
Disable many UI options in the floating hover window, such as
'foldcolumn' and 'number'. See `:help nvim_open_win()` for details.

Issue #1033