### PR TITLE
Fix incorrect params in textDocument_codeAction call

### DIFF
--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -35,7 +35,7 @@ function! LanguageClient_textDocument_references(...)
 endfunction
 
 function! LanguageClient_textDocument_codeAction(...)
-    return call('LanguageClient#textDocument_codeAction', 'n', a:000)
+    return call('LanguageClient#textDocument_codeAction', a:000)
 endfunction
 
 function! LanguageClient_textDocument_codeLens(...)


### PR DESCRIPTION
Fixes `LanguageClient_textDocument_codeAction`, as it was passing an extra parameter and causing the function not to work.