### PR TITLE
Remove unnecessary Arc in LanguageClient version field

### DIFF
--- a/src/language_client.rs
+++ b/src/language_client.rs
@@ -13,8 +13,9 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
+#[derive(Clone)]
 pub struct LanguageClient {
-    pub version: Arc<String>,
+    pub version: String,
     pub state_mutex: Arc<Mutex<State>>,
     pub clients_mutex: Arc<Mutex<HashMap<LanguageId, Arc<Mutex<()>>>>>,
 }

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -72,11 +72,7 @@ impl LanguageClient {
 
     pub fn loop_call(&self, rx: &crossbeam::channel::Receiver<Call>) -> Result<()> {
         for call in rx.iter() {
-            let language_client = LanguageClient {
-                version: self.version.clone(),
-                state_mutex: self.state_mutex.clone(),
-                clients_mutex: self.clients_mutex.clone(), // not sure if useful to clone this
-            };
+            let language_client = self.clone();
             thread::spawn(move || {
                 if let Err(err) = language_client.handle_call(call) {
                     error!("Error handling request:\n{:?}", err);
@@ -1173,7 +1169,7 @@ impl LanguageClient {
             InitializeParams {
                 client_info: Some(ClientInfo {
                     name: "LanguageClient-neovim".into(),
-                    version: Some((*self.version).clone()),
+                    version: Some(self.version.clone()),
                 }),
                 process_id: Some(u64::from(std::process::id())),
                 /* deprecated in lsp types, but can't initialize without it */

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 
     let (tx, rx) = crossbeam::channel::unbounded();
     let language_client = language_client::LanguageClient {
-        version: Arc::new(version),
+        version,
         state_mutex: Arc::new(Mutex::new(State::new(tx)?)),
         clients_mutex: Arc::new(Mutex::new(HashMap::new())),
     };


### PR DESCRIPTION
This PR removes the unnecessary Arc in the `version` field of `LanguageClient`.

It also adds a derive for `Clone` in the `LanguageClient` struct, as we were previously cloning it manually by manually cloning each field, and that seems unnecessary as well (with or without the `Arc` on `version`)