### PR TITLE
Adopt rust conventions

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1,23 +1,69 @@
-use super::*;
-
 use crate::language_client::LanguageClient;
-use crate::lsp::notification::Notification;
-use crate::lsp::request::Request;
-use crate::lsp::GotoDefinitionResponse;
-use crate::rpcclient::RpcClient;
-use failure::err_msg;
+use crate::vim::try_get;
+use crate::{
+    rpcclient::RpcClient,
+    types::*,
+    utils::{
+        apply_text_edits, code_action_kind_as_str, convert_to_vim_str, decode_parameter_label,
+        escape_single_quote, expand_json_path, get_default_initialization_options, get_root_path,
+        vim_cmd_args_to_value, Canonicalize, Combine, ToUrl,
+    },
+    viewport,
+};
+use failure::{bail, err_msg, format_err, Error, Fallible, ResultExt};
 use itertools::Itertools;
+use jsonrpc_core::Value;
+use log::{debug, error, info, warn};
+use lsp_types::notification::Notification;
+use lsp_types::request::Request;
+use lsp_types::{
+    code_action_kind, ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse, ClientCapabilities,
+    ClientInfo, CodeAction, CodeActionCapability, CodeActionContext, CodeActionKindLiteralSupport,
+    CodeActionLiteralSupport, CodeActionOrCommand, CodeActionParams, CodeActionResponse, CodeLens,
+    Command, CompletionCapability, CompletionItem, CompletionItemCapability, CompletionResponse,
+    CompletionTextEdit, Diagnostic, DiagnosticSeverity, DidChangeConfigurationParams,
+    DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
+    DidChangeWatchedFilesRegistrationOptions, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentChangeOperation, DocumentChanges,
+    DocumentFormattingParams, DocumentHighlight, DocumentHighlightKind,
+    DocumentRangeFormattingParams, DocumentSymbolParams, ExecuteCommandParams, FormattingOptions,
+    GenericCapability, GotoCapability, GotoDefinitionResponse, Hover, HoverCapability,
+    InitializeParams, InitializeResult, InitializedParams, Location, LogMessageParams, MarkupKind,
+    MessageType, NumberOrString, ParameterInformation, ParameterInformationSettings,
+    PartialResultParams, Position, ProgressParams, ProgressParamsValue,
+    PublishDiagnosticsCapability, PublishDiagnosticsParams, Range, ReferenceContext,
+    RegistrationParams, RenameParams, ResourceOp, SemanticHighlightingClientCapability,
+    SemanticHighlightingParams, ShowMessageParams, ShowMessageRequestParams, SignatureHelp,
+    SignatureHelpCapability, SignatureInformationSettings, SymbolInformation,
+    TextDocumentClientCapabilities, TextDocumentContentChangeEvent, TextDocumentIdentifier,
+    TextDocumentItem, TextDocumentPositionParams, TextEdit, TraceOption, UnregistrationParams,
+    VersionedTextDocumentIdentifier, WorkDoneProgress, WorkDoneProgressParams,
+    WorkspaceClientCapabilities, WorkspaceEdit, WorkspaceSymbolParams,
+};
+use maplit::hashmap;
 use notify::Watcher;
+use pathdiff::diff_paths;
 use serde::de::Deserialize;
