### PR TITLE
Abstract selection UI and use the correct one for codeActions and codeLenses

### DIFF
--- a/src/extensions/rust_analyzer.rs
+++ b/src/extensions/rust_analyzer.rs
@@ -50,7 +50,7 @@ impl LanguageClient {
                     .unwrap_or_else(|| Value::Array(vec![]));
                 let locations: Vec<Location> = serde_json::from_value(locations)?;
 
-                self.display_locations(&locations, "References")?;
+                self.present_list("References", &locations)?;
             }
             command::SELECT_APPLY_SOURCE_CHANGE => {
                 if let Some(ref edits) = cmd.arguments {


### PR DESCRIPTION
This PR abstract the creation of quickfix/location list/fzf items into a trait and implements it for the relevant types. This results less repeated code.

This also fixes the selection UI used by codeAction and codeLenses, which was hardcoded to FZF, so nothing else could be used. This PR adds support for location list, and quickfix, and will use the one configured by the user in `LanguageClient_selectionUI`.

There was one place were I couldn't use the new trait to get the list items, and that was in the `text_document_document_symbols` method, I may revisit this later, but if someone wants to give that a try, go ahead.

I'm not exactly excited about the names of the new functions added in this PR, so happy to take suggestions for better ones.