### PR TITLE
Show completion item documentation on selection change

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -671,6 +671,13 @@ handles its own count independently.
 
 Default: 5
 
+2.45 g:LanguageClient_showCompletionDocs  *g:LanguageClient_showCompletionDocs*
+
+Show completion item documentation in a floating window right next to pmenu.
+
+Default: 1
+Valid options: 1 | 0
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -150,6 +150,10 @@ function! LanguageClient_textDocument_switchSourceHeader(...)
     return call('LanguageClient#textDocument_switchSourceHeader', a:000)
 endfunction
 
+function! LanguageClient_showCompletionItemDocumentation(...)
+    return call('LanguageClient#showCompletionItemDocumentation', a:000)
+endfunction
+
 command! -nargs=* LanguageClientStart :call LanguageClient#startServer(<f-args>)
 command! LanguageClientStop call LanguageClient#shutdown()
 
@@ -184,11 +188,9 @@ function! s:ConfigureAutocmds()
     endif
     autocmd CursorMoved <buffer> call LanguageClient#handleCursorMoved()
     autocmd VimLeavePre <buffer> call LanguageClient#handleVimLeavePre()
-
     autocmd CompleteDone <buffer> call LanguageClient#handleCompleteDone()
-    if get(g:, 'LanguageClient_signatureHelpOnCompleteDone', 0)
-        autocmd CompleteDone <buffer>
-                    \ call LanguageClient#textDocument_signatureHelp({}, 's:HandleOutputNothing')
+    if exists('##CompleteChanged')
+      autocmd CompleteChanged <buffer> call LanguageClient#showCompletionItemDocumentation()
     endif
 
     nnoremap <Plug>(lcn-menu)               :call LanguageClient_contextMenu()<CR>

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -189,8 +189,12 @@ function! s:ConfigureAutocmds()
     autocmd CursorMoved <buffer> call LanguageClient#handleCursorMoved()
     autocmd VimLeavePre <buffer> call LanguageClient#handleVimLeavePre()
     autocmd CompleteDone <buffer> call LanguageClient#handleCompleteDone()
-    if exists('##CompleteChanged')
-      autocmd CompleteChanged <buffer> call LanguageClient#showCompletionItemDocumentation()
+    if get(g:, 'LanguageClient_signatureHelpOnCompleteDone', 0)
+        autocmd CompleteDone <buffer>
+                    \ call LanguageClient#textDocument_signatureHelp({}, 's:HandleOutputNothing')
+    endif
+    if exists('##CompleteChanged') && get(g:, 'LanguageClient_showCompletionDocs', 1)
+      autocmd CompleteChanged <buffer> call LanguageClient#handleCompleteChanged(deepcopy(v:event))
     endif
 
     nnoremap <Plug>(lcn-menu)               :call LanguageClient_contextMenu()<CR>

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1054,9 +1054,10 @@ impl LanguageClient {
         let filetype = &to_display.vim_filetype();
         let lines = to_display.to_display();
 
-        self.vim()?
-            .rpcclient
-            .notify("s:OpenHoverPreview", json!([bufname, lines, filetype]))?;
+        self.vim()?.rpcclient.notify(
+            "s:OpenHoverPreview",
+            json!([bufname, lines, filetype, Value::Null, Value::Null]),
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
This is a PR to propose adding a popup window to show completion item documentation when the user walks through the completion menu ~and to kick things off if this is something we wanted to add~.

This uses the `documentation` key in the completion items if provided in the `textDocument/completion` response, or uses `completionItem/resolve` as a fallback to get that documentation. The documentation is displayed reusing the `OpenHoverPreview` function, so it should behave in the same way as that (shows in floating window, popup window or preview, depending on which is configured or available).

~The code is a little messy and there are some things that I'm not completely sure about, but I figured I'd push this and receive feedback and requests for changes anyway.~

This is how it looks in vim:
![vim](https://user-images.githubusercontent.com/4250565/83550542-e773dd00-a4fe-11ea-8877-69c32b8aa17b.gif)

And in neovim:

![nvim](https://user-images.githubusercontent.com/4250565/83550554-ecd12780-a4fe-11ea-89d6-9c782aa73127.gif)

Note that in the vim example, the documentation is available in the `textDocument/completion` response, so no further `completionItem/resolve` calls are made. Whereas in the neovim example, the documentation is not available until we explicitly call `completionItem/resolve`, because the javascript language server does not provide it in the `textDocument/completion` response.

**IMPORTANT**
~This uses `pum_getpos` to get the completion menu position and dimensions, so it won't work in neovim 0.4.X, as it's not available there, but it is available in neovim 0.5 (nightly) and vim 8. We need to add a check for this somewhere.~

**EDIT**
This is now working for nvim 0.4.X and 0.5, as well as vim8.

Closes #875 