-use std::sync::mpsc;
-use vim::try_get;
+use serde_json::json;
+use std::{
+    collections::HashMap,
+    fs::{read_to_string, File},
+    io::{BufRead, BufReader, BufWriter},
+    net::TcpStream,
+    path::{Path, PathBuf},
+    process::Stdio,
+    str::FromStr,
+    sync::{mpsc, Arc, MutexGuard},
+    thread,
+    time::{Duration, Instant},
+};
 
 impl LanguageClient {
-    pub fn get_client(&self, lang_id: &LanguageId) -> Fallible<Arc<RpcClient>> {
-        self.get(|state| state.clients.get(lang_id).cloned())?
+    pub fn get_client(&self, language_id: &LanguageId) -> Fallible<Arc<RpcClient>> {
+        self.get(|state| state.clients.get(language_id).cloned())?
             .ok_or_else(|| {
                 LCError::ServerNotRunning {
-                    languageId: lang_id.clone().unwrap_or_default(),
+                    language_id: language_id.clone().unwrap_or_default(),
                 }
                 .into()
             })
@@ -43,7 +89,7 @@ impl LanguageClient {
     /////// Utils ///////
     fn sync_settings(&self) -> Fallible<()> {
         info!("Begin sync settings");
-        let (loggingFile, loggingLevel, serverStderr): (
+        let (logging_file, logging_level, server_stderr): (
             Option<PathBuf>,
             log::LevelFilter,
             Option<String>,
@@ -55,25 +101,25 @@ impl LanguageClient {
             ]
             .as_ref(),
         )?;
-        self.update(|state| state.logger.update_settings(loggingLevel, loggingFile))?;
+        self.update(|state| state.logger.update_settings(logging_level, logging_file))?;
 
         #[allow(clippy::type_complexity)]
         let (
-            autoStart,
-            serverCommands,
-            selectionUI,
+            auto_start,
+            server_commands,
+            selection_ui,
             trace,
-            settingsPath,
-            loadSettings,
-            rootMarkers,
+            settings_path,
+            load_settings,
+            root_markers,
             change_throttle,
             wait_output_timeout,
-            diagnosticsEnable,
-            diagnosticsList,
-            diagnosticsDisplay,
-            windowLogMessageLevel,
-            hoverPreview,
-            completionPreferTextEdit,
+            diagnostics_enable,
+            diagnostics_list,
+            diagnostics_display,
+            window_log_message_level,
+            hover_preview,
+            completion_prefer_text_edit,
             is_nvim,
         ): (
             u64,
@@ -116,15 +162,15 @@ impl LanguageClient {
 
         #[allow(clippy::type_complexity)]
         let (
-            diagnosticsSignsMax,
+            diagnostics_signs_max,
             diagnostics_max_severity,
-            documentHighlightDisplay,
-            selectionUI_autoOpen,
+            document_highlight_display,
+            selection_ui_auto_open,
             use_virtual_text,
             echo_project_root,
-            semanticHighlightMaps,
-            semanticScopeSeparator,
-            applyCompletionAdditionalTextEdits,
+            semantic_highlight_maps,
+            semantic_scope_separator,
+            apply_completion_text_edits,
             preferred_markup_kind,
         ): (
             Option<usize>,
@@ -154,22 +200,21 @@ impl LanguageClient {
         )?;
 
         // vimscript use 1 for true, 0 for false.
-        let autoStart = autoStart == 1;
-        let selectionUI_autoOpen = selectionUI_autoOpen == 1;
-        let loadSettings = loadSettings == 1;
+        let auto_start = auto_start == 1;
+        let selection_ui_auto_open = selection_ui_auto_open == 1;
+        let load_settings = load_settings == 1;
 
-        let trace = if let Some(t) = trace {
-            match t.to_ascii_uppercase().as_str() {
+        let trace = match trace {
+            Some(t) => match t.to_ascii_uppercase().as_str() {
                 "OFF" => Some(TraceOption::Off),
                 "MESSAGES" => Some(TraceOption::Messages),
                 "VERBOSE" => Some(TraceOption::Verbose),
                 _ => bail!("Invalid option for LanguageClient_trace: {}", t),
-            }
-        } else {
-            Some(TraceOption::default())
+            },
+            None => Some(TraceOption::default()),
         };
 
-        let selectionUI = if let Some(s) = selectionUI {
+        let selection_ui = if let Some(s) = selection_ui {
             SelectionUI::from_str(&s)?
         } else if self.vim()?.eval::<_, i64>("get(g:, 'loaded_fzf')")? == 1 {
             SelectionUI::FZF
@@ -181,33 +226,33 @@ impl LanguageClient {
         let wait_output_timeout =
             Duration::from_millis((wait_output_timeout.unwrap_or(10.0) * 1000.0) as u64);
 
-        let diagnosticsEnable = diagnosticsEnable == 1;
+        let diagnostics_enable = diagnostics_enable == 1;
 
-        let diagnosticsList = if let Some(s) = diagnosticsList {
+        let diagnostics_list = if let Some(s) = diagnostics_list {
             DiagnosticsList::from_str(&s)?
         } else {
             DiagnosticsList::Disabled
         };
 
-        let windowLogMessageLevel = match windowLogMessageLevel.to_ascii_uppercase().as_str() {
+        let window_log_level = match window_log_message_level.to_ascii_uppercase().as_str() {
             "ERROR" => MessageType::Error,
             "WARNING" => MessageType::Warning,
             "INFO" => MessageType::Info,
             "LOG" => MessageType::Log,
             _ => bail!(
                 "Invalid option for LanguageClient_windowLogMessageLevel: {}",
-                windowLogMessageLevel
+                window_log_message_level
             ),
         };
 
-        let hoverPreview = if let Some(s) = hoverPreview {
+        let hover_preview = if let Some(s) = hover_preview {
             HoverPreviewOption::from_str(&s)?
         } else {
             HoverPreviewOption::Auto
         };
 
-        let completionPreferTextEdit = completionPreferTextEdit == 1;
-        let applyCompletionAdditionalTextEdits = applyCompletionAdditionalTextEdits == 1;
+        let prefer_text_edit = completion_prefer_text_edit == 1;
+        let apply_completion_edits = apply_completion_text_edits == 1;
 
         let is_nvim = is_nvim == 1;
 
@@ -223,48 +268,48 @@ impl LanguageClient {
             ),
         };
 
-        let semanticHlUpdateLanguageIds: Vec<String> =
-            semanticHighlightMaps.keys().cloned().collect();
+        let semantic_highlight_language_ids: Vec<String> =
+            semantic_highlight_maps.keys().cloned().collect();
 
         self.update(|state| {
-            state.autoStart = autoStart;
-            state.semanticHighlightMaps = semanticHighlightMaps;
-            state.semanticScopeSeparator = semanticScopeSeparator;
+            state.auto_start = auto_start;
+            state.semantic_highlight_maps = semantic_highlight_maps;
+            state.semantic_scope_separator = semantic_scope_separator;
             state.semantic_scope_to_hl_group_table.clear();
-            state.serverCommands.extend(serverCommands);
-            state.selectionUI = selectionUI;
-            state.selectionUI_autoOpen = selectionUI_autoOpen;
+            state.server_commands.extend(server_commands);
+            state.selection_ui = selection_ui;
+            state.selection_ui_auto_open = selection_ui_auto_open;
             state.trace = trace;
-            state.diagnosticsEnable = diagnosticsEnable;
-            state.diagnosticsList = diagnosticsList;
-            state.diagnosticsDisplay = serde_json::from_value(
-                serde_json::to_value(&state.diagnosticsDisplay)?.combine(&diagnosticsDisplay),
+            state.diagnostics_enable = diagnostics_enable;
+            state.diagnostics_list = diagnostics_list;
+            state.diagnostics_display = serde_json::from_value(
+                serde_json::to_value(&state.diagnostics_display)?.combine(&diagnostics_display),
             )?;
-            state.diagnosticsSignsMax = diagnosticsSignsMax;
+            state.diagnostics_signs_max = diagnostics_signs_max;
             state.diagnostics_max_severity = diagnostics_max_severity;
-            state.documentHighlightDisplay = serde_json::from_value(
-                serde_json::to_value(&state.documentHighlightDisplay)?
-                    .combine(&documentHighlightDisplay),
+            state.document_highlight_display = serde_json::from_value(
+                serde_json::to_value(&state.document_highlight_display)?
+                    .combine(&document_highlight_display),
             )?;
-            state.windowLogMessageLevel = windowLogMessageLevel;
-            state.settingsPath = settingsPath;
-            state.loadSettings = loadSettings;
-            state.rootMarkers = rootMarkers;
+            state.window_log_message_level = window_log_level;
+            state.settings_path = settings_path;
+            state.load_settings = load_settings;
+            state.root_markers = root_markers;
             state.change_throttle = change_throttle;
             state.wait_output_timeout = wait_output_timeout;
-            state.hoverPreview = hoverPreview;
-            state.completionPreferTextEdit = completionPreferTextEdit;
-            state.applyCompletionAdditionalTextEdits = applyCompletionAdditionalTextEdits;
+            state.hover_preview = hover_preview;
+            state.completion_prefer_text_edit = prefer_text_edit;
+            state.apply_completion_additional_text_edits = apply_completion_edits;
             state.use_virtual_text = use_virtual_text;
             state.echo_project_root = echo_project_root == 1;
-            state.serverStderr = serverStderr;
+            state.server_stderr = server_stderr;
             state.is_nvim = is_nvim;
             state.preferred_markup_kind = preferred_markup_kind;
             Ok(())
         })?;
 
-        for languageId in semanticHlUpdateLanguageIds {
-            self.updateSemanticHighlightTables(&languageId)?;
+        for language_id in semantic_highlight_language_ids {
+            self.update_semantic_highlight_tables(&language_id)?;
         }
 
         info!("End sync settings");
@@ -272,14 +317,14 @@ impl LanguageClient {
     }
 
     fn get_workspace_settings(&self, root: &str) -> Fallible<Value> {
-        if !self.get(|state| state.loadSettings)? {
+        if !self.get(|state| state.load_settings)? {
             return Ok(Value::Null);
         }
 
         let mut res = Value::Null;
         let mut last_err = None;
         let mut at_least_one_success = false;
-        for orig_path in self.get(|state| state.settingsPath.clone())? {
+        for orig_path in self.get(|state| state.settings_path.clone())? {
             let path = Path::new(root).join(orig_path);
             let buffer = read_to_string(&path).with_context(|err| {
                 format!("Failed to read file ({}): {}", path.to_string_lossy(), err)
@@ -315,10 +360,13 @@ impl LanguageClient {
         info!("Defining signs");
 
         let mut cmds = vec![];
-        for entry in self.get(|state| state.diagnosticsDisplay.clone())?.values() {
+        for entry in self
+            .get(|state| state.diagnostics_display.clone())?
+            .values()
+        {
             cmds.push(format!(
                 "sign define LanguageClient{} text={} texthl={}",
-                entry.name, entry.signText, entry.signTexthl,
+                entry.name, entry.sign_text, entry.sign_texthl,
             ));
         }
 
@@ -326,9 +374,7 @@ impl LanguageClient {
         Ok(())
     }
 
-    fn apply_WorkspaceEdit(&self, edit: &WorkspaceEdit) -> Fallible<()> {
-        use self::{DocumentChangeOperation::*, ResourceOp::*};
-
+    fn apply_workspace_edit(&self, edit: &WorkspaceEdit) -> Fallible<()> {
         debug!("Begin apply WorkspaceEdit: {:?}", edit);
         let mut filename = self.vim()?.get_filename(&Value::Null)?;
         let mut position = self.vim()?.get_position(&Value::Null)?;
@@ -337,7 +383,7 @@ impl LanguageClient {
             match changes {
                 DocumentChanges::Edits(ref changes) => {
                     for e in changes {
-                        position = self.apply_TextEdits(
+                        position = self.apply_text_edits(
                             &e.text_document.uri.filepath()?,
                             &e.edits,
                             position,
@@ -347,20 +393,24 @@ impl LanguageClient {
                 DocumentChanges::Operations(ref ops) => {
                     for op in ops {
                         match op {
-                            Edit(ref e) => {
-                                position = self.apply_TextEdits(
+                            DocumentChangeOperation::Edit(ref e) => {
+                                position = self.apply_text_edits(
                                     &e.text_document.uri.filepath()?,
                                     &e.edits,
                                     position,
                                 )?
                             }
-                            Op(ref rop) => match rop {
-                                Create(file) => {
+                            DocumentChangeOperation::Op(ref rop) => match rop {
+                                ResourceOp::Create(file) => {
                                     filename = file.uri.filepath()?.to_string_lossy().into_owned();
                                     position = Position::default();
                                 }
-                                Rename(_file) => bail!("file renaming not yet supported."),
-                                Delete(_file) => bail!("file deletion not yet supported."),
+                                ResourceOp::Rename(_file) => {
+                                    bail!("file renaming not yet supported.")
+                                }
+                                ResourceOp::Delete(_file) => {
+                                    bail!("file deletion not yet supported.")
+                                }
                             },
                         }
                     }
@@ -368,7 +418,7 @@ impl LanguageClient {
             }
         } else if let Some(ref changes) = edit.changes {
             for (uri, edits) in changes {
-                position = self.apply_TextEdits(&uri.filepath()?, edits, position)?;
+                position = self.apply_text_edits(&uri.filepath()?, edits, position)?;
             }
         }
         self.edit(&None, &filename)?;
@@ -378,15 +428,18 @@ impl LanguageClient {
         Ok(())
     }
 
-    pub fn textDocument_documentHighlight(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::DocumentHighlightRequest::METHOD);
+    pub fn text_document_document_highlight(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!(
+            "Begin {}",
+            lsp_types::request::DocumentHighlightRequest::METHOD
+        );
         let filename = self.vim()?.get_filename(&Value::Null)?;
-        let languageId = self.vim()?.get_languageId(&filename, &Value::Null)?;
+        let language_id = self.vim()?.get_language_id(&filename, &Value::Null)?;
         let position = self.vim()?.get_position(&Value::Null)?;
 
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::DocumentHighlightRequest::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::DocumentHighlightRequest::METHOD,
             TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -402,8 +455,8 @@ impl LanguageClient {
         let document_highlight: Option<Vec<DocumentHighlight>> =
             serde_json::from_value(result.clone())?;
         if let Some(document_highlight) = document_highlight {
-            let documentHighlightDisplay =
-                self.get(|state| state.documentHighlightDisplay.clone())?;
+            let document_highlight_display =
+                self.get(|state| state.document_highlight_display.clone())?;
             let highlights = document_highlight
                 .into_iter()
                 .map(|DocumentHighlight { range, kind }| {
@@ -411,7 +464,7 @@ impl LanguageClient {
                         line: range.start.line,
                         character_start: range.start.character,
                         character_end: range.end.character,
-                        group: documentHighlightDisplay
+                        group: document_highlight_display
                             .get(
                                 &kind
                                     .unwrap_or(DocumentHighlightKind::Text)
@@ -475,12 +528,15 @@ impl LanguageClient {
             })?;
         }
 
-        info!("End {}", lsp::request::DocumentHighlightRequest::METHOD);
+        info!(
+            "End {}",
+            lsp_types::request::DocumentHighlightRequest::METHOD
+        );
         Ok(result)
     }
 
-    pub fn languageClient_clearDocumentHighlight(&self, _params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__ClearDocumentHighlight);
+    pub fn clear_document_highlight(&self, _params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_CLEAR_DOCUMENT_HL);
 
         // The following code needs to be inside the critical section as a whole to update
         // everything correctly and not leave hanging highlights.
@@ -495,11 +551,11 @@ impl LanguageClient {
             Ok(())
         })?;
 
-        info!("End {}", NOTIFICATION__ClearDocumentHighlight);
+        info!("End {}", NOTIFICATION_CLEAR_DOCUMENT_HL);
         Ok(())
     }
 
-    fn apply_TextEdits<P: AsRef<Path>>(
+    fn apply_text_edits<P: AsRef<Path>>(
         &self,
         path: P,
         edits: &[TextEdit],
@@ -530,7 +586,7 @@ impl LanguageClient {
             lines.push("".to_owned());
         }
 
-        let (mut lines, position) = apply_TextEdits(&lines, &edits, &position)?;
+        let (mut lines, position) = apply_text_edits(&lines, &edits, &position)?;
 
         if lines.last().map(String::is_empty) == Some(true) && fixendofline {
             lines.pop();
@@ -564,8 +620,8 @@ impl LanguageClient {
             .collect();
 
         let title = "[LC]: diagnostics";
-        let diagnosticsList = self.get(|state| state.diagnosticsList)?;
-        match diagnosticsList {
+        let diagnostics_list = self.get(|state| state.diagnostics_list)?;
+        match diagnostics_list {
             DiagnosticsList::Quickfix => {
                 self.vim()?.setqflist(&qflist, "r", title)?;
             }
@@ -618,7 +674,7 @@ impl LanguageClient {
         })?;
 
         // Highlight.
-        let diagnosticsDisplay = self.get(|state| state.diagnosticsDisplay.clone())?;
+        let diagnostics_display = self.get(|state| state.diagnostics_display.clone())?;
 
         let mut highlights = vec![];
         for dn in diagnostics {
@@ -627,7 +683,7 @@ impl LanguageClient {
             let character_end = dn.range.end.character;
 
             let severity = dn.severity.unwrap_or(DiagnosticSeverity::Hint);
-            let group = diagnosticsDisplay
+            let group = diagnostics_display
                 .get(&severity.to_int()?)
                 .ok_or_else(|| err_msg("Failed to get display"))?
                 .texthl
@@ -675,7 +731,7 @@ impl LanguageClient {
             let mut new_match_ids = Vec::new();
 
             for (severity, dns) in match_groups {
-                let hl_group = diagnosticsDisplay
+                let hl_group = diagnostics_display
                     .get(&severity)
                     .ok_or_else(|| err_msg("Failed to get display"))?
                     .texthl
@@ -694,24 +750,24 @@ impl LanguageClient {
                                 length,
                             ]]
                         } else {
-                            let mut middleLines: Vec<_> = (dn.range.start.line + 1
+                            let mut middle_lines: Vec<_> = (dn.range.start.line + 1
                                 ..dn.range.end.line)
                                 .map(|l| vec![l + 1])
                                 .collect();
-                            let startLine = vec![
+                            let start_line = vec![
                                 dn.range.start.line + 1,
                                 dn.range.start.character + 1,
                                 999_999, //Clear to the end of the line
                             ];
-                            let endLine =
+                            let end_line =
                                 vec![dn.range.end.line + 1, 1, dn.range.end.character + 1];
-                            middleLines.push(startLine);
+                            middle_lines.push(start_line);
                             // For a multi-ringe range ending at the exact start of the last line,
                             // don't highlight the first character of the last line.
                             if dn.range.end.character > 0 {
-                                middleLines.push(endLine);
+                                middle_lines.push(end_line);
                             }
-                            middleLines
+                            middle_lines
                         }
                     })
                     .collect();
@@ -748,9 +804,9 @@ impl LanguageClient {
                 })
             };
 
-        let selectionUI = self.get(|state| state.selectionUI)?;
-        let selectionUI_autoOpen = self.get(|state| state.selectionUI_autoOpen)?;
-        match selectionUI {
+        let selection_ui = self.get(|state| state.selection_ui)?;
+        let selection_ui_auto_open = self.get(|state| state.selection_ui_auto_open)?;
+        match selection_ui {
             SelectionUI::FZF => {
                 let cwd: String = self.vim()?.eval("getcwd()")?;
                 let source: Fallible<Vec<_>> = locations
@@ -773,7 +829,7 @@ impl LanguageClient {
 
                 self.vim()?.rpcclient.notify(
                     "s:FZF",
-                    json!([source, format!("s:{}", NOTIFICATION__FZFSinkLocation)]),
+                    json!([source, format!("s:{}", NOTIFICATION_FZF_SINK_LOCATION)]),
                 )?;
             }
             SelectionUI::Quickfix => {
@@ -783,7 +839,7 @@ impl LanguageClient {
                     .collect();
                 let list = list?;
                 self.vim()?.setqflist(&list, " ", title)?;
-                if selectionUI_autoOpen {
+                if selection_ui_auto_open {
                     self.vim()?.command("botright copen")?;
                 }
                 self.vim()?.echo("Quickfix list updated.")?;
@@ -795,7 +851,7 @@ impl LanguageClient {
                     .collect();
                 let list = list?;
                 self.vim()?.setloclist(&list, " ", title)?;
-                if selectionUI_autoOpen {
+                if selection_ui_auto_open {
                     self.vim()?.command("lopen")?;
                 }
                 self.vim()?.echo("Location list updated.")?;
@@ -804,10 +860,10 @@ impl LanguageClient {
         Ok(())
     }
 
-    fn registerCMSource(&self, languageId: &str, result: &Value) -> Fallible<()> {
+    fn register_cm_source(&self, language_id: &str, result: &Value) -> Fallible<()> {
         info!("Begin register NCM source");
-        let exists_CMRegister: u64 = self.vim()?.eval("exists('g:cm_matcher')")?;
-        if exists_CMRegister == 0 {
+        let exists_cm_register: u64 = self.vim()?.eval("exists('g:cm_matcher')")?;
+        if exists_cm_register == 0 {
             return Ok(());
         }
 
@@ -833,19 +889,19 @@ impl LanguageClient {
         self.vim()?.rpcclient.notify(
             "cm#register_source",
             json!([{
-                "name": format!("LanguageClient_{}", languageId),
+                "name": format!("LanguageClient_{}", language_id),
                 "priority": 9,
-                "scopes": [languageId],
+                "scopes": [language_id],
                 "cm_refresh_patterns": trigger_patterns,
                 "abbreviation": "LC",
-                "cm_refresh": REQUEST__NCMRefresh,
+                "cm_refresh": REQUEST_NCM_REFRESH,
             }]),
         )?;
         info!("End register NCM source");
         Ok(())
     }
 
-    fn registerNCM2Source(&self, languageId: &str, result: &Value) -> Fallible<()> {
+    fn register_ncm2_source(&self, language_id: &str, result: &Value) -> Fallible<()> {
         info!("Begin register NCM2 source");
         let exists_ncm2: u64 = self.vim()?.eval("exists('g:ncm2_loaded')")?;
         if exists_ncm2 == 0 {
@@ -874,19 +930,19 @@ impl LanguageClient {
         self.vim()?.rpcclient.notify(
             "ncm2#register_source",
             json!([{
-                "name": format!("LanguageClient_{}", languageId),
+                "name": format!("LanguageClient_{}", language_id),
                 "priority": 9,
-                "scope": [languageId],
+                "scope": [language_id],
                 "complete_pattern": trigger_patterns,
                 "mark": "LC",
-                "on_complete": REQUEST__NCM2OnComplete,
+                "on_complete": REQUEST_NCM2_ON_COMPLETE,
             }]),
         )?;
         info!("End register NCM2 source");
         Ok(())
     }
 
-    fn parseSemanticScopes(&self, languageId: &str, result: &Value) -> Fallible<()> {
+    fn parse_semantic_scopes(&self, language_id: &str, result: &Value) -> Fallible<()> {
         info!("Begin parse Semantic Scopes");
         let result: InitializeResult = serde_json::from_value(result.clone())?;
 
@@ -894,7 +950,7 @@ impl LanguageClient {
             self.update(|state| {
                 state
                     .semantic_scopes
-                    .insert(languageId.into(), capability.scopes.unwrap_or_default());
+                    .insert(language_id.into(), capability.scopes.unwrap_or_default());
                 Ok(())
             })?;
         }
@@ -906,25 +962,25 @@ impl LanguageClient {
     /// Build the Semantic Highlight Lookup Table of
     ///
     /// ScopeIndex -> Option<HighlightGroup>
-    fn updateSemanticHighlightTables(&self, languageId: &str) -> Fallible<()> {
+    fn update_semantic_highlight_tables(&self, language_id: &str) -> Fallible<()> {
         info!("Begin updateSemanticHighlightTables");
-        let (opt_scopes, opt_hl_map, scopeSeparator) = self.get(|state| {
+        let (opt_scopes, opt_hl_map, scope_separator) = self.get(|state| {
             (
-                state.semantic_scopes.get(languageId).cloned(),
-                state.semanticHighlightMaps.get(languageId).cloned(),
-                state.semanticScopeSeparator.clone(),
+                state.semantic_scopes.get(language_id).cloned(),
+                state.semantic_highlight_maps.get(language_id).cloned(),
+                state.semantic_scope_separator.clone(),
             )
         })?;
 
-        if let (Some(semantic_scopes), Some(semanticHighlightMap)) = (opt_scopes, opt_hl_map) {
+        if let (Some(semantic_scopes), Some(shm)) = (opt_scopes, opt_hl_map) {
             let mut table: Vec<Option<String>> = Vec::new();
 
             for scope_list in semantic_scopes {
                 // Combine all scopes ["scopeA", "scopeB", ...] -> "scopeA:scopeB:..."
-                let scope_str = scope_list.iter().join(&scopeSeparator);
+                let scope_str = scope_list.iter().join(&scope_separator);
 
                 let mut matched = false;
-                for (scope_regex, hl_group) in &semanticHighlightMap {
+                for (scope_regex, hl_group) in &shm {
                     let match_expr = format!(
                         "({} =~ {})",
                         convert_to_vim_str(&scope_str),
@@ -948,12 +1004,12 @@ impl LanguageClient {
             self.update(|state| {
                 state
                     .semantic_scope_to_hl_group_table
-                    .insert(languageId.into(), table);
+                    .insert(language_id.into(), table);
                 Ok(())
             })?;
         } else {
             self.update(|state| {
-                state.semantic_scope_to_hl_group_table.remove(languageId);
+                state.semantic_scope_to_hl_group_table.remove(language_id);
                 Ok(())
             })?;
         }
@@ -986,7 +1042,7 @@ impl LanguageClient {
                 if let Some(ref edits) = cmd.arguments {
                     for edit in edits {
                         let edit: WorkspaceEdit = serde_json::from_value(edit.clone())?;
-                        self.apply_WorkspaceEdit(&edit)?;
+                        self.apply_workspace_edit(&edit)?;
                     }
                 }
             }
@@ -994,7 +1050,7 @@ impl LanguageClient {
                 let locations = cmd
                     .arguments
                     .clone()
-                    .unwrap_or_else(|| vec![])
+                    .unwrap_or_default()
                     .get(2)
                     .cloned()
                     .unwrap_or_else(|| Value::Array(vec![]));
@@ -1008,11 +1064,11 @@ impl LanguageClient {
                         let workspace_edits: Vec<WorkspaceEditWithCursor> =
                             serde_json::from_value(edit.clone())?;
                         for edit in workspace_edits {
-                            self.apply_WorkspaceEdit(&edit.workspaceEdit)?;
-                            if let Some(cursorPosition) = edit.cursorPosition {
+                            self.apply_workspace_edit(&edit.workspace_edit)?;
+                            if let Some(cursor_position) = edit.cursor_position {
                                 self.vim()?.cursor(
-                                    cursorPosition.position.line + 1,
-                                    cursorPosition.position.character + 1,
+                                    cursor_position.position.line + 1,
+                                    cursor_position.position.character + 1,
                                 )?;
                             }
                         }
@@ -1023,11 +1079,11 @@ impl LanguageClient {
                 if let Some(ref edits) = cmd.arguments {
                     for edit in edits {
                         let edit: WorkspaceEditWithCursor = serde_json::from_value(edit.clone())?;
-                        self.apply_WorkspaceEdit(&edit.workspaceEdit)?;
-                        if let Some(cursorPosition) = edit.cursorPosition {
+                        self.apply_workspace_edit(&edit.workspace_edit)?;
+                        if let Some(cursor_position) = edit.cursor_position {
                             self.vim()?.cursor(
-                                cursorPosition.position.line + 1,
-                                cursorPosition.position.character + 1,
+                                cursor_position.position.line + 1,
+                                cursor_position.position.character + 1,
                             )?;
                         }
                     }
@@ -1057,16 +1113,15 @@ impl LanguageClient {
         Ok(true)
     }
 
-    fn cleanup(&self, languageId: &str) -> Fallible<()> {
+    fn cleanup(&self, language_id: &str) -> Fallible<()> {
         info!("Begin cleanup");
 
-        let root = self.get(|state| {
-            state
-                .roots
-                .get(languageId)
-                .cloned()
-                .ok_or_else(|| format_err!("No project root found! languageId: {}", languageId))
-        })??;
+        let root =
+            self.get(|state| {
+                state.roots.get(language_id).cloned().ok_or_else(|| {
+                    format_err!("No project root found! languageId: {}", language_id)
+                })
+            })??;
 
         let mut filenames = vec![];
         self.update(|state| {
@@ -1085,26 +1140,26 @@ impl LanguageClient {
                 if bufnr > 0 {
                     self.vim()?.rpcclient.notify(
                         "setbufvar",
-                        json!([f, VIM__StatusLineDiagnosticsCounts, {}]),
+                        json!([f, VIM_STATUS_LINE_DIAGNOSTICS_COUNTS, {}]),
                     )?;
                 }
             }
             self.process_diagnostics(&f, &[])?;
         }
-        self.languageClient_handleCursorMoved(&Value::Null)?;
+        self.handle_cursor_moved(&Value::Null)?;
 
         self.update(|state| {
-            state.clients.remove(&Some(languageId.into()));
+            state.clients.remove(&Some(language_id.into()));
             state.last_cursor_line = 0;
             state.text_documents.retain(|f, _| !f.starts_with(&root));
-            state.roots.remove(languageId);
+            state.roots.remove(language_id);
             Ok(())
         })?;
         self.update_quickfixlist()?;
 
         self.vim()?.command(vec![
-            format!("let {}=0", VIM__ServerStatus),
-            format!("let {}=''", VIM__ServerStatusMessage),
+            format!("let {}=0", VIM_SERVER_STATUS),
+            format!("let {}=''", VIM_SERVER_STATUS_MESSAGE),
         ])?;
         self.vim()?
             .rpcclient
@@ -1132,7 +1187,7 @@ impl LanguageClient {
     fn edit(&self, goto_cmd: &Option<String>, path: impl AsRef<Path>) -> Fallible<()> {
         let path = path.as_ref().to_string_lossy();
         if path.starts_with("jdt://") {
-            self.java_classFileContents(&json!({ "gotoCmd": goto_cmd, "uri": path }))?;
+            self.java_class_file_contents(&json!({ "gotoCmd": goto_cmd, "uri": path }))?;
             Ok(())
         } else {
             self.vim()?.edit(&goto_cmd, path.into_owned())
@@ -1142,13 +1197,13 @@ impl LanguageClient {
     /////// LSP ///////
 
     fn initialize(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::Initialize::METHOD);
+        info!("Begin {}", lsp_types::request::Initialize::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let has_snippet_support: i8 = try_get("hasSnippetSupport", params)?
             .map_or_else(|| self.vim()?.eval("s:hasSnippetSupport()"), Ok)?;
         let has_snippet_support = has_snippet_support > 0;
-        let root = self.get(|state| state.roots.get(&languageId).cloned().unwrap_or_default())?;
+        let root = self.get(|state| state.roots.get(&language_id).cloned().unwrap_or_default())?;
 
         let initialization_options = self
             .get_workspace_settings(&root)
@@ -1158,7 +1213,7 @@ impl LanguageClient {
                 json!(Value::Null)
             });
         let initialization_options =
-            get_default_initializationOptions(&languageId).combine(&initialization_options);
+            get_default_initialization_options(&language_id).combine(&initialization_options);
         let initialization_options = if initialization_options.is_null() {
             None
         } else {
@@ -1168,8 +1223,8 @@ impl LanguageClient {
         let trace = self.get(|state| state.trace)?;
         let preferred_markup_kind = self.get(|state| state.preferred_markup_kind.clone())?;
 
-        let result: Value = self.get_client(&Some(languageId.clone()))?.call(
-            lsp::request::Initialize::METHOD,
+        let result: Value = self.get_client(&Some(language_id.clone()))?.call(
+            lsp_types::request::Initialize::METHOD,
             #[allow(deprecated)]
             InitializeParams {
                 client_info: Some(ClientInfo {
@@ -1278,23 +1333,23 @@ impl LanguageClient {
         self.update(|state| {
             state
                 .capabilities
-                .insert(languageId.clone(), result.clone());
+                .insert(language_id.clone(), result.clone());
             Ok(())
         })?;
 
-        info!("End {}", lsp::request::Initialize::METHOD);
+        info!("End {}", lsp_types::request::Initialize::METHOD);
 
-        if let Err(e) = self.registerCMSource(&languageId, &result) {
+        if let Err(e) = self.register_cm_source(&language_id, &result) {
             let message = format!("LanguageClient: failed to register as NCM source: {}", e);
             error!("{}\n{:?}", message, e);
             self.vim()?.echoerr(&message)?;
         }
-        if let Err(e) = self.registerNCM2Source(&languageId, &result) {
+        if let Err(e) = self.register_ncm2_source(&language_id, &result) {
             let message = format!("LanguageClient: failed to register as NCM source: {}", e);
             error!("{}\n{:?}", message, e);
             self.vim()?.echoerr(&message)?;
         }
-        if let Err(e) = self.parseSemanticScopes(&languageId, &result) {
+        if let Err(e) = self.parse_semantic_scopes(&language_id, &result) {
             let message = format!("LanguageClient: failed to parse semantic scopes: {}", e);
             error!("{}\n{:?}", message, e);
             self.vim()?.echoerr(&message)?;
@@ -1304,25 +1359,27 @@ impl LanguageClient {
     }
 
     fn initialized(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::Initialized::METHOD);
+        info!("Begin {}", lsp_types::notification::Initialized::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
-        self.updateSemanticHighlightTables(&languageId)?;
-        self.get_client(&Some(languageId))?
-            .notify(lsp::notification::Initialized::METHOD, InitializedParams {})?;
-        info!("End {}", lsp::notification::Initialized::METHOD);
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
+        self.update_semantic_highlight_tables(&language_id)?;
+        self.get_client(&Some(language_id))?.notify(
+            lsp_types::notification::Initialized::METHOD,
+            InitializedParams {},
+        )?;
+        info!("End {}", lsp_types::notification::Initialized::METHOD);
         Ok(())
     }
 
-    pub fn textDocument_hover(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::HoverRequest::METHOD);
+    pub fn text_document_hover(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!("Begin {}", lsp_types::request::HoverRequest::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
 
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::HoverRequest::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::HoverRequest::METHOD,
             TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -1335,10 +1392,10 @@ impl LanguageClient {
             return Ok(result);
         }
 
-        let hover: Option<Hover> = serde_json::from_value(result.clone())?;
+        let hover = Option::<Hover>::deserialize(&result)?;
         if let Some(hover) = hover {
-            let hoverPreview = self.get(|state| state.hoverPreview)?;
-            let use_preview = match hoverPreview {
+            let hover_preview = self.get(|state| state.hover_preview)?;
+            let use_preview = match hover_preview {
                 HoverPreviewOption::Always => true,
                 HoverPreviewOption::Never => false,
                 HoverPreviewOption::Auto => hover.lines_len() > 1,
@@ -1350,18 +1407,18 @@ impl LanguageClient {
             }
         }
 
-        info!("End {}", lsp::request::HoverRequest::METHOD);
+        info!("End {}", lsp_types::request::HoverRequest::METHOD);
         Ok(result)
     }
 
     /// Generic find locations, e.g, definitions, references.
     pub fn find_locations(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
+        self.text_document_did_change(params)?;
         let method: String =
             try_get("method", params)?.ok_or_else(|| err_msg("method not found in request!"))?;
         info!("Begin {}", method);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
         let current_word = self.vim()?.get_current_word(params)?;
         let goto_cmd = self.vim()?.get_goto_cmd(params)?;
@@ -1374,13 +1431,15 @@ impl LanguageClient {
         })?
         .combine(params);
 
-        let result = self.get_client(&Some(languageId))?.call(&method, &params)?;
+        let result = self
+            .get_client(&Some(language_id))?
+            .call(&method, &params)?;
 
         if !self.vim()?.get_handle(&params)? {
             return Ok(result);
         }
 
-        let response: Option<GotoDefinitionResponse> = result.clone().to_lsp()?;
+        let response = Option::<GotoDefinitionResponse>::deserialize(&result)?;
 
         let locations = match response {
             None => vec![],
@@ -1418,11 +1477,11 @@ impl LanguageClient {
         Ok(result)
     }
 
-    pub fn textDocument_rename(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::Rename::METHOD);
+    pub fn text_document_rename(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!("Begin {}", lsp_types::request::Rename::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
         let current_word = self.vim()?.get_current_word(params)?;
         let new_name: Option<String> = try_get("newName", params)?;
@@ -1438,8 +1497,8 @@ impl LanguageClient {
             return Ok(Value::Null);
         }
 
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::Rename::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::Rename::METHOD,
             RenameParams {
                 text_document_position: TextDocumentPositionParams {
                     text_document: TextDocumentIdentifier {
@@ -1460,21 +1519,24 @@ impl LanguageClient {
         }
 
         let edit: WorkspaceEdit = serde_json::from_value(result.clone())?;
-        self.apply_WorkspaceEdit(&edit)?;
+        self.apply_workspace_edit(&edit)?;
 
-        info!("End {}", lsp::request::Rename::METHOD);
+        info!("End {}", lsp_types::request::Rename::METHOD);
         Ok(result)
     }
 
-    pub fn textDocument_documentSymbol(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::DocumentSymbolRequest::METHOD);
+    pub fn text_document_document_symbol(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!(
+            "Begin {}",
+            lsp_types::request::DocumentSymbolRequest::METHOD
+        );
 
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::DocumentSymbolRequest::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::DocumentSymbolRequest::METHOD,
             DocumentSymbolParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -1488,17 +1550,17 @@ impl LanguageClient {
             return Ok(result);
         }
 
-        let syms: <lsp::request::DocumentSymbolRequest as lsp::request::Request>::Result =
+        let syms: <lsp_types::request::DocumentSymbolRequest as lsp_types::request::Request>::Result =
             serde_json::from_value(result.clone())?;
 
         let title = format!("[LC]: symbols for {}", filename);
 
-        let selectionUI = self.get(|state| state.selectionUI)?;
-        let selectionUI_autoOpen = self.get(|state| state.selectionUI_autoOpen)?;
-        match selectionUI {
+        let selection_ui = self.get(|state| state.selection_ui)?;
+        let selection_ui_auto_open = self.get(|state| state.selection_ui_auto_open)?;
+        match selection_ui {
             SelectionUI::FZF => {
                 let symbols = match syms {
-                    Some(lsp::DocumentSymbolResponse::Flat(flat)) => flat
+                    Some(lsp_types::DocumentSymbolResponse::Flat(flat)) => flat
                         .iter()
                         .map(|sym| {
                             let start = sym.location.range.start;
@@ -1511,13 +1573,13 @@ impl LanguageClient {
                             )
                         })
                         .collect(),
-                    Some(lsp::DocumentSymbolResponse::Nested(nested)) => {
+                    Some(lsp_types::DocumentSymbolResponse::Nested(nested)) => {
                         let mut symbols = Vec::new();
 
                         fn walk_document_symbol(
                             buffer: &mut Vec<String>,
                             parent: Option<&str>,
-                            ds: &lsp::DocumentSymbol,
+                            ds: &lsp_types::DocumentSymbol,
                         ) {
                             let start = ds.selection_range.start;
 
@@ -1555,15 +1617,15 @@ impl LanguageClient {
 
                 self.vim()?.rpcclient.notify(
                     "s:FZF",
-                    json!([symbols, format!("s:{}", NOTIFICATION__FZFSinkLocation)]),
+                    json!([symbols, format!("s:{}", NOTIFICATION_FZF_SINK_LOCATION)]),
                 )?;
             }
             SelectionUI::Quickfix => {
                 let list = match syms {
-                    Some(lsp::DocumentSymbolResponse::Flat(flat)) => {
+                    Some(lsp_types::DocumentSymbolResponse::Flat(flat)) => {
                         flat.iter().map(QuickfixEntry::from_lsp).collect()
                     }
-                    Some(lsp::DocumentSymbolResponse::Nested(nested)) => {
+                    Some(lsp_types::DocumentSymbolResponse::Nested(nested)) => {
                         <Vec<QuickfixEntry>>::from_lsp(&nested)
                     }
                     _ => Ok(Vec::new()),
@@ -1571,7 +1633,7 @@ impl LanguageClient {
 
                 let list = list?;
                 self.vim()?.setqflist(&list, " ", &title)?;
-                if selectionUI_autoOpen {
+                if selection_ui_auto_open {
                     self.vim()?.command("botright copen")?;
                 }
                 self.vim()?
@@ -1579,10 +1641,10 @@ impl LanguageClient {
             }
             SelectionUI::LocationList => {
                 let list = match syms {
-                    Some(lsp::DocumentSymbolResponse::Flat(flat)) => {
+                    Some(lsp_types::DocumentSymbolResponse::Flat(flat)) => {
                         flat.iter().map(QuickfixEntry::from_lsp).collect()
                     }
-                    Some(lsp::DocumentSymbolResponse::Nested(nested)) => {
+                    Some(lsp_types::DocumentSymbolResponse::Nested(nested)) => {
                         <Vec<QuickfixEntry>>::from_lsp(&nested)
                     }
                     _ => Ok(Vec::new()),
@@ -1590,7 +1652,7 @@ impl LanguageClient {
 
                 let list = list?;
                 self.vim()?.setloclist(&list, " ", &title)?;
-                if selectionUI_autoOpen {
+                if selection_ui_auto_open {
                     self.vim()?.command("lopen")?;
                 }
                 self.vim()?
@@ -1598,15 +1660,15 @@ impl LanguageClient {
             }
         }
 
-        info!("End {}", lsp::request::DocumentSymbolRequest::METHOD);
+        info!("End {}", lsp_types::request::DocumentSymbolRequest::METHOD);
         Ok(result)
     }
 
-    pub fn textDocument_codeAction(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::CodeActionRequest::METHOD);
+    pub fn text_document_code_action(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!("Begin {}", lsp_types::request::CodeActionRequest::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let range: Range = serde_json::from_value(params["range"].clone())?;
 
         // Unify filename.
@@ -1623,8 +1685,8 @@ impl LanguageClient {
                 .collect()
         })?;
 
-        let result: Value = self.get_client(&Some(languageId))?.call(
-            lsp::request::CodeActionRequest::METHOD,
+        let result: Value = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::CodeActionRequest::METHOD,
             CodeActionParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -1640,7 +1702,7 @@ impl LanguageClient {
         )?;
 
         let response: Option<CodeActionResponse> = serde_json::from_value(result.clone())?;
-        let response = response.unwrap_or_else(|| vec![]);
+        let response = response.unwrap_or_default();
 
         // Convert any Commands into CodeActions, so that the remainder of the handling can be
         // shared.
@@ -1665,7 +1727,7 @@ impl LanguageClient {
             .collect();
 
         self.update(|state| {
-            state.stashed_codeAction_actions = actions;
+            state.stashed_code_action_actions = actions;
             Ok(())
         })?;
 
@@ -1675,21 +1737,21 @@ impl LanguageClient {
 
         self.vim()?
             .rpcclient
-            .notify("s:FZF", json!([source, NOTIFICATION__FZFSinkCommand]))?;
+            .notify("s:FZF", json!([source, NOTIFICATION_FZF_SINK_COMMAND]))?;
 
-        info!("End {}", lsp::request::CodeActionRequest::METHOD);
+        info!("End {}", lsp_types::request::CodeActionRequest::METHOD);
         Ok(result)
     }
 
-    pub fn textDocument_completion(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::Completion::METHOD);
+    pub fn text_document_completion(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", lsp_types::request::Completion::METHOD);
 
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
 
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::Completion::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::Completion::METHOD,
             TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -1702,19 +1764,19 @@ impl LanguageClient {
             return Ok(result);
         }
 
-        info!("End {}", lsp::request::Completion::METHOD);
+        info!("End {}", lsp_types::request::Completion::METHOD);
         Ok(result)
     }
 
-    pub fn textDocument_signatureHelp(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::SignatureHelpRequest::METHOD);
+    pub fn text_document_signature_help(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!("Begin {}", lsp_types::request::SignatureHelpRequest::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
 
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::SignatureHelpRequest::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::SignatureHelpRequest::METHOD,
             TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -1756,7 +1818,7 @@ impl LanguageClient {
         }
 
         if let Some((begin, label, end)) = active_parameter.and_then(|active_parameter| {
-            decode_parameterLabel(&active_parameter.label, &active_signature.label).ok()
+            decode_parameter_label(&active_parameter.label, &active_signature.label).ok()
         }) {
             let cmd = format!(
                 "echo | echon '{}' | echohl WarningMsg | echon '{}' | echohl None | echon '{}'",
@@ -1767,17 +1829,17 @@ impl LanguageClient {
             self.vim()?.echo(&active_signature.label)?;
         }
 
-        info!("End {}", lsp::request::SignatureHelpRequest::METHOD);
+        info!("End {}", lsp_types::request::SignatureHelpRequest::METHOD);
         Ok(Value::Null)
     }
 
-    pub fn textDocument_references(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::References::METHOD);
+    pub fn text_document_references(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", lsp_types::request::References::METHOD);
 
         let include_declaration: bool = try_get("includeDeclaration", params)?.unwrap_or(true);
         // TODO: cleanup.
         let params = json!({
-            "method": lsp::request::References::METHOD,
+            "method": lsp_types::request::References::METHOD,
             "context": ReferenceContext {
                 include_declaration,
             }
@@ -1785,20 +1847,20 @@ impl LanguageClient {
         .combine(params);
         let result = self.find_locations(&params)?;
 
-        info!("End {}", lsp::request::References::METHOD);
+        info!("End {}", lsp_types::request::References::METHOD);
         Ok(result)
     }
 
-    pub fn textDocument_formatting(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::Formatting::METHOD);
+    pub fn text_document_formatting(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!("Begin {}", lsp_types::request::Formatting::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
         let tab_size = self.vim()?.get_tab_size()?;
         let insert_spaces = self.vim()?.get_insert_spaces(&filename)?;
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::Formatting::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::Formatting::METHOD,
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -1819,20 +1881,20 @@ impl LanguageClient {
 
         let text_edits: Option<Vec<TextEdit>> = serde_json::from_value(result.clone())?;
         let text_edits = text_edits.unwrap_or_default();
-        let edit = lsp::WorkspaceEdit {
+        let edit = lsp_types::WorkspaceEdit {
             changes: Some(hashmap! {filename.to_url()? => text_edits}),
             document_changes: None,
         };
-        self.apply_WorkspaceEdit(&edit)?;
-        info!("End {}", lsp::request::Formatting::METHOD);
+        self.apply_workspace_edit(&edit)?;
+        info!("End {}", lsp_types::request::Formatting::METHOD);
         Ok(result)
     }
 
-    pub fn textDocument_rangeFormatting(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::RangeFormatting::METHOD);
+    pub fn text_document_range_formatting(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!("Begin {}", lsp_types::request::RangeFormatting::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let start_line = try_get("range_start_line", params)?
             .map_or_else(|| self.vim()?.eval("LSP#range_start_line()"), Ok)?;
         let end_line = try_get("range_end_line", params)?
@@ -1840,8 +1902,8 @@ impl LanguageClient {
 
         let tab_size = self.vim()?.get_tab_size()?;
         let insert_spaces = self.vim()?.get_insert_spaces(&filename)?;
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::RangeFormatting::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::RangeFormatting::METHOD,
             DocumentRangeFormattingParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -1872,26 +1934,30 @@ impl LanguageClient {
 
         let text_edits: Option<Vec<TextEdit>> = serde_json::from_value(result.clone())?;
         let text_edits = text_edits.unwrap_or_default();
-        let edit = lsp::WorkspaceEdit {
+        let edit = lsp_types::WorkspaceEdit {
             changes: Some(hashmap! {filename.to_url()? => text_edits}),
             document_changes: None,
         };
-        self.apply_WorkspaceEdit(&edit)?;
-        info!("End {}", lsp::request::RangeFormatting::METHOD);
+        self.apply_workspace_edit(&edit)?;
+        info!("End {}", lsp_types::request::RangeFormatting::METHOD);
         Ok(result)
     }
 
-    pub fn completionItem_resolve(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::ResolveCompletionItem::METHOD);
+    pub fn completion_item_resolve(&self, params: &Value) -> Fallible<Value> {
+        self.text_document_did_change(params)?;
+        info!(
+            "Begin {}",
+            lsp_types::request::ResolveCompletionItem::METHOD
+        );
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let completion_item: CompletionItem = try_get("completionItem", params)?
             .ok_or_else(|| err_msg("completionItem not found in request!"))?;
 
-        let result = self
-            .get_client(&Some(languageId))?
-            .call(lsp::request::ResolveCompletionItem::METHOD, completion_item)?;
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::ResolveCompletionItem::METHOD,
+            completion_item,
+        )?;
 
         if !self.vim()?.get_handle(params)? {
             return Ok(result);
@@ -1902,19 +1968,19 @@ impl LanguageClient {
         warn!("{}", msg);
         self.vim()?.echowarn(&msg)?;
 
-        info!("End {}", lsp::request::ResolveCompletionItem::METHOD);
+        info!("End {}", lsp_types::request::ResolveCompletionItem::METHOD);
         Ok(Value::Null)
     }
 
     pub fn workspace_symbol(&self, params: &Value) -> Fallible<Value> {
-        self.textDocument_didChange(params)?;
-        info!("Begin {}", lsp::request::WorkspaceSymbol::METHOD);
+        self.text_document_did_change(params)?;
+        info!("Begin {}", lsp_types::request::WorkspaceSymbol::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
         let query = try_get("query", params)?.unwrap_or_default();
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::WorkspaceSymbol::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::WorkspaceSymbol::METHOD,
             WorkspaceSymbolParams {
                 query,
                 partial_result_params: PartialResultParams::default(),
@@ -1929,9 +1995,9 @@ impl LanguageClient {
         let symbols: Vec<SymbolInformation> = serde_json::from_value(result.clone())?;
         let title = "[LC]: workspace symbols";
 
-        let selectionUI = self.get(|state| state.selectionUI)?;
-        let selectionUI_autoOpen = self.get(|state| state.selectionUI_autoOpen)?;
-        match selectionUI {
+        let selection_ui = self.get(|state| state.selection_ui)?;
+        let selection_ui_auto_open = self.get(|state| state.selection_ui_auto_open)?;
+        match selection_ui {
             SelectionUI::FZF => {
                 let cwd: String = self.vim()?.eval("getcwd()")?;
                 let source: Fallible<Vec<_>> = symbols
@@ -1954,14 +2020,14 @@ impl LanguageClient {
 
                 self.vim()?.rpcclient.notify(
                     "s:FZF",
-                    json!([source, format!("s:{}", NOTIFICATION__FZFSinkLocation)]),
+                    json!([source, format!("s:{}", NOTIFICATION_FZF_SINK_LOCATION)]),
                 )?;
             }
             SelectionUI::Quickfix => {
                 let list: Fallible<Vec<_>> = symbols.iter().map(QuickfixEntry::from_lsp).collect();
                 let list = list?;
                 self.vim()?.setqflist(&list, " ", title)?;
-                if selectionUI_autoOpen {
+                if selection_ui_auto_open {
                     self.vim()?.command("botright copen")?;
                 }
                 self.vim()?
@@ -1971,7 +2037,7 @@ impl LanguageClient {
                 let list: Fallible<Vec<_>> = symbols.iter().map(QuickfixEntry::from_lsp).collect();
                 let list = list?;
                 self.vim()?.setloclist(&list, " ", title)?;
-                if selectionUI_autoOpen {
+                if selection_ui_auto_open {
                     self.vim()?.command("lopen")?;
                 }
                 self.vim()?
@@ -1979,61 +2045,64 @@ impl LanguageClient {
             }
         }
 
-        info!("End {}", lsp::request::WorkspaceSymbol::METHOD);
+        info!("End {}", lsp_types::request::WorkspaceSymbol::METHOD);
         Ok(result)
     }
 
-    pub fn workspace_executeCommand(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::ExecuteCommand::METHOD);
+    pub fn workspace_execute_command(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", lsp_types::request::ExecuteCommand::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let command: String =
             try_get("command", params)?.ok_or_else(|| err_msg("command not found in request!"))?;
         let arguments: Vec<Value> = try_get("arguments", params)?.unwrap_or_default();
 
-        let result = self.get_client(&Some(languageId))?.call(
-            lsp::request::ExecuteCommand::METHOD,
+        let result = self.get_client(&Some(language_id))?.call(
+            lsp_types::request::ExecuteCommand::METHOD,
             ExecuteCommandParams {
                 command,
                 arguments,
                 work_done_progress_params: WorkDoneProgressParams::default(),
             },
         )?;
-        info!("End {}", lsp::request::ExecuteCommand::METHOD);
+        info!("End {}", lsp_types::request::ExecuteCommand::METHOD);
         Ok(result)
     }
 
-    pub fn workspace_applyEdit(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::ApplyWorkspaceEdit::METHOD);
+    pub fn workspace_apply_edit(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", lsp_types::request::ApplyWorkspaceEdit::METHOD);
 
-        let params: ApplyWorkspaceEditParams = params.clone().to_lsp()?;
-        self.apply_WorkspaceEdit(&params.edit)?;
+        let params = ApplyWorkspaceEditParams::deserialize(params)?;
+        self.apply_workspace_edit(&params.edit)?;
 
-        info!("End {}", lsp::request::ApplyWorkspaceEdit::METHOD);
+        info!("End {}", lsp_types::request::ApplyWorkspaceEdit::METHOD);
 
         Ok(serde_json::to_value(ApplyWorkspaceEditResponse {
             applied: true,
         })?)
     }
 
-    pub fn workspace_didChangeConfiguration(&self, params: &Value) -> Fallible<()> {
+    pub fn workspace_did_change_configuration(&self, params: &Value) -> Fallible<()> {
         info!(
             "Begin {}",
-            lsp::notification::DidChangeConfiguration::METHOD
+            lsp_types::notification::DidChangeConfiguration::METHOD
         );
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let settings: Value = try_get("settings", params)?.unwrap_or_default();
 
-        self.get_client(&Some(languageId))?.notify(
-            lsp::notification::DidChangeConfiguration::METHOD,
+        self.get_client(&Some(language_id))?.notify(
+            lsp_types::notification::DidChangeConfiguration::METHOD,
             DidChangeConfigurationParams { settings },
         )?;
-        info!("End {}", lsp::notification::DidChangeConfiguration::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::DidChangeConfiguration::METHOD
+        );
         Ok(())
     }
 
-    pub fn languageClient_handleCodeLensAction(&self, params: &Value) -> Fallible<Value> {
+    pub fn handle_code_lens_action(&self, params: &Value) -> Fallible<Value> {
         let filename = self.vim()?.get_filename(params)?;
         let line = self.vim()?.get_position(params)?.line;
 
@@ -2068,7 +2137,7 @@ impl LanguageClient {
                 })
                 .filter(|c| c.is_ok())
                 .collect();
-            state.stashed_codeAction_actions = actions?;
+            state.stashed_code_action_actions = actions?;
             Ok(())
         })?;
 
@@ -2083,7 +2152,7 @@ impl LanguageClient {
 
         self.vim()?
             .rpcclient
-            .notify("s:FZF", json!([source?, NOTIFICATION__FZFSinkCommand]))?;
+            .notify("s:FZF", json!([source?, NOTIFICATION_FZF_SINK_COMMAND]))?;
 
         Ok(Value::Null)
     }
@@ -2118,7 +2187,7 @@ impl LanguageClient {
         Ok(())
     }
 
-    pub fn textDocument_codeLens(&self, params: &Value) -> Fallible<Value> {
+    pub fn text_document_code_lens(&self, params: &Value) -> Fallible<Value> {
         let use_virtual_text = self.get(|state| state.use_virtual_text.clone())?;
         if UseVirtualText::No == use_virtual_text || UseVirtualText::Diagnostics == use_virtual_text
         {
@@ -2126,7 +2195,7 @@ impl LanguageClient {
         }
 
         let filename = self.vim()?.get_filename(params)?;
-        let language_id = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let capabilities = self.get(|state| state.capabilities.clone())?;
         if let Some(initialize_result) = capabilities.get(&language_id) {
             // XXX: the capabilities state field stores the initialize result, not the capabilities
@@ -2136,9 +2205,9 @@ impl LanguageClient {
             let capabilities = initialize_result.capabilities;
 
             if let Some(code_lens_provider) = capabilities.code_lens_provider {
-                info!("Begin {}", lsp::request::CodeLensRequest::METHOD);
+                info!("Begin {}", lsp_types::request::CodeLensRequest::METHOD);
                 let client = self.get_client(&Some(language_id))?;
-                let input = lsp::CodeLensParams {
+                let input = lsp_types::CodeLensParams {
                     text_document: TextDocumentIdentifier {
                         uri: filename.to_url()?,
                     },
@@ -2146,7 +2215,8 @@ impl LanguageClient {
                     partial_result_params: PartialResultParams::default(),
                 };
 
-                let results: Value = client.call(lsp::request::CodeLensRequest::METHOD, &input)?;
+                let results: Value =
+                    client.call(lsp_types::request::CodeLensRequest::METHOD, &input)?;
                 let code_lens: Option<Vec<CodeLens>> = serde_json::from_value(results)?;
                 let mut code_lens: Vec<CodeLens> = code_lens.unwrap_or_default();
 
@@ -2159,7 +2229,7 @@ impl LanguageClient {
                             }
 
                             client
-                                .call(lsp::request::CodeLensResolve::METHOD, &cl)
+                                .call(lsp_types::request::CodeLensResolve::METHOD, &cl)
                                 .unwrap_or(cl)
                         })
                         .collect();
@@ -2170,11 +2240,11 @@ impl LanguageClient {
                     Ok(Value::Null)
                 })?;
 
-                info!("End {}", lsp::request::CodeLensRequest::METHOD);
+                info!("End {}", lsp_types::request::CodeLensRequest::METHOD);
             } else {
                 info!(
                     "CodeLens not supported. Skipping {}",
-                    lsp::request::CodeLensRequest::METHOD
+                    lsp_types::request::CodeLensRequest::METHOD
                 );
             }
         }
@@ -2186,15 +2256,18 @@ impl LanguageClient {
         Ok(Value::Null)
     }
 
-    pub fn textDocument_didOpen(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::DidOpenTextDocument::METHOD);
+    pub fn text_document_did_open(&self, params: &Value) -> Fallible<()> {
+        info!(
+            "Begin {}",
+            lsp_types::notification::DidOpenTextDocument::METHOD
+        );
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let text = self.vim()?.get_text(&filename)?;
 
         let text_document = TextDocumentItem {
             uri: filename.to_url()?,
-            language_id: languageId.clone(),
+            language_id: language_id.clone(),
             version: 0,
             text: text.join("\n"),
         };
@@ -2205,14 +2278,14 @@ impl LanguageClient {
                 .insert(filename.clone(), text_document.clone()))
         })?;
 
-        self.get_client(&Some(languageId.clone()))?.notify(
-            lsp::notification::DidOpenTextDocument::METHOD,
+        self.get_client(&Some(language_id.clone()))?.notify(
+            lsp_types::notification::DidOpenTextDocument::METHOD,
             DidOpenTextDocumentParams { text_document },
         )?;
 
         self.vim()?
             .command("setlocal omnifunc=LanguageClient#complete")?;
-        let root = self.get(|state| state.roots.get(&languageId).cloned().unwrap_or_default())?;
+        let root = self.get(|state| state.roots.get(&language_id).cloned().unwrap_or_default())?;
         self.vim()?.rpcclient.notify(
             "setbufvar",
             json!([filename, "LanguageClient_projectRoot", root]),
@@ -2221,19 +2294,25 @@ impl LanguageClient {
             .rpcclient
             .notify("s:ExecuteAutocmd", "LanguageClientTextDocumentDidOpenPost")?;
 
-        self.textDocument_codeLens(params)?;
+        self.text_document_code_lens(params)?;
 
-        info!("End {}", lsp::notification::DidOpenTextDocument::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::DidOpenTextDocument::METHOD
+        );
         Ok(())
     }
 
-    pub fn textDocument_didChange(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::DidChangeTextDocument::METHOD);
+    pub fn text_document_did_change(&self, params: &Value) -> Fallible<()> {
+        info!(
+            "Begin {}",
+            lsp_types::notification::DidChangeTextDocument::METHOD
+        );
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         if !self.get(|state| state.text_documents.contains_key(&filename))? {
             info!("Not opened yet. Switching to didOpen.");
-            return self.textDocument_didOpen(params);
+            return self.text_document_did_open(params);
         }
 
         let text = self.vim()?.get_text(&filename)?.join("\n");
@@ -2268,8 +2347,8 @@ impl LanguageClient {
             Ok(version)
         })?;
 
-        self.get_client(&Some(languageId))?.notify(
-            lsp::notification::DidChangeTextDocument::METHOD,
+        self.get_client(&Some(language_id))?.notify(
+            lsp_types::notification::DidChangeTextDocument::METHOD,
             DidChangeTextDocumentParams {
                 text_document: VersionedTextDocumentIdentifier {
                     uri: filename.to_url()?,
@@ -2283,54 +2362,72 @@ impl LanguageClient {
             },
         )?;
 
-        self.textDocument_codeLens(params)?;
+        self.text_document_code_lens(params)?;
 
-        info!("End {}", lsp::notification::DidChangeTextDocument::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::DidChangeTextDocument::METHOD
+        );
         Ok(())
     }
 
-    pub fn textDocument_didSave(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::DidSaveTextDocument::METHOD);
+    pub fn text_document_did_save(&self, params: &Value) -> Fallible<()> {
+        info!(
+            "Begin {}",
+            lsp_types::notification::DidSaveTextDocument::METHOD
+        );
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
-        if !self.get(|state| state.serverCommands.contains_key(&languageId))? {
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
+        if !self.get(|state| state.server_commands.contains_key(&language_id))? {
             return Ok(());
         }
 
         let uri = filename.to_url()?;
 
-        self.get_client(&Some(languageId))?.notify(
-            lsp::notification::DidSaveTextDocument::METHOD,
+        self.get_client(&Some(language_id))?.notify(
+            lsp_types::notification::DidSaveTextDocument::METHOD,
             DidSaveTextDocumentParams {
                 text_document: TextDocumentIdentifier { uri },
             },
         )?;
 
-        info!("End {}", lsp::notification::DidSaveTextDocument::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::DidSaveTextDocument::METHOD
+        );
         Ok(())
     }
 
-    pub fn textDocument_didClose(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::DidCloseTextDocument::METHOD);
+    pub fn text_document_did_close(&self, params: &Value) -> Fallible<()> {
+        info!(
+            "Begin {}",
+            lsp_types::notification::DidCloseTextDocument::METHOD
+        );
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
-        self.get_client(&Some(languageId))?.notify(
-            lsp::notification::DidCloseTextDocument::METHOD,
+        self.get_client(&Some(language_id))?.notify(
+            lsp_types::notification::DidCloseTextDocument::METHOD,
             DidCloseTextDocumentParams {
                 text_document: TextDocumentIdentifier {
                     uri: filename.to_url()?,
                 },
             },
         )?;
-        info!("End {}", lsp::notification::DidCloseTextDocument::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::DidCloseTextDocument::METHOD
+        );
         Ok(())
     }
 
-    pub fn textDocument_publishDiagnostics(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::PublishDiagnostics::METHOD);
-        let params: PublishDiagnosticsParams = params.clone().to_lsp()?;
-        if !self.get(|state| state.diagnosticsEnable)? {
+    pub fn text_document_publish_diagnostics(&self, params: &Value) -> Fallible<()> {
+        info!(
+            "Begin {}",
+            lsp_types::notification::PublishDiagnostics::METHOD
+        );
+        let params = PublishDiagnosticsParams::deserialize(params)?;
+        if !self.get(|state| state.diagnostics_enable)? {
             return Ok(());
         }
 
@@ -2360,7 +2457,7 @@ impl LanguageClient {
         })?;
         self.update_quickfixlist()?;
 
-        let mut severityCount: HashMap<String, u64> = [
+        let mut severity_count: HashMap<String, u64> = [
             (
                 DiagnosticSeverity::Error
                     .to_quickfix_entry_type()
@@ -2396,7 +2493,7 @@ impl LanguageClient {
                 .unwrap_or(DiagnosticSeverity::Hint)
                 .to_quickfix_entry_type()
                 .to_string();
-            let count = severityCount.entry(severity).or_insert(0);
+            let count = severity_count.entry(severity).or_insert(0);
             *count += 1;
         }
 
@@ -2408,7 +2505,7 @@ impl LanguageClient {
             if bufnr > 0 {
                 self.vim()?.rpcclient.notify(
                     "setbufvar",
-                    json!([filename, VIM__StatusLineDiagnosticsCounts, severityCount]),
+                    json!([filename, VIM_STATUS_LINE_DIAGNOSTICS_COUNTS, severity_count]),
                 )?;
             }
         }
@@ -2432,18 +2529,24 @@ impl LanguageClient {
         });
 
         self.process_diagnostics(&current_filename, &diagnostics)?;
-        self.languageClient_handleCursorMoved(&Value::Null)?;
+        self.handle_cursor_moved(&Value::Null)?;
         self.vim()?
             .rpcclient
             .notify("s:ExecuteAutocmd", "LanguageClientDiagnosticsChanged")?;
 
-        info!("End {}", lsp::notification::PublishDiagnostics::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::PublishDiagnostics::METHOD
+        );
         Ok(())
     }
 
-    pub fn textDocument_semanticHighlight(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::SemanticHighlighting::METHOD);
-        let mut params: SemanticHighlightingParams = params.clone().to_lsp()?;
+    pub fn text_document_semantic_highlight(&self, params: &Value) -> Fallible<()> {
+        info!(
+            "Begin {}",
+            lsp_types::notification::SemanticHighlighting::METHOD
+        );
+        let mut params = SemanticHighlightingParams::deserialize(params)?;
 
         // TODO: Do we need to handle the versioning of the file?
         let mut filename = params
@@ -2458,12 +2561,12 @@ impl LanguageClient {
         }
         // Unify name to avoid mismatch due to case insensitivity.
         let filename = filename.canonicalize();
-        let languageId = self.vim()?.get_languageId(&filename, &Value::Null)?;
+        let language_id = self.vim()?.get_language_id(&filename, &Value::Null)?;
 
         let opt_hl_table = self.get(|state| {
             state
                 .semantic_scope_to_hl_group_table
-                .get(&languageId)
+                .get(&language_id)
                 .cloned()
         })?;
 
@@ -2575,9 +2678,9 @@ impl LanguageClient {
 
                 let old_semantic_hl_state = state
                     .semantic_highlights
-                    .insert(languageId.clone(), semantic_hl_state);
+                    .insert(language_id.clone(), semantic_hl_state);
 
-                let semantic_hl_state = state.semantic_highlights.get_mut(&languageId).unwrap();
+                let semantic_hl_state = state.semantic_highlights.get_mut(&language_id).unwrap();
 
                 let mut combined_hls = Vec::with_capacity(highlights.len());
 
@@ -2644,42 +2747,45 @@ impl LanguageClient {
             self.update(|state| {
                 state
                     .semantic_highlights
-                    .insert(languageId.clone(), semantic_hl_state);
+                    .insert(language_id.clone(), semantic_hl_state);
                 Ok(())
             })?;
         }
 
-        info!("End {}", lsp::notification::SemanticHighlighting::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::SemanticHighlighting::METHOD
+        );
         Ok(())
     }
 
-    pub fn window_logMessage(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::LogMessage::METHOD);
-        let params: LogMessageParams = params.clone().to_lsp()?;
-        let threshold = self.get(|state| state.windowLogMessageLevel.to_int())??;
+    pub fn window_log_message(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", lsp_types::notification::LogMessage::METHOD);
+        let params = LogMessageParams::deserialize(params)?;
+        let threshold = self.get(|state| state.window_log_message_level.to_int())??;
         if params.typ.to_int()? > threshold {
             return Ok(());
         }
 
         let msg = format!("[{:?}] {}", params.typ, params.message);
         self.vim()?.echomsg(&msg)?;
-        info!("End {}", lsp::notification::LogMessage::METHOD);
+        info!("End {}", lsp_types::notification::LogMessage::METHOD);
         Ok(())
     }
 
-    pub fn window_showMessage(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::ShowMessage::METHOD);
-        let params: ShowMessageParams = params.clone().to_lsp()?;
+    pub fn window_show_message(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", lsp_types::notification::ShowMessage::METHOD);
+        let params = ShowMessageParams::deserialize(params)?;
         let msg = format!("[{:?}] {}", params.typ, params.message);
         self.vim()?.echomsg(&msg)?;
-        info!("End {}", lsp::notification::ShowMessage::METHOD);
+        info!("End {}", lsp_types::notification::ShowMessage::METHOD);
         Ok(())
     }
 
-    pub fn window_showMessageRequest(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::ShowMessageRequest::METHOD);
+    pub fn window_show_message_request(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", lsp_types::request::ShowMessageRequest::METHOD);
         let mut v = Value::Null;
-        let msg_params: ShowMessageRequestParams = params.clone().to_lsp()?;
+        let msg_params = ShowMessageRequestParams::deserialize(params)?;
         let msg = format!("[{:?}] {}", msg_params.typ, msg_params.message);
         let msg_actions = msg_params.actions.unwrap_or_default();
         if msg_actions.is_empty() {
@@ -2700,31 +2806,31 @@ impl LanguageClient {
             }
         }
 
-        info!("End {}", lsp::request::ShowMessageRequest::METHOD);
+        info!("End {}", lsp_types::request::ShowMessageRequest::METHOD);
         Ok(v)
     }
 
-    pub fn client_registerCapability(&self, languageId: &str, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::RegisterCapability::METHOD);
-        let params: RegistrationParams = params.clone().to_lsp()?;
+    pub fn client_register_capability(&self, language_id: &str, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", lsp_types::request::RegisterCapability::METHOD);
+        let params = RegistrationParams::deserialize(params)?;
         for r in &params.registrations {
             match r.method.as_str() {
-                lsp::notification::DidChangeWatchedFiles::METHOD => {
+                lsp_types::notification::DidChangeWatchedFiles::METHOD => {
                     let opt: DidChangeWatchedFilesRegistrationOptions =
                         serde_json::from_value(r.register_options.clone().unwrap_or_default())?;
-                    if !self.get(|state| state.watchers.contains_key(languageId))? {
+                    if !self.get(|state| state.watchers.contains_key(language_id))? {
                         let (watcher_tx, watcher_rx) = mpsc::channel();
                         // TODO: configurable duration.
                         let watcher = notify::watcher(watcher_tx, Duration::from_secs(2))?;
                         self.update(|state| {
-                            state.watchers.insert(languageId.to_owned(), watcher);
-                            state.watcher_rxs.insert(languageId.to_owned(), watcher_rx);
+                            state.watchers.insert(language_id.to_owned(), watcher);
+                            state.watcher_rxs.insert(language_id.to_owned(), watcher_rx);
                             Ok(())
                         })?;
                     }
 
                     self.update(|state| {
-                        if let Some(ref mut watcher) = state.watchers.get_mut(languageId) {
+                        if let Some(ref mut watcher) = state.watchers.get_mut(language_id) {
                             for w in &opt.watchers {
                                 let recursive_mode = if w.glob_pattern.ends_with("**") {
                                     notify::RecursiveMode::Recursive
@@ -2748,13 +2854,17 @@ impl LanguageClient {
             state.registrations.extend(params.registrations);
             Ok(())
         })?;
-        info!("End {}", lsp::request::RegisterCapability::METHOD);
+        info!("End {}", lsp_types::request::RegisterCapability::METHOD);
         Ok(Value::Null)
     }
 
-    pub fn client_unregisterCapability(&self, languageId: &str, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", lsp::request::UnregisterCapability::METHOD);
-        let params: UnregistrationParams = params.clone().to_lsp()?;
+    pub fn client_unregister_capability(
+        &self,
+        language_id: &str,
+        params: &Value,
+    ) -> Fallible<Value> {
+        info!("Begin {}", lsp_types::request::UnregisterCapability::METHOD);
+        let params = UnregistrationParams::deserialize(params)?;
         let mut regs_removed = vec![];
         for r in &params.unregisterations {
             if let Some(idx) = self.get(|state| {
@@ -2769,11 +2879,11 @@ impl LanguageClient {
 
         for r in &regs_removed {
             match r.method.as_str() {
-                lsp::notification::DidChangeWatchedFiles::METHOD => {
+                lsp_types::notification::DidChangeWatchedFiles::METHOD => {
                     let opt: DidChangeWatchedFilesRegistrationOptions =
                         serde_json::from_value(r.register_options.clone().unwrap_or_default())?;
                     self.update(|state| {
-                        if let Some(ref mut watcher) = state.watchers.get_mut(languageId) {
+                        if let Some(ref mut watcher) = state.watchers.get_mut(language_id) {
                             for w in opt.watchers {
                                 watcher.unwatch(w.glob_pattern)?;
                             }
@@ -2787,93 +2897,93 @@ impl LanguageClient {
             }
         }
 
-        info!("End {}", lsp::request::UnregisterCapability::METHOD);
+        info!("End {}", lsp_types::request::UnregisterCapability::METHOD);
         Ok(Value::Null)
     }
 
     pub fn exit(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::Exit::METHOD);
+        info!("Begin {}", lsp_types::notification::Exit::METHOD);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
         let result = self
-            .get_client(&Some(languageId.clone()))?
-            .notify(lsp::notification::Exit::METHOD, Value::Null);
+            .get_client(&Some(language_id.clone()))?
+            .notify(lsp_types::notification::Exit::METHOD, Value::Null);
         if let Err(err) = result {
             error!("Error: {:?}", err);
         }
 
         self.vim()?
             .rpcclient
-            .notify("setbufvar", json!([filename, VIM__IsServerRunning, 0]))?;
+            .notify("setbufvar", json!([filename, VIM_IS_SERVER_RUNNING, 0]))?;
 
-        if let Err(err) = self.cleanup(&languageId) {
+        if let Err(err) = self.cleanup(&language_id) {
             error!("Error: {:?}", err);
         }
-        info!("End {}", lsp::notification::Exit::METHOD);
+        info!("End {}", lsp_types::notification::Exit::METHOD);
         Ok(())
     }
 
     /////// Extensions by this plugin ///////
 
-    pub fn languageClient_getState(&self, _params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__GetState);
+    pub fn get_state(&self, _params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_GET_STATE);
         let s = self.get(|state| serde_json::to_string(state))??;
-        info!("End {}", REQUEST__GetState);
+        info!("End {}", REQUEST_GET_STATE);
         Ok(Value::String(s))
     }
 
-    pub fn languageClient_isAlive(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__IsAlive);
+    pub fn is_alive(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_IS_ALIVE);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
-        let is_alive = self.get(|state| state.clients.contains_key(&Some(languageId.clone())))?;
-        info!("End {}", REQUEST__IsAlive);
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
+        let is_alive = self.get(|state| state.clients.contains_key(&Some(language_id.clone())))?;
+        info!("End {}", REQUEST_IS_ALIVE);
         Ok(Value::Bool(is_alive))
     }
 
-    pub fn languageClient_registerServerCommands(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__RegisterServerCommands);
-        let commands: HashMap<String, Vec<String>> = params.clone().to_lsp()?;
+    pub fn register_server_commands(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_REGISTER_SERVER_COMMANDS);
+        let commands = HashMap::<String, Vec<String>>::deserialize(params)?;
         self.update(|state| {
-            state.serverCommands.extend(commands);
+            state.server_commands.extend(commands);
             Ok(())
         })?;
         let exp = format!(
             "let g:LanguageClient_serverCommands={}",
-            serde_json::to_string(&self.get(|state| state.serverCommands.clone())?)?
+            serde_json::to_string(&self.get(|state| state.server_commands.clone())?)?
         );
         self.vim()?.command(&exp)?;
-        info!("End {}", REQUEST__RegisterServerCommands);
+        info!("End {}", REQUEST_REGISTER_SERVER_COMMANDS);
         Ok(Value::Null)
     }
 
-    pub fn languageClient_setLoggingLevel(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__SetLoggingLevel);
-        let loggingLevel =
+    pub fn set_logging_level(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_SET_LOGGING_LEVEL);
+        let logging_level =
             try_get("loggingLevel", params)?.ok_or_else(|| err_msg("loggingLevel not found!"))?;
         self.update(|state| {
-            state.logger.set_level(loggingLevel)?;
+            state.logger.set_level(logging_level)?;
             Ok(())
         })?;
-        info!("End {}", REQUEST__SetLoggingLevel);
+        info!("End {}", REQUEST_SET_LOGGING_LEVEL);
         Ok(Value::Null)
     }
 
-    pub fn languageClient_setDiagnosticsList(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__SetDiagnosticsList);
-        let diagnosticsList = try_get("diagnosticsList", params)?
+    pub fn set_diagnostics_list(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_SET_DIAGNOSTICS_LIST);
+        let diagnostics_list = try_get("diagnosticsList", params)?
             .ok_or_else(|| err_msg("diagnosticsList not found!"))?;
         self.update(|state| {
-            state.diagnosticsList = diagnosticsList;
+            state.diagnostics_list = diagnostics_list;
             Ok(())
         })?;
-        info!("End {}", REQUEST__SetDiagnosticsList);
+        info!("End {}", REQUEST_SET_DIAGNOSTICS_LIST);
         Ok(Value::Null)
     }
 
-    pub fn languageClient_registerHandlers(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__RegisterHandlers);
+    pub fn register_handlers(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_REGISTER_HANDLERS);
         let handlers: Fallible<HashMap<String, String>> = params
             .as_object()
             .ok_or_else(|| err_msg("Invalid arguments!"))?
@@ -2895,13 +3005,13 @@ impl LanguageClient {
             state.user_handlers.extend(handlers);
             Ok(())
         })?;
-        info!("End {}", REQUEST__RegisterHandlers);
+        info!("End {}", REQUEST_REGISTER_HANDLERS);
         Ok(Value::Null)
     }
 
-    pub fn languageClient_omniComplete(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__OmniComplete);
-        let result = self.textDocument_completion(params)?;
+    pub fn omnicomplete(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_OMNI_COMPLETE);
+        let result = self.text_document_completion(params)?;
         let result: Option<CompletionResponse> = serde_json::from_value(result)?;
         let result = result.unwrap_or_else(|| CompletionResponse::Array(vec![]));
         let matches = match result {
@@ -2916,77 +3026,77 @@ impl LanguageClient {
             .map(|item| VimCompleteItem::from_lsp(item, complete_position))
             .collect();
         let matches = matches?;
-        info!("End {}", REQUEST__OmniComplete);
+        info!("End {}", REQUEST_OMNI_COMPLETE);
         Ok(serde_json::to_value(matches)?)
     }
 
-    pub fn languageClient_handleBufNewFile(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__HandleBufNewFile);
+    pub fn handle_buf_new_file(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_HANDLE_BUF_NEW_FILE);
         if self.vim()?.get_filename(params)?.is_empty() {
             return Ok(());
         }
 
-        let autoStart: u8 = self
+        let auto_start: u8 = self
             .vim()?
             .eval("!!get(g:, 'LanguageClient_autoStart', 1)")?;
-        if autoStart == 1 {
-            let ret = self.languageClient_startServer(params);
+        if auto_start == 1 {
+            let ret = self.start_server(params);
             // This is triggered from autocmd, silent all errors.
             if let Err(err) = ret {
                 warn!("Failed to start language server automatically. {}", err);
             }
         }
 
-        info!("End {}", NOTIFICATION__HandleBufNewFile);
+        info!("End {}", NOTIFICATION_HANDLE_BUF_NEW_FILE);
         Ok(())
     }
 
-    pub fn languageClient_handleBufEnter(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__HandleBufEnter);
+    pub fn handle_buf_enter(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_HANDLE_BUF_ENTER);
         if self.vim()?.get_filename(params)?.is_empty() {
             return Ok(());
         }
 
         let filename = self.vim()?.get_filename(params)?.canonicalize();
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
-        if self.get(|state| state.clients.contains_key(&Some(languageId.clone())))? {
+        if self.get(|state| state.clients.contains_key(&Some(language_id.clone())))? {
             self.vim()?
                 .rpcclient
-                .notify("setbufvar", json!([filename, VIM__IsServerRunning, 1]))?;
+                .notify("setbufvar", json!([filename, VIM_IS_SERVER_RUNNING, 1]))?;
         } else {
             self.vim()?
                 .rpcclient
-                .notify("setbufvar", json!([filename, VIM__IsServerRunning, 0]))?;
+                .notify("setbufvar", json!([filename, VIM_IS_SERVER_RUNNING, 0]))?;
         }
-        info!("End {}", NOTIFICATION__HandleBufEnter);
+        info!("End {}", NOTIFICATION_HANDLE_BUF_ENTER);
         Ok(())
     }
 
-    pub fn languageClient_handleFileType(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__HandleFileType);
+    pub fn handle_file_type(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_HANDLE_FILE_TYPE);
         if self.vim()?.get_filename(params)?.is_empty() {
             return Ok(());
         }
 
         let filename = self.vim()?.get_filename(params)?.canonicalize();
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
-        if self.get(|state| state.clients.contains_key(&Some(languageId.clone())))? {
-            self.textDocument_didOpen(params)?;
+        if self.get(|state| state.clients.contains_key(&Some(language_id.clone())))? {
+            self.text_document_did_open(params)?;
 
             if let Some(diagnostics) =
                 self.get(|state| state.diagnostics.get(&filename).cloned())?
             {
                 self.process_diagnostics(&filename, &diagnostics)?;
-                self.languageClient_handleCursorMoved(params)?;
+                self.handle_cursor_moved(params)?;
             }
         } else {
-            let autoStart: u8 = self
+            let auto_start: u8 = self
                 .vim()?
                 .eval("!!get(g:, 'LanguageClient_autoStart', 1)")?;
-            if autoStart == 1 {
-                let ret = self.languageClient_startServer(params);
+            if auto_start == 1 {
+                let ret = self.start_server(params);
                 // This is triggered from autocmd, silent all errors.
                 if let Err(err) = ret {
                     warn!("Failed to start language server automatically. {}", err);
@@ -2994,15 +3104,15 @@ impl LanguageClient {
             }
         }
 
-        info!("End {}", NOTIFICATION__HandleFileType);
+        info!("End {}", NOTIFICATION_HANDLE_FILE_TYPE);
         Ok(())
     }
 
-    pub fn languageClient_handleTextChanged(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__HandleTextChanged);
+    pub fn handle_text_changed(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_HANDLE_TEXT_CHANGED);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
-        if !self.get(|state| state.serverCommands.contains_key(&languageId))? {
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
+        if !self.get(|state| state.server_commands.contains_key(&language_id))? {
             return Ok(());
         }
 
@@ -3021,23 +3131,23 @@ impl LanguageClient {
             return Ok(());
         }
 
-        self.textDocument_didChange(params)?;
-        info!("End {}", NOTIFICATION__HandleTextChanged);
+        self.text_document_did_change(params)?;
+        info!("End {}", NOTIFICATION_HANDLE_TEXT_CHANGED);
         Ok(())
     }
 
-    pub fn languageClient_handleBufWritePost(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__HandleBufWritePost);
-        self.textDocument_didSave(params)?;
-        info!("End {}", NOTIFICATION__HandleBufWritePost);
+    pub fn handle_buf_write_post(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_HANDLE_BUF_WRITE_POST);
+        self.text_document_did_save(params)?;
+        info!("End {}", NOTIFICATION_HANDLE_BUF_WRITE_POST);
         Ok(())
     }
 
-    pub fn languageClient_handleBufDelete(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__HandleBufWritePost);
+    pub fn handle_buf_delete(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_HANDLE_BUF_WRITE_POST);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
-        if !self.get(|state| state.serverCommands.contains_key(&languageId))? {
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
+        if !self.get(|state| state.server_commands.contains_key(&language_id))? {
             return Ok(());
         }
 
@@ -3048,17 +3158,17 @@ impl LanguageClient {
             state.signs.retain(|f, _| f != &filename);
             Ok(())
         })?;
-        self.textDocument_didClose(params)?;
-        info!("End {}", NOTIFICATION__HandleBufWritePost);
+        self.text_document_did_close(params)?;
+        info!("End {}", NOTIFICATION_HANDLE_BUF_WRITE_POST);
         Ok(())
     }
 
-    pub fn languageClient_handleCursorMoved(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__HandleCursorMoved);
+    pub fn handle_cursor_moved(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_HANDLE_CURSOR_MOVED);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let line = self.vim()?.get_position(params)?.line;
-        if !self.get(|state| state.serverCommands.contains_key(&languageId))? {
+        if !self.get(|state| state.server_commands.contains_key(&language_id))? {
             return Ok(());
         }
         if !self.get(|state| state.diagnostics.contains_key(&filename))?
@@ -3110,7 +3220,7 @@ impl LanguageClient {
             diagnostics.dedup_by_key(|diag| diag.range.start.line);
             Ok(diagnostics
                 .into_iter()
-                .take(state.diagnosticsSignsMax.unwrap_or(std::usize::MAX))
+                .take(state.diagnostics_signs_max.unwrap_or(std::usize::MAX))
                 .map(Into::into)
                 .collect())
         })?;
@@ -3156,7 +3266,7 @@ impl LanguageClient {
             Ok(state
                 .highlights
                 .entry(filename.clone())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .iter()
                 .filter_map(|h| {
                     if h.line < viewport.start || h.line > viewport.end {
@@ -3206,7 +3316,7 @@ impl LanguageClient {
         let bufnr = self.vim()?.get_bufnr(&filename, params)?;
         self.draw_virtual_texts(&filename, viewport, bufnr)?;
 
-        info!("End {}", NOTIFICATION__HandleCursorMoved);
+        info!("End {}", NOTIFICATION_HANDLE_CURSOR_MOVED);
         Ok(())
     }
 
@@ -3255,7 +3365,7 @@ impl LanguageClient {
     ) -> Fallible<Vec<VirtualText>> {
         let mut virtual_texts = vec![];
         let diagnostics = self.get(|state| state.diagnostics.clone())?;
-        let diagnosticsDisplay = self.get(|state| state.diagnosticsDisplay.clone())?;
+        let diagnostics_display = self.get(|state| state.diagnostics_display.clone())?;
         let diag_list = diagnostics.get(filename);
         if let Some(diag_list) = diag_list {
             for diag in diag_list {
@@ -3263,10 +3373,10 @@ impl LanguageClient {
                     virtual_texts.push(VirtualText {
                         line: diag.range.start.line,
                         text: diag.message.replace("\n", "  ").clone(),
-                        hl_group: diagnosticsDisplay
+                        hl_group: diagnostics_display
                             .get(&(diag.severity.unwrap_or(DiagnosticSeverity::Hint) as u64))
                             .ok_or_else(|| err_msg("Failed to get display"))?
-                            .virtualTexthl
+                            .virtual_texthl
                             .clone(),
                     });
                 }
@@ -3305,7 +3415,7 @@ impl LanguageClient {
         Ok(virtual_texts)
     }
 
-    pub fn languageClient_handleCompleteDone(&self, params: &Value) -> Fallible<()> {
+    pub fn handle_complete_done(&self, params: &Value) -> Fallible<()> {
         let filename = self.vim()?.get_filename(params)?;
         let position = self.vim()?.get_position(params)?;
         let completed_item: VimCompleteItem = try_get("completed_item", params)?
@@ -3322,7 +3432,7 @@ impl LanguageClient {
         };
 
         let mut edits = vec![];
-        if self.get(|state| state.completionPreferTextEdit)? {
+        if self.get(|state| state.completion_prefer_text_edit)? {
             if let Some(CompletionTextEdit::InsertAndReplace(_)) = lspitem.text_edit {
                 error!("insert and replace is not supported");
             }
@@ -3345,7 +3455,7 @@ impl LanguageClient {
             }
         }
 
-        if self.get(|state| state.applyCompletionAdditionalTextEdits)? {
+        if self.get(|state| state.apply_completion_additional_text_edits)? {
             if let Some(aedits) = lspitem.additional_text_edits {
                 edits.extend(aedits);
             };
@@ -3355,13 +3465,13 @@ impl LanguageClient {
             return Ok(());
         }
 
-        let position = self.apply_TextEdits(filename, &edits, position)?;
+        let position = self.apply_text_edits(filename, &edits, position)?;
         self.vim()?
             .cursor(position.line + 1, position.character + 1)
     }
 
-    pub fn languageClient_FZFSinkLocation(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__FZFSinkLocation);
+    pub fn fzf_sink_location(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_FZF_SINK_LOCATION);
         let params = match params {
             Value::Array(ref arr) => Value::Array(arr.clone()),
             _ => {
@@ -3405,12 +3515,12 @@ impl LanguageClient {
         self.edit(&None, &filename)?;
         self.vim()?.cursor(line + 1, character + 1)?;
 
-        info!("End {}", NOTIFICATION__FZFSinkLocation);
+        info!("End {}", NOTIFICATION_FZF_SINK_LOCATION);
         Ok(())
     }
 
-    pub fn languageClient_FZFSinkCommand(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__FZFSinkCommand);
+    pub fn fzf_sink_command(&self, params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_FZF_SINK_COMMAND);
         let selection: String =
             try_get("selection", params)?.ok_or_else(|| err_msg("selection not found!"))?;
         let tokens: Vec<&str> = selection.splitn(2, ": ").collect();
@@ -3423,7 +3533,7 @@ impl LanguageClient {
             .cloned()
             .ok_or_else(|| format_err!("Failed to get title! tokens: {:?}", tokens))?;
         let action = self.get(|state| {
-            let actions = &state.stashed_codeAction_actions;
+            let actions = &state.stashed_code_action_actions;
 
             actions
                 .iter()
@@ -3436,7 +3546,7 @@ impl LanguageClient {
 
         // Apply edit before command.
         if let Some(edit) = &action.edit {
-            self.apply_WorkspaceEdit(edit)?;
+            self.apply_workspace_edit(edit)?;
         }
 
         if let Some(command) = &action.command {
@@ -3445,33 +3555,33 @@ impl LanguageClient {
                 "command": command.command,
                 "arguments": command.arguments,
                 });
-                self.workspace_executeCommand(&params)?;
+                self.workspace_execute_command(&params)?;
             }
         }
 
         self.update(|state| {
-            state.stashed_codeAction_actions = vec![];
+            state.stashed_code_action_actions = vec![];
             Ok(())
         })?;
 
-        info!("End {}", NOTIFICATION__FZFSinkCommand);
+        info!("End {}", NOTIFICATION_FZF_SINK_COMMAND);
         Ok(())
     }
 
-    pub fn languageClient_semanticScopes(&self, params: &Value) -> Fallible<Value> {
+    pub fn semantic_scopes(&self, params: &Value) -> Fallible<Value> {
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
         let (scopes, mut scope_mapping) = self.get(|state| {
             (
                 state
                     .semantic_scopes
-                    .get(&languageId)
+                    .get(&language_id)
                     .cloned()
                     .unwrap_or_default(),
                 state
                     .semantic_scope_to_hl_group_table
-                    .get(&languageId)
+                    .get(&language_id)
                     .cloned()
                     .unwrap_or_default(),
             )
@@ -3501,14 +3611,14 @@ impl LanguageClient {
         Ok(json!(semantic_scopes))
     }
 
-    pub fn languageClient_semanticHlSyms(&self, params: &Value) -> Fallible<Value> {
+    pub fn semantic_highlight_symbols(&self, params: &Value) -> Fallible<Value> {
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
         let (opt_scopes, opt_hl_state) = self.get(|state| {
             (
-                state.semantic_scopes.get(&languageId).cloned(),
-                state.semantic_highlights.get(&languageId).cloned(),
+                state.semantic_scopes.get(&language_id).cloned(),
+                state.semantic_highlights.get(&language_id).cloned(),
             )
         })?;
 
@@ -3532,9 +3642,10 @@ impl LanguageClient {
         }
     }
 
-    pub fn NCM_refresh(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__NCMRefresh);
-        let params: NCMRefreshParams = serde_json::from_value(rpc::to_value(params.clone())?)?;
+    pub fn ncm_refresh(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_NCM_REFRESH);
+        let params: NCMRefreshParams =
+            serde_json::from_value(jsonrpc_core::to_value(params.clone())?)?;
         let NCMRefreshParams { info, ctx } = params;
         if ctx.typed.is_empty() {
             return Ok(Value::Null);
@@ -3544,7 +3655,7 @@ impl LanguageClient {
         let line = ctx.lnum - 1;
         let character = ctx.col - 1;
 
-        let result = self.textDocument_completion(&json!({
+        let result = self.text_document_completion(&json!({
             "languageId": ctx.filetype,
             "filename": filename,
             "line": line,
@@ -3569,14 +3680,14 @@ impl LanguageClient {
             "cm#complete",
             json!([info.name, ctx, ctx.startcol, matches, is_incomplete]),
         )?;
-        info!("End {}", REQUEST__NCMRefresh);
+        info!("End {}", REQUEST_NCM_REFRESH);
         Ok(Value::Null)
     }
 
-    pub fn NCM2_on_complete(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__NCM2OnComplete);
+    pub fn ncm2_on_complete(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_NCM2_ON_COMPLETE);
 
-        let orig_ctx: Value = serde_json::from_value(rpc::to_value(params.clone())?)?;
+        let orig_ctx: Value = serde_json::from_value(jsonrpc_core::to_value(params.clone())?)?;
         let orig_ctx = &orig_ctx["ctx"];
 
         let ctx: NCM2Context = serde_json::from_value(orig_ctx.clone())?;
@@ -3588,7 +3699,7 @@ impl LanguageClient {
         let line = ctx.lnum - 1;
         let character = ctx.ccol - 1;
 
-        let result = self.textDocument_completion(&json!({
+        let result = self.text_document_completion(&json!({
                 "languageId": ctx.filetype,
                 "filename": filename,
                 "line": line,
@@ -3618,12 +3729,12 @@ impl LanguageClient {
             "ncm2#complete",
             json!([orig_ctx, ctx.startccol, matches, is_incomplete]),
         )?;
-        info!("End {}", REQUEST__NCM2OnComplete);
+        info!("End {}", REQUEST_NCM2_ON_COMPLETE);
         result
     }
 
-    pub fn languageClient_explainErrorAtPoint(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__ExplainErrorAtPoint);
+    pub fn explain_error_at_point(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_EXPLAIN_ERROR_AT_POINT);
         let filename = self.vim()?.get_filename(params)?;
         let position = self.vim()?.get_position(params)?;
         let diag = self.get(|state| {
@@ -3644,18 +3755,18 @@ impl LanguageClient {
                 })
         })??;
 
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
-        let root = self.get(|state| state.roots.get(&languageId).cloned().unwrap_or_default())?;
-        let rootUri = root.to_url()?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
+        let root = self.get(|state| state.roots.get(&language_id).cloned().unwrap_or_default())?;
+        let root_uri = root.to_url()?;
 
         let mut explanation = diag.message;
         if let Some(related_information) = diag.related_information {
             explanation = format!("{}\n", explanation);
             for ri in related_information {
-                let prefix = format!("{}/", rootUri);
+                let prefix = format!("{}/", root_uri);
                 let uri = if ri.location.uri.as_str().starts_with(prefix.as_str()) {
                     // Heuristic: if start of stringified URI matches rootUri, abbreviate it away
-                    &ri.location.uri.as_str()[rootUri.as_str().len() + 1..]
+                    &ri.location.uri.as_str()[root_uri.as_str().len() + 1..]
                 } else {
                     ri.location.uri.as_str()
                 };
@@ -3676,53 +3787,56 @@ impl LanguageClient {
 
         self.preview(explanation.as_str())?;
 
-        info!("End {}", REQUEST__ExplainErrorAtPoint);
+        info!("End {}", REQUEST_EXPLAIN_ERROR_AT_POINT);
         Ok(Value::Null)
     }
 
     // Extensions by language servers.
     pub fn language_status(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__LanguageStatus);
-        let params: LanguageStatusParams = params.clone().to_lsp()?;
+        info!("Begin {}", NOTIFICATION_LANGUAGE_STATUS);
+        let params = LanguageStatusParams::deserialize(params)?;
         let msg = format!("{} {}", params.typee, params.message);
         self.vim()?.echomsg(&msg)?;
-        info!("End {}", NOTIFICATION__LanguageStatus);
+        info!("End {}", NOTIFICATION_LANGUAGE_STATUS);
         Ok(())
     }
 
-    pub fn rust_handleBeginBuild(&self, _params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__RustBeginBuild);
+    pub fn rust_handle_begin_build(&self, _params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_RUST_BEGIN_BUILD);
         self.vim()?.command(vec![
-            format!("let {}=1", VIM__ServerStatus),
-            format!("let {}='Rust: build begin'", VIM__ServerStatusMessage),
+            format!("let {}=1", VIM_SERVER_STATUS),
+            format!("let {}='Rust: build begin'", VIM_SERVER_STATUS_MESSAGE),
         ])?;
-        info!("End {}", NOTIFICATION__RustBeginBuild);
+        info!("End {}", NOTIFICATION_RUST_BEGIN_BUILD);
         Ok(())
     }
 
-    pub fn rust_handleDiagnosticsBegin(&self, _params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__RustDiagnosticsBegin);
+    pub fn rust_handle_diagnostics_begin(&self, _params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_RUST_DIAGNOSTICS_BEGIN);
         self.vim()?.command(vec![
-            format!("let {}=1", VIM__ServerStatus),
-            format!("let {}='Rust: diagnostics begin'", VIM__ServerStatusMessage),
+            format!("let {}=1", VIM_SERVER_STATUS),
+            format!(
+                "let {}='Rust: diagnostics begin'",
+                VIM_SERVER_STATUS_MESSAGE
+            ),
         ])?;
-        info!("End {}", NOTIFICATION__RustDiagnosticsBegin);
+        info!("End {}", NOTIFICATION_RUST_DIAGNOSTICS_BEGIN);
         Ok(())
     }
 
-    pub fn rust_handleDiagnosticsEnd(&self, _params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__RustDiagnosticsEnd);
+    pub fn rust_handle_diagnostics_end(&self, _params: &Value) -> Fallible<()> {
+        info!("Begin {}", NOTIFICATION_RUST_DIAGNOSTICS_END);
         self.vim()?.command(vec![
-            format!("let {}=0", VIM__ServerStatus),
-            format!("let {}='Rust: diagnostics end'", VIM__ServerStatusMessage),
+            format!("let {}=0", VIM_SERVER_STATUS),
+            format!("let {}='Rust: diagnostics end'", VIM_SERVER_STATUS_MESSAGE),
         ])?;
-        info!("End {}", NOTIFICATION__RustDiagnosticsEnd);
+        info!("End {}", NOTIFICATION_RUST_DIAGNOSTICS_END);
         Ok(())
     }
 
     pub fn window_progress(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", NOTIFICATION__WindowProgress);
-        let params: WindowProgressParams = params.clone().to_lsp()?;
+        info!("Begin {}", NOTIFICATION_WINDOW_PROGRESS);
+        let params = WindowProgressParams::deserialize(params)?;
 
         let done = params.done.unwrap_or(false);
 
@@ -3745,21 +3859,21 @@ impl LanguageClient {
         }
 
         self.vim()?.command(vec![
-            format!("let {}={}", VIM__ServerStatus, if done { 0 } else { 1 }),
+            format!("let {}={}", VIM_SERVER_STATUS, if done { 0 } else { 1 }),
             format!(
                 "let {}='{}'",
-                VIM__ServerStatusMessage,
+                VIM_SERVER_STATUS_MESSAGE,
                 &escape_single_quote(buf)
             ),
         ])?;
-        info!("End {}", NOTIFICATION__WindowProgress);
+        info!("End {}", NOTIFICATION_WINDOW_PROGRESS);
         Ok(())
     }
 
-    pub fn languageClient_startServer(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__StartServer);
+    pub fn start_server(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_START_SERVER);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let cmdargs: Vec<String> = try_get("cmdargs", params)?.unwrap_or_default();
         let cmdparams = vim_cmd_args_to_value(&cmdargs)?;
         let params = params.combine(&cmdparams);
@@ -3778,16 +3892,16 @@ impl LanguageClient {
         //   (ensure that the mutex is acquired by what starts the group of servers)
         //
         // TODO: May want to lock other methods that update the list of clients.
-        let mutex_for_language_id = self.get_client_update_mutex(Some(languageId.clone()))?;
+        let mutex_for_language_id = self.get_client_update_mutex(Some(language_id.clone()))?;
         let _raii_lock: MutexGuard<()> = mutex_for_language_id.lock().map_err(|err| {
             format_err!(
                 "Failed to lock client creation for languageId {:?}: {:?}",
-                languageId,
+                language_id,
                 err
             )
         })?;
 
-        if self.get(|state| state.clients.contains_key(&Some(languageId.clone())))? {
+        if self.get(|state| state.clients.contains_key(&Some(language_id.clone())))? {
             return Ok(json!({}));
         }
 
@@ -3795,21 +3909,21 @@ impl LanguageClient {
         info!("settings synced");
 
         let command = self
-            .get(|state| state.serverCommands.get(&languageId).cloned())?
+            .get(|state| state.server_commands.get(&language_id).cloned())?
             .ok_or_else(|| {
                 Error::from(LCError::NoServerCommands {
-                    languageId: languageId.clone(),
+                    language_id: language_id.clone(),
                 })
             })?;
 
-        let rootPath: Option<String> = try_get("rootPath", &params)?;
-        let root = if let Some(r) = rootPath {
+        let root_path: Option<String> = try_get("rootPath", &params)?;
+        let root = if let Some(r) = root_path {
             r
         } else {
-            get_rootPath(
+            get_root_path(
                 Path::new(&filename),
-                &languageId,
-                &self.get(|state| state.rootMarkers.clone())?,
+                &language_id,
+                &self.get(|state| state.root_markers.clone())?,
             )?
             .to_string_lossy()
             .into()
@@ -3820,7 +3934,7 @@ impl LanguageClient {
         }
         info!("{}", message);
         self.update(|state| {
-            state.roots.insert(languageId.clone(), root.clone());
+            state.roots.insert(language_id.clone(), root.clone());
             Ok(())
         })?;
 
@@ -3846,7 +3960,7 @@ impl LanguageClient {
                     })
                     .collect();
 
-                let stderr = match self.get(|state| state.serverStderr.clone())? {
+                let stderr = match self.get(|state| state.server_stderr.clone())? {
                     Some(ref path) => std::fs::OpenOptions::new()
                         .create(true)
                         .append(true)
@@ -3884,7 +3998,7 @@ impl LanguageClient {
             };
 
         let client = RpcClient::new(
-            Some(languageId.clone()),
+            Some(language_id.clone()),
             reader,
             writer,
             child_id,
@@ -3893,11 +4007,11 @@ impl LanguageClient {
         self.update(|state| {
             state
                 .clients
-                .insert(Some(languageId.clone()), Arc::new(client));
+                .insert(Some(language_id.clone()), Arc::new(client));
             Ok(())
         })?;
 
-        info!("End {}", REQUEST__StartServer);
+        info!("End {}", REQUEST_START_SERVER);
 
         if self.get(|state| state.clients.len())? == 2 {
             self.define_signs()?;
@@ -3906,11 +4020,11 @@ impl LanguageClient {
         self.initialize(&params)?;
         self.initialized(&params)?;
 
-        let root = self.get(|state| state.roots.get(&languageId).cloned().unwrap_or_default())?;
+        let root = self.get(|state| state.roots.get(&language_id).cloned().unwrap_or_default())?;
         match self.get_workspace_settings(&root) {
             Ok(Value::Null) => (),
-            Ok(settings) => self.workspace_didChangeConfiguration(&json!({
-                "languageId": languageId,
+            Ok(settings) => self.workspace_did_change_configuration(&json!({
+                "languageId": language_id,
                 "settings": settings,
             }))?,
             Err(err) => warn!("Failed to get workspace settings: {}", err),
@@ -3918,10 +4032,10 @@ impl LanguageClient {
 
         self.vim()?
             .rpcclient
-            .notify("setbufvar", json!([filename, VIM__IsServerRunning, 1]))?;
+            .notify("setbufvar", json!([filename, VIM_IS_SERVER_RUNNING, 1]))?;
 
-        self.textDocument_didOpen(&params)?;
-        self.textDocument_didChange(&params)?;
+        self.text_document_did_open(&params)?;
+        self.text_document_did_change(&params)?;
 
         self.vim()?
             .rpcclient
@@ -3929,18 +4043,18 @@ impl LanguageClient {
         Ok(Value::Null)
     }
 
-    pub fn languageClient_serverExited(&self, params: &Value) -> Fallible<()> {
+    pub fn handle_server_exited(&self, params: &Value) -> Fallible<()> {
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let message: String = try_get("message", params)?.unwrap_or_default();
 
-        if self.get(|state| state.clients.contains_key(&Some(languageId.clone())))? {
-            if let Err(err) = self.cleanup(&languageId) {
+        if self.get(|state| state.clients.contains_key(&Some(language_id.clone())))? {
+            if let Err(err) = self.cleanup(&language_id) {
                 error!("Error in cleanup: {:?}", err);
             }
             if let Err(err) = self.vim()?.echoerr(format!(
                 "Language server {} exited unexpectedly: {}",
-                languageId, message
+                language_id, message
             )) {
                 error!("Error in echoerr: {:?}", err);
             }
@@ -3952,7 +4066,7 @@ impl LanguageClient {
     pub fn handle_fs_events(&self) -> Fallible<()> {
         let mut pending_changes = HashMap::new();
         self.update(|state| {
-            for (languageId, watcher_rx) in &mut state.watcher_rxs {
+            for (language_id, watcher_rx) in &mut state.watcher_rxs {
                 let mut events = vec![];
                 loop {
                     let result = watcher_rx.try_recv();
@@ -3979,14 +4093,14 @@ impl LanguageClient {
                     continue;
                 }
 
-                pending_changes.insert(languageId.to_owned(), changes);
+                pending_changes.insert(language_id.to_owned(), changes);
             }
             Ok(())
         })?;
 
-        for (languageId, changes) in pending_changes {
-            self.workspace_didChangeWatchedFiles(&json!({
-                "languageId": languageId,
+        for (language_id, changes) in pending_changes {
+            self.workspace_did_change_watched_files(&json!({
+                "languageId": language_id,
                 "changes": changes
             }))?;
         }
@@ -3994,27 +4108,35 @@ impl LanguageClient {
         Ok(())
     }
 
-    pub fn workspace_didChangeWatchedFiles(&self, params: &Value) -> Fallible<()> {
-        info!("Begin {}", lsp::notification::DidChangeWatchedFiles::METHOD);
+    pub fn workspace_did_change_watched_files(&self, params: &Value) -> Fallible<()> {
+        info!(
+            "Begin {}",
+            lsp_types::notification::DidChangeWatchedFiles::METHOD
+        );
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
-        let params: DidChangeWatchedFilesParams = params.clone().to_lsp()?;
-        self.get_client(&Some(languageId))?
-            .notify(lsp::notification::DidChangeWatchedFiles::METHOD, params)?;
+        let params = DidChangeWatchedFilesParams::deserialize(params)?;
+        self.get_client(&Some(language_id))?.notify(
+            lsp_types::notification::DidChangeWatchedFiles::METHOD,
+            params,
+        )?;
 
-        info!("End {}", lsp::notification::DidChangeWatchedFiles::METHOD);
+        info!(
+            "End {}",
+            lsp_types::notification::DidChangeWatchedFiles::METHOD
+        );
         Ok(())
     }
 
-    pub fn java_classFileContents(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__ClassFileContents);
+    pub fn java_class_file_contents(&self, params: &Value) -> Fallible<Value> {
+        info!("Begin {}", REQUEST_CLASS_FILE_CONTENTS);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
 
         let content: String = self
-            .get_client(&Some(languageId))?
-            .call(REQUEST__ClassFileContents, params)?;
+            .get_client(&Some(language_id))?
+            .call(REQUEST_CLASS_FILE_CONTENTS, params)?;
 
         let lines: Vec<String> = content
             .lines()
@@ -4037,37 +4159,37 @@ impl LanguageClient {
         self.vim()?
             .command("setlocal buftype=nofile filetype=java noswapfile")?;
 
-        info!("End {}", REQUEST__ClassFileContents);
+        info!("End {}", REQUEST_CLASS_FILE_CONTENTS);
         Ok(Value::String(content))
     }
 
     pub fn debug_info(&self, params: &Value) -> Fallible<Value> {
-        info!("Begin {}", REQUEST__DebugInfo);
+        info!("Begin {}", REQUEST_DEBUG_INFO);
         let filename = self.vim()?.get_filename(params)?;
-        let languageId = self.vim()?.get_languageId(&filename, params)?;
+        let language_id = self.vim()?.get_language_id(&filename, params)?;
         let mut msg = String::new();
         self.get(|state| {
             msg += &format!(
                 "Project root: {}\n",
-                state.roots.get(&languageId).cloned().unwrap_or_default()
+                state.roots.get(&language_id).cloned().unwrap_or_default()
             );
             msg += &format!(
                 "Language server process id: {:?}\n",
                 state
                     .clients
-                    .get(&Some(languageId.clone()))
+                    .get(&Some(language_id.clone()))
                     .map(|c| c.process_id)
                     .unwrap_or_default(),
             );
             msg += &format!(
                 "Language server stderr: {}\n",
-                state.serverStderr.clone().unwrap_or_default()
+                state.server_stderr.clone().unwrap_or_default()
             );
             msg += &format!("Log level: {}\n", state.logger.level);
             msg += &format!("Log file: {:?}\n", state.logger.path);
         })?;
         self.vim()?.echo(&msg)?;
-        info!("End {}", REQUEST__DebugInfo);
+        info!("End {}", REQUEST_DEBUG_INFO);
         Ok(json!(msg))
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,9 +1,12 @@
-use super::*;
 use derivative::Derivative;
+use failure::{Fallible, ResultExt};
 use log::LevelFilter;
 use log4rs::append::file::FileAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
+use serde::Serialize;
+use std::io::Write;
+use std::path::PathBuf;
 
 #[derive(Derivative)]
 #[derivative(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,57 +1,20 @@
-#![allow(non_snake_case, non_upper_case_globals)]
-#![deny(clippy::option_unwrap_used)]
-
-use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
-use std::fs::{read_to_string, File};
-use std::io::prelude::*;
-use std::io::{BufRead, BufReader, BufWriter};
-use std::net::TcpStream;
-use std::ops::Deref;
-use std::path::{Path, PathBuf};
-use std::process::{ChildStdin, ChildStdout, Stdio};
-use std::str::FromStr;
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::thread;
-use std::time::{Duration, Instant};
-
-use log::{debug, error, info, log_enabled, warn};
-
-#[allow(unused_imports)]
-use failure::{bail, err_msg, format_err, Error, Fail, ResultExt};
-
-use maplit::hashmap;
-
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-#[macro_use]
-extern crate serde_derive;
-use serde_json::json;
-
-use jsonrpc_core::{self as rpc, Params, Value};
-
-use lsp_types::{self as lsp, *};
-
-use url::Url;
-
-use pathdiff::diff_paths;
-
-use structopt::StructOpt;
-
-mod types;
-use crate::types::*;
-mod utils;
-use crate::utils::*;
 mod language_client;
 mod language_server_protocol;
 mod logger;
+mod rpcclient;
 mod rpchandler;
 mod sign;
+mod types;
+mod utils;
 mod viewport;
 mod vim;
 mod vimext;
 
-mod rpcclient;
+use failure::Fallible;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use structopt::StructOpt;
+use types::State;
 
 #[derive(Debug, StructOpt)]
 struct Arguments {}

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -1,7 +1,9 @@
-use super::*;
-use crate::language_client::LanguageClient;
-use crate::lsp::notification::Notification;
-use crate::lsp::request::Request;
+use crate::{language_client::LanguageClient, types::*};
+use failure::{err_msg, Fallible};
+use log::*;
+use lsp_types::notification::{self, Notification};
+use lsp_types::request::{self, Request};
+use serde_json::Value;
 
 fn is_content_modified_error(err: &failure::Error) -> bool {
     match err.as_fail().downcast_ref::<LSError>() {
@@ -61,8 +63,8 @@ impl LanguageClient {
 
     pub fn handle_method_call(
         &self,
-        languageId: Option<&str>,
-        method_call: &rpc::MethodCall,
+        language_id: Option<&str>,
+        method_call: &jsonrpc_core::MethodCall,
     ) -> Fallible<Value> {
         let params = serde_json::to_value(method_call.params.clone())?;
 
@@ -73,53 +75,51 @@ impl LanguageClient {
         }
 
         match method_call.method.as_str() {
-            lsp::request::RegisterCapability::METHOD => {
-                self.client_registerCapability(languageId.unwrap_or_default(), &params)
+            request::RegisterCapability::METHOD => {
+                self.client_register_capability(language_id.unwrap_or_default(), &params)
             }
-            lsp::request::UnregisterCapability::METHOD => {
-                self.client_unregisterCapability(languageId.unwrap_or_default(), &params)
+            request::UnregisterCapability::METHOD => {
+                self.client_unregister_capability(language_id.unwrap_or_default(), &params)
             }
-            lsp::request::HoverRequest::METHOD => self.textDocument_hover(&params),
-            REQUEST__FindLocations => self.find_locations(&params),
-            lsp::request::Rename::METHOD => self.textDocument_rename(&params),
-            lsp::request::DocumentSymbolRequest::METHOD => {
-                self.textDocument_documentSymbol(&params)
-            }
-            lsp::request::ShowMessageRequest::METHOD => self.window_showMessageRequest(&params),
-            lsp::request::WorkspaceSymbol::METHOD => self.workspace_symbol(&params),
-            lsp::request::CodeActionRequest::METHOD => self.textDocument_codeAction(&params),
-            lsp::request::Completion::METHOD => self.textDocument_completion(&params),
-            lsp::request::SignatureHelpRequest::METHOD => self.textDocument_signatureHelp(&params),
-            lsp::request::References::METHOD => self.textDocument_references(&params),
-            lsp::request::Formatting::METHOD => self.textDocument_formatting(&params),
-            lsp::request::RangeFormatting::METHOD => self.textDocument_rangeFormatting(&params),
-            lsp::request::CodeLensRequest::METHOD => self.textDocument_codeLens(&params),
-            lsp::request::ResolveCompletionItem::METHOD => self.completionItem_resolve(&params),
-            lsp::request::ExecuteCommand::METHOD => self.workspace_executeCommand(&params),
-            lsp::request::ApplyWorkspaceEdit::METHOD => self.workspace_applyEdit(&params),
-            lsp::request::DocumentHighlightRequest::METHOD => {
-                self.textDocument_documentHighlight(&params)
+            request::HoverRequest::METHOD => self.text_document_hover(&params),
+            request::Rename::METHOD => self.text_document_rename(&params),
+            request::DocumentSymbolRequest::METHOD => self.text_document_document_symbol(&params),
+            request::ShowMessageRequest::METHOD => self.window_show_message_request(&params),
+            request::WorkspaceSymbol::METHOD => self.workspace_symbol(&params),
+            request::CodeActionRequest::METHOD => self.text_document_code_action(&params),
+            request::Completion::METHOD => self.text_document_completion(&params),
+            request::SignatureHelpRequest::METHOD => self.text_document_signature_help(&params),
+            request::References::METHOD => self.text_document_references(&params),
+            request::Formatting::METHOD => self.text_document_formatting(&params),
+            request::RangeFormatting::METHOD => self.text_document_range_formatting(&params),
+            request::CodeLensRequest::METHOD => self.text_document_code_lens(&params),
+            request::ResolveCompletionItem::METHOD => self.completion_item_resolve(&params),
+            request::ExecuteCommand::METHOD => self.workspace_execute_command(&params),
+            request::ApplyWorkspaceEdit::METHOD => self.workspace_apply_edit(&params),
+            request::DocumentHighlightRequest::METHOD => {
+                self.text_document_document_highlight(&params)
             }
             // Extensions.
-            REQUEST__GetState => self.languageClient_getState(&params),
-            REQUEST__IsAlive => self.languageClient_isAlive(&params),
-            REQUEST__StartServer => self.languageClient_startServer(&params),
-            REQUEST__RegisterServerCommands => self.languageClient_registerServerCommands(&params),
-            REQUEST__SetLoggingLevel => self.languageClient_setLoggingLevel(&params),
-            REQUEST__SetDiagnosticsList => self.languageClient_setDiagnosticsList(&params),
-            REQUEST__RegisterHandlers => self.languageClient_registerHandlers(&params),
-            REQUEST__NCMRefresh => self.NCM_refresh(&params),
-            REQUEST__NCM2OnComplete => self.NCM2_on_complete(&params),
-            REQUEST__ExplainErrorAtPoint => self.languageClient_explainErrorAtPoint(&params),
-            REQUEST__OmniComplete => self.languageClient_omniComplete(&params),
-            REQUEST__ClassFileContents => self.java_classFileContents(&params),
-            REQUEST__DebugInfo => self.debug_info(&params),
-            REQUEST__CodeLensAction => self.languageClient_handleCodeLensAction(&params),
-            REQUEST__SemanticScopes => self.languageClient_semanticScopes(&params),
-            REQUEST__ShowSemanticHighlightSymbols => self.languageClient_semanticHlSyms(&params),
+            REQUEST_FIND_LOCATIONS => self.find_locations(&params),
+            REQUEST_GET_STATE => self.get_state(&params),
+            REQUEST_IS_ALIVE => self.is_alive(&params),
+            REQUEST_START_SERVER => self.start_server(&params),
+            REQUEST_REGISTER_SERVER_COMMANDS => self.register_server_commands(&params),
+            REQUEST_SET_LOGGING_LEVEL => self.set_logging_level(&params),
+            REQUEST_SET_DIAGNOSTICS_LIST => self.set_diagnostics_list(&params),
+            REQUEST_REGISTER_HANDLERS => self.register_handlers(&params),
+            REQUEST_NCM_REFRESH => self.ncm_refresh(&params),
+            REQUEST_NCM2_ON_COMPLETE => self.ncm2_on_complete(&params),
+            REQUEST_EXPLAIN_ERROR_AT_POINT => self.explain_error_at_point(&params),
+            REQUEST_OMNI_COMPLETE => self.omnicomplete(&params),
+            REQUEST_CLASS_FILE_CONTENTS => self.java_class_file_contents(&params),
+            REQUEST_DEBUG_INFO => self.debug_info(&params),
+            REQUEST_CODE_LENS_ACTION => self.handle_code_lens_action(&params),
+            REQUEST_SEMANTIC_SCOPES => self.semantic_scopes(&params),
+            REQUEST_SHOW_SEMANTIC_HL_SYMBOLS => self.semantic_highlight_symbols(&params),
 
             _ => {
-                let languageId_target = if languageId.is_some() {
+                let language_id_target = if language_id.is_some() {
                     // Message from language server. No handler found.
                     let msg = format!("Message not handled: {:?}", method_call);
                     if method_call.method.starts_with('$') {
@@ -131,15 +131,15 @@ impl LanguageClient {
                 } else {
                     // Message from vim. Proxy to language server.
                     let filename = self.vim()?.get_filename(&params)?;
-                    let languageId_target = self.vim()?.get_languageId(&filename, &params)?;
+                    let language_id_target = self.vim()?.get_language_id(&filename, &params)?;
                     info!(
                         "Proxy message directly to language server: {:?}",
                         method_call
                     );
-                    Some(languageId_target)
+                    Some(language_id_target)
                 };
 
-                self.get_client(&languageId_target)?
+                self.get_client(&language_id_target)?
                     .call(&method_call.method, &params)
             }
         }
@@ -147,8 +147,8 @@ impl LanguageClient {
 
     pub fn handle_notification(
         &self,
-        languageId: Option<&str>,
-        notification: &rpc::Notification,
+        language_id: Option<&str>,
+        notification: &jsonrpc_core::Notification,
     ) -> Fallible<()> {
         let params = serde_json::to_value(notification.params.clone())?;
 
@@ -159,51 +159,46 @@ impl LanguageClient {
         }
 
         match notification.method.as_str() {
-            lsp::notification::DidChangeConfiguration::METHOD => {
-                self.workspace_didChangeConfiguration(&params)?
+            notification::DidChangeConfiguration::METHOD => {
+                self.workspace_did_change_configuration(&params)?
             }
-            lsp::notification::DidOpenTextDocument::METHOD => self.textDocument_didOpen(&params)?,
-            lsp::notification::DidChangeTextDocument::METHOD => {
-                self.textDocument_didChange(&params)?
+            notification::DidOpenTextDocument::METHOD => self.text_document_did_open(&params)?,
+            notification::DidChangeTextDocument::METHOD => {
+                self.text_document_did_change(&params)?
             }
-            lsp::notification::DidSaveTextDocument::METHOD => self.textDocument_didSave(&params)?,
-            lsp::notification::DidCloseTextDocument::METHOD => {
-                self.textDocument_didClose(&params)?
+            notification::DidSaveTextDocument::METHOD => self.text_document_did_save(&params)?,
+            notification::DidCloseTextDocument::METHOD => self.text_document_did_close(&params)?,
+            notification::PublishDiagnostics::METHOD => {
+                self.text_document_publish_diagnostics(&params)?
             }
-            lsp::notification::PublishDiagnostics::METHOD => {
-                self.textDocument_publishDiagnostics(&params)?
+            notification::SemanticHighlighting::METHOD => {
+                self.text_document_semantic_highlight(&params)?
             }
-            lsp::notification::SemanticHighlighting::METHOD => {
-                self.textDocument_semanticHighlight(&params)?
-            }
-            lsp::notification::Progress::METHOD => self.progress(&params)?,
-            lsp::notification::LogMessage::METHOD => self.window_logMessage(&params)?,
-            lsp::notification::ShowMessage::METHOD => self.window_showMessage(&params)?,
-            lsp::notification::Exit::METHOD => self.exit(&params)?,
+            notification::Progress::METHOD => self.progress(&params)?,
+            notification::LogMessage::METHOD => self.window_log_message(&params)?,
+            notification::ShowMessage::METHOD => self.window_show_message(&params)?,
+            notification::Exit::METHOD => self.exit(&params)?,
             // Extensions.
-            NOTIFICATION__HandleFileType => self.languageClient_handleFileType(&params)?,
-            NOTIFICATION__HandleBufNewFile => self.languageClient_handleBufNewFile(&params)?,
-            NOTIFICATION__HandleBufEnter => self.languageClient_handleBufEnter(&params)?,
-            NOTIFICATION__HandleTextChanged => self.languageClient_handleTextChanged(&params)?,
-            NOTIFICATION__HandleBufWritePost => self.languageClient_handleBufWritePost(&params)?,
-            NOTIFICATION__HandleBufDelete => self.languageClient_handleBufDelete(&params)?,
-            NOTIFICATION__HandleCursorMoved => self.languageClient_handleCursorMoved(&params)?,
-            NOTIFICATION__HandleCompleteDone => self.languageClient_handleCompleteDone(&params)?,
-            NOTIFICATION__FZFSinkLocation => self.languageClient_FZFSinkLocation(&params)?,
-            NOTIFICATION__FZFSinkCommand => self.languageClient_FZFSinkCommand(&params)?,
-            NOTIFICATION__ClearDocumentHighlight => {
-                self.languageClient_clearDocumentHighlight(&params)?
-            }
-            // Extensions by language servers.
-            NOTIFICATION__LanguageStatus => self.language_status(&params)?,
-            NOTIFICATION__RustBeginBuild => self.rust_handleBeginBuild(&params)?,
-            NOTIFICATION__RustDiagnosticsBegin => self.rust_handleDiagnosticsBegin(&params)?,
-            NOTIFICATION__RustDiagnosticsEnd => self.rust_handleDiagnosticsEnd(&params)?,
-            NOTIFICATION__WindowProgress => self.window_progress(&params)?,
-            NOTIFICATION__ServerExited => self.languageClient_serverExited(&params)?,
+            NOTIFICATION_HANDLE_FILE_TYPE => self.handle_file_type(&params)?,
+            NOTIFICATION_HANDLE_BUF_NEW_FILE => self.handle_buf_new_file(&params)?,
+            NOTIFICATION_HANDLE_BUF_ENTER => self.handle_buf_enter(&params)?,
+            NOTIFICATION_HANDLE_TEXT_CHANGED => self.handle_text_changed(&params)?,
+            NOTIFICATION_HANDLE_BUF_WRITE_POST => self.handle_buf_write_post(&params)?,
+            NOTIFICATION_HANDLE_BUF_DELETE => self.handle_buf_delete(&params)?,
+            NOTIFICATION_HANDLE_CURSOR_MOVED => self.handle_cursor_moved(&params)?,
+            NOTIFICATION_HANDLE_COMPLETE_DONE => self.handle_complete_done(&params)?,
+            NOTIFICATION_FZF_SINK_LOCATION => self.fzf_sink_location(&params)?,
+            NOTIFICATION_FZF_SINK_COMMAND => self.fzf_sink_command(&params)?,
+            NOTIFICATION_CLEAR_DOCUMENT_HL => self.clear_document_highlight(&params)?,
+            NOTIFICATION_LANGUAGE_STATUS => self.language_status(&params)?,
+            NOTIFICATION_WINDOW_PROGRESS => self.window_progress(&params)?,
+            NOTIFICATION_SERVER_EXITED => self.handle_server_exited(&params)?,
+            NOTIFICATION_RUST_BEGIN_BUILD => self.rust_handle_begin_build(&params)?,
+            NOTIFICATION_RUST_DIAGNOSTICS_BEGIN => self.rust_handle_diagnostics_begin(&params)?,
+            NOTIFICATION_RUST_DIAGNOSTICS_END => self.rust_handle_diagnostics_end(&params)?,
 
             _ => {
-                let languageId_target = if languageId.is_some() {
+                let language_id_target = if language_id.is_some() {
                     // Message from language server. No handler found.
                     let msg = format!("Message not handled: {:?}", notification);
                     if notification.method.starts_with('$') {
@@ -215,15 +210,15 @@ impl LanguageClient {
                 } else {
                     // Message from vim. Proxy to language server.
                     let filename = self.vim()?.get_filename(&params)?;
-                    let languageId_target = self.vim()?.get_languageId(&filename, &params)?;
+                    let language_id_target = self.vim()?.get_language_id(&filename, &params)?;
                     info!(
                         "Proxy message directly to language server: {:?}",
                         notification
                     );
-                    Some(languageId_target)
+                    Some(language_id_target)
                 };
 
-                self.get_client(&languageId_target)?
+                self.get_client(&language_id_target)?
                     .notify(&notification.method, &params)?;
             }
         };

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,4 +1,5 @@
 use lsp_types::{Diagnostic, DiagnosticSeverity};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Sign {

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -1,4 +1,5 @@
-use lsp_types::*;
+use lsp_types::Range;
+use serde::{Deserialize, Serialize};
 
 /// Visible lines of editor.
 ///
@@ -33,6 +34,8 @@ fn test_new() {
 
 #[test]
 fn test_overlaps() {
+    use lsp_types::*;
+
     let viewport = Viewport::new(2, 7);
     assert_eq!(
         viewport.overlaps(Range::new(Position::new(0, 0), Position::new(1, 10))),

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -1,7 +1,17 @@
-use super::*;
 use crate::rpcclient::RpcClient;
-use crate::sign::Sign;
-use crate::viewport::Viewport;
+use crate::{
+    sign::Sign,
+    types::{Bufnr, QuickfixEntry, VimExp, VirtualText},
+    utils::Canonicalize,
+    viewport::Viewport,
+};
+use failure::Fallible;
+use jsonrpc_core::Value;
+use log::*;
+use lsp_types::Position;
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::json;
+use std::{path::Path, sync::Arc};
 
 /// Try get value of an variable from RPC params.
 pub fn try_get<R: DeserializeOwned>(key: &str, params: &Value) -> Fallible<Option<R>> {
@@ -51,7 +61,7 @@ impl Vim {
         Ok(filename.canonicalize())
     }
 
-    pub fn get_languageId(&self, filename: &str, params: &Value) -> Fallible<String> {
+    pub fn get_language_id(&self, filename: &str, params: &Value) -> Fallible<String> {
         let key = "languageId";
         let expr = "&filetype";
 


### PR DESCRIPTION
This PR makes tries to take the code to a better place in terms of rust conventions and good practices adoption. Specifically, it renames everything to snake case and removes most instances of glob imports.

Closes #1049 