### PR TITLE
Drop failure in favor of anyhow + thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arc-swap"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,26 +49,6 @@ dependencies = [
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "backtrace"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "base64"
@@ -186,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -203,26 +188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "failure"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "filetime"
@@ -392,10 +357,10 @@ dependencies = [
 name = "languageclient"
 version = "0.1.157"
 dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "json-patch 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -412,6 +377,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -687,11 +653,6 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -774,7 +735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -840,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.3"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,22 +810,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1045,11 +1013,10 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+"checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-"checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
-"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "b548a4ee81fccb95919d4e22cfea83c7693ebfd78f0495493178db20b3139da7"
@@ -1067,8 +1034,6 @@ dependencies = [
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
-"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
-"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8c63033fcba1f51ef744505b3cad42510432b904c062afa67ad7ece008429d"
 "checksum flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1121,7 +1086,6 @@ dependencies = [
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
@@ -1141,9 +1105,10 @@ dependencies = [
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "158521e6f544e7e3dcfc370ac180794aa38cb34a1b1e07609376d4adcf429b93"
-"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+"checksum thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ pre-release-hook = ["cargo", "build"]
 tag-name = "{{version}}"
 
 [dependencies]
-failure = "0"
 itertools = "0.8"
 log = "0.4"
 log4rs = "0"
@@ -38,3 +37,5 @@ glob = "0"
 notify = "4"
 shellexpand = "1"
 derivative = "2"
+anyhow = "1.0.31"
+thiserror = "1.0.19"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,5 @@
+use anyhow::{Context, Result};
 use derivative::Derivative;
-use failure::{Fallible, ResultExt};
 use log::LevelFilter;
 use log4rs::append::file::FileAppender;
 use log4rs::config::{Appender, Config, Root};
@@ -21,7 +21,7 @@ pub struct Logger {
 }
 
 impl Logger {
-    pub fn new() -> Fallible<Self> {
+    pub fn new() -> Result<Self> {
         let level = LevelFilter::Warn;
         let path = None;
 
@@ -34,7 +34,7 @@ impl Logger {
         })
     }
 
-    pub fn update_settings(&mut self, level: LevelFilter, path: Option<PathBuf>) -> Fallible<()> {
+    pub fn update_settings(&mut self, level: LevelFilter, path: Option<PathBuf>) -> Result<()> {
         let config = create_config(&path, level)?;
         self.handle.set_config(config);
         self.level = level;
@@ -42,7 +42,7 @@ impl Logger {
         Ok(())
     }
 
-    pub fn set_level(&mut self, level: LevelFilter) -> Fallible<()> {
+    pub fn set_level(&mut self, level: LevelFilter) -> Result<()> {
         let config = create_config(&self.path, level)?;
         self.handle.set_config(config);
         self.level = level;
@@ -50,7 +50,7 @@ impl Logger {
     }
 
     #[allow(dead_code)]
-    pub fn set_path(&mut self, path: Option<PathBuf>) -> Fallible<()> {
+    pub fn set_path(&mut self, path: Option<PathBuf>) -> Result<()> {
         let config = create_config(&path, self.level)?;
         self.handle.set_config(config);
         self.path = path;
@@ -58,7 +58,7 @@ impl Logger {
     }
 }
 
-fn create_config(path: &Option<PathBuf>, level: LevelFilter) -> Fallible<Config> {
+fn create_config(path: &Option<PathBuf>, level: LevelFilter) -> Result<Config> {
     let encoder =
         PatternEncoder::new("{date(%H:%M:%S)} {level} {thread} {file}:{line} {message}{n}");
 
@@ -76,7 +76,7 @@ fn create_config(path: &Option<PathBuf>, level: LevelFilter) -> Fallible<Config>
                 .write(true)
                 .truncate(true)
                 .open(&path)
-                .with_context(|err| format!("Failed to open file ({}): {}", path, err))?;
+                .with_context(|| format!("Failed to open file ({})", path))?;
             #[allow(clippy::write_literal)]
             writeln!(
                 f,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod viewport;
 mod vim;
 mod vimext;
 
-use failure::Fallible;
+use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
@@ -19,7 +19,7 @@ use types::State;
 #[derive(Debug, StructOpt)]
 struct Arguments {}
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let version = format!("{} {}", env!("CARGO_PKG_VERSION"), env!("GIT_HASH"));
     let args = Arguments::clap().version(version.as_str());
     let _ = args.get_matches();

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::Canonicalize,
     viewport::Viewport,
 };
-use failure::Fallible;
+use anyhow::Result;
 use jsonrpc_core::Value;
 use log::*;
 use lsp_types::Position;
@@ -14,7 +14,7 @@ use serde_json::json;
 use std::{path::Path, sync::Arc};
 
 /// Try get value of an variable from RPC params.
-pub fn try_get<R: DeserializeOwned>(key: &str, params: &Value) -> Fallible<Option<R>> {
+pub fn try_get<R: DeserializeOwned>(key: &str, params: &Value) -> Result<Option<R>> {
     let value = &params[key];
     if value == &Value::Null {
         Ok(None)
@@ -72,16 +72,16 @@ impl Vim {
 
     /// Fundamental functions.
 
-    pub fn get_mode(&self) -> Fallible<Mode> {
+    pub fn get_mode(&self) -> Result<Mode> {
         let mode: String = self.rpcclient.call("mode", json!([]))?;
         Ok(Mode::from(mode.as_str()))
     }
 
-    pub fn command(&self, cmds: impl Serialize) -> Fallible<()> {
+    pub fn command(&self, cmds: impl Serialize) -> Result<()> {
         self.rpcclient.notify("s:command", &cmds)
     }
 
-    pub fn eval<E, T>(&self, exp: E) -> Fallible<T>
+    pub fn eval<E, T>(&self, exp: E) -> Result<T>
     where
         E: VimExp,
         T: DeserializeOwned,
@@ -91,11 +91,11 @@ impl Vim {
 
     /// Function wrappers.
 
-    pub fn getbufvar<R: DeserializeOwned>(&self, bufname: &str, var: &str) -> Fallible<R> {
+    pub fn getbufvar<R: DeserializeOwned>(&self, bufname: &str, var: &str) -> Result<R> {
         self.rpcclient.call("getbufvar", json!([bufname, var]))
     }
 
-    pub fn get_filename(&self, params: &Value) -> Fallible<String> {
+    pub fn get_filename(&self, params: &Value) -> Result<String> {
         let key = "filename";
         let expr = "LSP#filename()";
 
@@ -103,110 +103,110 @@ impl Vim {
         Ok(filename.canonicalize())
     }
 
-    pub fn get_language_id(&self, filename: &str, params: &Value) -> Fallible<String> {
+    pub fn get_language_id(&self, filename: &str, params: &Value) -> Result<String> {
         let key = "languageId";
         let expr = "&filetype";
 
         try_get(key, params)?.map_or_else(|| self.getbufvar(filename, expr), Ok)
     }
 
-    pub fn get_bufnr(&self, filename: &str, params: &Value) -> Fallible<Bufnr> {
+    pub fn get_bufnr(&self, filename: &str, params: &Value) -> Result<Bufnr> {
         let key = "bufnr";
 
         try_get(key, params)?.map_or_else(|| self.eval(format!("bufnr('{}')", filename)), Ok)
     }
 
-    pub fn get_viewport(&self, params: &Value) -> Fallible<Viewport> {
+    pub fn get_viewport(&self, params: &Value) -> Result<Viewport> {
         let key = "viewport";
         let expr = "LSP#viewport()";
 
         try_get(key, params)?.map_or_else(|| self.eval(expr), Ok)
     }
 
-    pub fn get_position(&self, params: &Value) -> Fallible<Position> {
+    pub fn get_position(&self, params: &Value) -> Result<Position> {
         let key = "position";
         let expr = "LSP#position()";
 
         try_get(key, params)?.map_or_else(|| self.eval(expr), Ok)
     }
 
-    pub fn get_current_word(&self, params: &Value) -> Fallible<String> {
+    pub fn get_current_word(&self, params: &Value) -> Result<String> {
         let key = "cword";
         let expr = "expand('<cword>')";
 
         try_get(key, params)?.map_or_else(|| self.eval(expr), Ok)
     }
 
-    pub fn get_goto_cmd(&self, params: &Value) -> Fallible<Option<String>> {
+    pub fn get_goto_cmd(&self, params: &Value) -> Result<Option<String>> {
         let key = "gotoCmd";
 
         try_get(key, params)
     }
 
-    pub fn get_tab_size(&self) -> Fallible<u64> {
+    pub fn get_tab_size(&self) -> Result<u64> {
         let expr = "shiftwidth()";
 
         self.eval(expr)
     }
 
-    pub fn get_insert_spaces(&self, filename: &str) -> Fallible<bool> {
+    pub fn get_insert_spaces(&self, filename: &str) -> Result<bool> {
         let insert_spaces: i8 = self.getbufvar(filename, "&expandtab")?;
         Ok(insert_spaces == 1)
     }
 
-    pub fn get_text(&self, bufname: &str) -> Fallible<Vec<String>> {
+    pub fn get_text(&self, bufname: &str) -> Result<Vec<String>> {
         self.rpcclient.call("LSP#text", json!([bufname]))
     }
 
-    pub fn get_handle(&self, params: &Value) -> Fallible<bool> {
+    pub fn get_handle(&self, params: &Value) -> Result<bool> {
         let key = "handle";
 
         try_get(key, params)?.map_or_else(|| Ok(true), Ok)
     }
 
-    pub fn echo(&self, message: impl AsRef<str>) -> Fallible<()> {
+    pub fn echo(&self, message: impl AsRef<str>) -> Result<()> {
         self.rpcclient.notify("s:Echo", message.as_ref())
     }
 
-    pub fn echo_ellipsis(&self, message: impl AsRef<str>) -> Fallible<()> {
+    pub fn echo_ellipsis(&self, message: impl AsRef<str>) -> Result<()> {
         let message = message.as_ref().lines().collect::<Vec<_>>().join(" ");
         self.rpcclient.notify("s:EchoEllipsis", message)
     }
 
-    pub fn echomsg_ellipsis(&self, message: impl AsRef<str>) -> Fallible<()> {
+    pub fn echomsg_ellipsis(&self, message: impl AsRef<str>) -> Result<()> {
         let message = message.as_ref().lines().collect::<Vec<_>>().join(" ");
         self.rpcclient.notify("s:EchomsgEllipsis", message)
     }
 
-    pub fn echomsg(&self, message: impl AsRef<str>) -> Fallible<()> {
+    pub fn echomsg(&self, message: impl AsRef<str>) -> Result<()> {
         self.rpcclient.notify("s:Echomsg", message.as_ref())
     }
 
-    pub fn echoerr(&self, message: impl AsRef<str>) -> Fallible<()> {
+    pub fn echoerr(&self, message: impl AsRef<str>) -> Result<()> {
         self.rpcclient.notify("s:Echoerr", message.as_ref())
     }
 
-    pub fn echowarn(&self, message: impl AsRef<str>) -> Fallible<()> {
+    pub fn echowarn(&self, message: impl AsRef<str>) -> Result<()> {
         self.rpcclient.notify("s:Echowarn", message.as_ref())
     }
 
-    pub fn cursor(&self, lnum: u64, col: u64) -> Fallible<()> {
+    pub fn cursor(&self, lnum: u64, col: u64) -> Result<()> {
         self.rpcclient.notify("cursor", json!([lnum, col]))
     }
 
     #[allow(dead_code)]
-    pub fn setline(&self, lnum: u64, text: &[String]) -> Fallible<()> {
+    pub fn setline(&self, lnum: u64, text: &[String]) -> Result<()> {
         self.rpcclient.notify("setline", json!([lnum, text]))
     }
 
-    pub fn edit(&self, goto_cmd: &Option<String>, path: impl AsRef<Path>) -> Fallible<()> {
+    pub fn edit(&self, goto_cmd: &Option<String>, path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref().to_string_lossy();
         let goto = goto_cmd.as_deref().unwrap_or("edit");
         self.rpcclient.notify("s:Edit", json!([goto, path]))?;
         Ok(())
     }
 
-    pub fn setqflist(&self, list: &[QuickfixEntry], action: &str, title: &str) -> Fallible<()> {
+    pub fn setqflist(&self, list: &[QuickfixEntry], action: &str, title: &str) -> Result<()> {
         info!("Begin setqflist");
         let parms = json!([list, action]);
         self.rpcclient.notify("setqflist", parms)?;
@@ -215,7 +215,7 @@ impl Vim {
         Ok(())
     }
 
-    pub fn setloclist(&self, list: &[QuickfixEntry], action: &str, title: &str) -> Fallible<()> {
+    pub fn setloclist(&self, list: &[QuickfixEntry], action: &str, title: &str) -> Result<()> {
         let parms = json!([0, list, action]);
         self.rpcclient.notify("setloclist", parms)?;
         let parms = json!([0, [], "a", { "title": title }]);
@@ -223,7 +223,7 @@ impl Vim {
         Ok(())
     }
 
-    pub fn create_namespace(&self, name: &str) -> Fallible<i64> {
+    pub fn create_namespace(&self, name: &str) -> Result<i64> {
         self.rpcclient.call("nvim_create_namespace", [name])
     }
 
@@ -234,7 +234,7 @@ impl Vim {
         line_start: u64,
         line_end: u64,
         virtual_texts: &[VirtualText],
-    ) -> Fallible<i8> {
+    ) -> Result<i8> {
         self.rpcclient.call(
             "s:set_virtual_texts",
             json!([buf_id, ns_id, line_start, line_end, virtual_texts]),
@@ -246,7 +246,7 @@ impl Vim {
         filename: &str,
         signs_to_add: &[Sign],
         signs_to_delete: &[Sign],
-    ) -> Fallible<i8> {
+    ) -> Result<i8> {
         self.rpcclient.call(
             "s:set_signs",
             json!([filename, signs_to_add, signs_to_delete]),

--- a/src/vimext.rs
+++ b/src/vimext.rs
@@ -1,9 +1,9 @@
 use crate::language_client::LanguageClient;
 use crate::types::LCNamespace;
-use failure::Fallible;
+use anyhow::Result;
 
 impl LanguageClient {
-    pub fn get_or_create_namespace(&self, ns: &LCNamespace) -> Fallible<i64> {
+    pub fn get_or_create_namespace(&self, ns: &LCNamespace) -> Result<i64> {
         let ns_name = ns.name();
 
         if let Some(namespace_id) = self.get(|state| state.namespace_ids.get(&ns_name).cloned())? {


### PR DESCRIPTION
This PR removes the dependency on `failure`, as it is deprecated, and replaces it with `anyhow` + `thiserror`. 