### PR TITLE
Move tests into a test module inside their current module

### DIFF
--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -25,24 +25,29 @@ impl Viewport {
     }
 }
 
-#[test]
-fn test_new() {
-    let viewport = Viewport::new(0, 7);
-    assert_eq!(viewport.start, 0);
-    assert_eq!(viewport.end, 7);
-}
+#[cfg(test)]
+mod test {
+    use super::*;
 
-#[test]
-fn test_overlaps() {
-    use lsp_types::*;
+    #[test]
+    fn test_new() {
+        let viewport = Viewport::new(0, 7);
+        assert_eq!(viewport.start, 0);
+        assert_eq!(viewport.end, 7);
+    }
 
-    let viewport = Viewport::new(2, 7);
-    assert_eq!(
-        viewport.overlaps(Range::new(Position::new(0, 0), Position::new(1, 10))),
-        false
-    );
-    assert_eq!(
-        viewport.overlaps(Range::new(Position::new(0, 0), Position::new(2, 0))),
-        true
-    );
+    #[test]
+    fn test_overlaps() {
+        use lsp_types::*;
+
+        let viewport = Viewport::new(2, 7);
+        assert_eq!(
+            viewport.overlaps(Range::new(Position::new(0, 0), Position::new(1, 10))),
+            false
+        );
+        assert_eq!(
+            viewport.overlaps(Range::new(Position::new(0, 0), Position::new(2, 0))),
+            true
+        );
+    }
 }


### PR DESCRIPTION
This PR moves all Rust tests to a `test` mod inside their current module. This results in a cleaner code organisation and makes it easier to navigate tests as they are all grouped inside their corresponding module.