### PR TITLE
Allow funcref in g:LanguageClient_selectionUI

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -118,10 +118,10 @@ function! s:hasSnippetSupport() abort
 endfunction
 
 function! s:getSelectionUI() abort
-	if type(s:GetVar('LanguageClient_selectionUI')) is s:TYPE.funcref
+	if type(get(g:, 'LanguageClient_selectionUI', v:null)) is s:TYPE.funcref
 		return 'funcref'
 	else
-		return s:GetVar('LanguageClient_selectionUI')
+		return get(g:, 'LanguageClient_selectionUI', v:null)
 	endif
 endfunction
 
@@ -210,7 +210,8 @@ function! s:inputlist(...) abort
 endfunction
 
 function! s:selectionUI_funcref(source, sink) abort
-    if g:LanguageClient_selectionUI ==? 'FZF'
+    if get(g:, 'LanguageClient_selectionUI', 'FZF') ==? 'FZF'
+                \ && get(g:, 'loaded_fzf')
         call s:FZF(a:source, a:sink)
     else
         call call(g:LanguageClient_selectionUI, [a:source, function(a:sink)])
@@ -1427,7 +1428,12 @@ endfunction
 
 function! LanguageClient_contextMenu() abort
     let l:options = keys(LanguageClient_contextMenuItems())
-    if type(s:GetVar('LanguageClient_selectionUI')) is s:TYPE.funcref || s:GetVar('LanguageClient_selectionUI') ==? 'FZF'
+    if get(g:, 'LanguageClient_fzfContextMenu', 1)
+            \ && (type(get(g:, 'LanguageClient_selectionUI', v:null)) is s:TYPE.funcref
+                \ || (get(g:, 'LanguageClient_selectionUI', v:null) ==? 'FZF'
+                    \ && get(g:, 'loaded_fzf')
+                \ )
+            \ )
         return s:selectionUI_funcref(l:options, function('LanguageClient_handleContextMenuItem'))
     endif
 

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1428,7 +1428,9 @@ endfunction
 
 function! LanguageClient_contextMenu() abort
     let l:options = keys(LanguageClient_contextMenuItems())
-    if get(g:, 'LanguageClient_fzfContextMenu', 1)
+    let l:useSelectionUI = get(g:, 'LanguageClient_selectionUIContextMenu',
+				\ get(g:, 'LanguageClient_fzfContextMenu', 1))
+    if l:useSelectionUI
             \ && (type(get(g:, 'LanguageClient_selectionUI', v:null)) is s:TYPE.funcref
                 \ || (get(g:, 'LanguageClient_selectionUI', v:null) ==? 'FZF'
                     \ && get(g:, 'loaded_fzf')

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -210,11 +210,14 @@ function! s:inputlist(...) abort
 endfunction
 
 function! s:selectionUI_funcref(source, sink) abort
-    if get(g:, 'LanguageClient_selectionUI', 'FZF') ==? 'FZF'
+    if type(get(g:, 'LanguageClient_selectionUI')) is s:TYPE.funcref
+        call call(g:LanguageClient_selectionUI, [a:source, function(a:sink)])
+    elseif get(g:, 'LanguageClient_selectionUI', 'FZF') ==? 'FZF'
                 \ && get(g:, 'loaded_fzf')
         call s:FZF(a:source, a:sink)
     else
-        call call(g:LanguageClient_selectionUI, [a:source, function(a:sink)])
+        call s:Echoerr('Unsupported selection UI, use "FZF" or a funcref')
+        return
     endif
 endfunction
 

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -174,11 +174,19 @@ An example implementation is "s:FZF()" in autoload/LanguageClient.vim. For
 details, see the source and sink arguments of fzf#run():
 https://github.com/junegunn/fzf/blob/master/README-VIM.md#fzfrun
 
+Another example, this time using vim-clap: >
+
+	function! MySelectionUI(source, sink) abort
+		return clap#run({'id': 'LCN', 'source': a:source, 'sink': a:sink})
+	endfunction
+
+	let g:LanguageClient_selectionUI = function('MySelectionUI')
+
 2.7 g:LanguageClient_selectionUI_autoOpen                *LanguageClient_selectionUI_autoOpen*
 Selection UI auto open when selectionUI is not "fzf"
 
-Valid options: 1 | 0
 Default: 1
+Valid options: 1 | 0
 
 2.8 g:LanguageClient_trace                           *g:LanguageClient_trace*
 

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -312,9 +312,11 @@ Controls how hover output is displayed. Must be one of the following:
 Default: "Auto"
 Valid options: "Never", "Auto", "Always"
 
-2.22 g:LanguageClient_fzfContextMenu         *g:LanguageClient_fzfContextMenu*
+2.22 g:LanguageClient_selectionUIContextMenu *g:LanguageClient_selectionUIContextMenu* *g:LanguageClient_fzfContextMenu*
 
-Should FZF be used for `LanguageClient_contextMenu()`.
+Should the selection UI be used for `LanguageClient_contextMenu()`.
+
+(Alias for the deprecated `LanguageClient_fzfContextMenu`)
 
 Default: 1
 Valid options: 1 | 0

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -163,7 +163,16 @@ Default: 1.
 Selection UI used when there are multiple entries.
 
 Default: If fzf is loaded, use "fzf", otherwise use "location-list".
-Valid options: "fzf" | "quickfix" | "location-list"
+Valid options: "fzf" | "quickfix" | "location-list" | |Funcref|
+
+If you use a |Funcref|, the referenced function should have two arguments
+(source, sink). The "source" argument can be either a command string or a
+list. The sink argument can be a command string or a |Funcref| that takes the
+selected line as its first argument.
+
+An example implementation is "s:FZF()" in autoload/LanguageClient.vim. For
+details, see the source and sink arguments of fzf#run():
+https://github.com/junegunn/fzf/blob/master/README-VIM.md#fzfrun
 
 2.7 g:LanguageClient_selectionUI_autoOpen                *LanguageClient_selectionUI_autoOpen*
 Selection UI auto open when selectionUI is not "fzf"

--- a/src/types.rs
+++ b/src/types.rs
@@ -295,7 +295,7 @@ impl State {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum SelectionUI {
-    FZF,
+    Funcref,
     Quickfix,
     LocationList,
 }
@@ -311,7 +311,7 @@ impl FromStr for SelectionUI {
 
     fn from_str(s: &str) -> Result<Self> {
         match s.to_ascii_uppercase().as_str() {
-            "FZF" => Ok(SelectionUI::FZF),
+            "FUNCREF" | "FZF" => Ok(SelectionUI::Funcref),
             "QUICKFIX" => Ok(SelectionUI::Quickfix),
             "LOCATIONLIST" | "LOCATION-LIST" => Ok(SelectionUI::LocationList),
             _ => Err(anyhow!(


### PR DESCRIPTION
Hot on the heels of https://github.com/autozimu/LanguageClient-neovim/pull/1045#issuecomment-641455349, here's a way to use a selection UI other than FZF. The `FZF` selection UI is implemented as a special backwards-compatible version of the `Funcref` selection UI.

The function has to adhere to the arguments provided to `s:FZF()`, i.e. it has to take `source` and a `sink` arguments. [As in `fzf#run()`](https://github.com/junegunn/fzf/blob/master/README-VIM.md#fzfrun), `source` can be either a list or a string, and `sink` may be a string or a reference to another function of one argument (the selected line).

In action, using [vim-clap](https://github.com/liuchengxu/vim-clap) instead of FZF:

![works](https://user-images.githubusercontent.com/620981/85034923-e4295400-b182-11ea-9ac1-5a9852ff0a44.gif)

Config:

```vim
function! MySelectionUI(source, sink) abort
	return clap#run({'id': 'LCN', 'source': a:source, 'sink': a:sink})
endfunction

let g:LanguageClient_selectionUI = function('MySelectionUI')
```