### PR TITLE
Add Plug mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,22 @@ let g:LanguageClient_serverCommands = {
     \ 'ruby': ['~/.rbenv/shims/solargraph', 'stdio'],
     \ }
 
-nnoremap <F5> :call LanguageClient_contextMenu()<CR>
+" note that if you are using Plug mapping you should not use `noremap` mappings.
+nmap <F5> <Plug>(lcn-menu)
 " Or map each action separately
-nnoremap <silent> K :call LanguageClient#textDocument_hover()<CR>
-nnoremap <silent> gd :call LanguageClient#textDocument_definition()<CR>
-nnoremap <silent> <F2> :call LanguageClient#textDocument_rename()<CR>
+nmap <silent>K <Plug>(lcn-hover)
+nmap <silent> gd <Plug>(lcn-definition)
+nmap <silent> <F2> <Plug>(lcn-rename)
 ```
 
 Run command `nvim +PlugInstall +UpdateRemotePlugins +qa` in shell to install
 this plugin. Install corresponding language servers. Restart neovim/vim and
 language services will be available right away. Happy hacking!
+
+# Mappings
+
+LanguageClient-neovim defines various Plug mappings, see `:help LanguageClientMappings` for a full
+list and an example configuration.
 
 # Install
 

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -8,10 +8,11 @@ CONTENTS                                               *LanguageClientContents*
 2. Configuration ............... |LanguageClientConfiguration|
 3. Commands .................... |LanguageClientCommands|
 4. Functions ................... |LanguageClientFunctions|
-5. Events ...................... |LanguageClientEvents|
-6. License ..................... |LanguageClientLicense|
-7. Bugs ........................ |LanguageClientBugs|
-8. Contributing ................ |LanguageClientContributing|
+5. Mappings .................... |LanguageClientMappings|
+6. Events ...................... |LanguageClientEvents|
+7. License ..................... |LanguageClientLicense|
+8. Bugs ........................ |LanguageClientBugs|
+9. Contributing ................ |LanguageClientContributing|
 
 ==============================================================================
 1. Usage                                                 *LanguageClientUsage*
@@ -905,16 +906,71 @@ Signature: LanguageClient#debugInfo(...)
 Print out debug info.
 
 ==============================================================================
-5. Events                                               *LanguageClientEvents*
+5. Mappings                                           *LanguageClientMappings*
+
+LanguageClient provides various Plug mappings which can be used to set up
+custom mappings. For example, to create a mapping to call the rename function
+you would create a custom mapping like this:
+
+  nmap <silent><F2> <Plug>(lcn-rename)
+
+The full list of Plug mappings is:
+
+*(lcn-menu)*
+Calls LanguageClient_contextMenu.
+
+*(lcn-hover)*
+Calls LanguageClient_textDocument_hover.
+
+*(lcn-rename)*
+Calls LanguageClient_textDocument_rename.
+
+*(lcn-definition)*
+Calls LanguageClient_textDocument_definition.
+
+*(lcn-type-definition)*
+Calls LanguageClient_textDocument_typeDefinition.
+
+*(lcn-references)*
+Calls LanguageClient_textDocument_references.
+
+*(lcn-implementation)*
+Calls LanguageClient_textDocument_implementation.
+
+*(lcn-code-action)*
+Calls LanguageClient_textDocument_codeAction if called in normal model or
+LanguageClient_textDocument_visualCodeAction if called in visual mode.
+
+*(lcn-code-lens-action)*
+Calls LanguageClient_handleCodeLensAction.
+
+*(lcn-symbols)*
+Calls LanguageClient_textDocument_documentSymbol.
+
+*(lcn-highlight)*
+Calls LanguageClient_textDocument_documentHighlight.
+
+*(lcn-explain-error)*
+Calls LanguageClient_textDocument_explainErrorAtPoint.
+
+*(lcn-format)*
+Calls LanguageClient_textDocument_formatting.
+
+*(lcn-format-sync)*
+Calls LanguageClient_textDocument_formatting_sync.
+
+
+==============================================================================
+6. Events                                               *LanguageClientEvents*
 
 LanguageClient provides two events for use with |User| |autocmd|s.
 
-5.1 LanguageClientStarted
+6.1 LanguageClientStarted
 *LanguageClientStarted*
 
 This event is triggered after LanguageClient has successfully started.
 
-5.2 LanguageClientStopped
+6.2 LanguageClientStopped
 *LanguageClientStopped*
 
 This event is triggered after LanguageClient has stopped.
@@ -926,23 +982,23 @@ Example: >
     autocmd User LanguageClientStopped setlocal signcolumn=auto
   augroup END
 
-5.3 LanguageClientDiagnosticsChanged
+6.3 LanguageClientDiagnosticsChanged
 *LanguageClientDiagnosticsChanged*
 
 This event is triggered when diagnostics changed.
 
-5.4 LanguageClientTextDocumentDidOpenPost
+6.4 LanguageClientTextDocumentDidOpenPost
 *LanguageClientTextDocumentDidOpenPost*
 
 Triggered after textDocument/didOpen notification is sent to language server.
 
 ==============================================================================
-6. License                                             *LanguageClientLicense*
+7. License                                             *LanguageClientLicense*
 
 The MIT License.
 
 ==============================================================================
-7. Bugs                                                   *LanguageClientBugs*
+8. Bugs                                                   *LanguageClientBugs*
 
 Please report all bugs at https://github.com/autozimu/LanguageClient-neovim/issues
 
@@ -963,7 +1019,7 @@ which can work like a proxy and logs all stdin and stdout of the language
 server into a log file.
 
 ==============================================================================
-8. Contributing                                   *LanguageClientContributing*
+9. Contributing                                   *LanguageClientContributing*
 
 https://github.com/autozimu/LanguageClient-neovim
 

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -126,6 +126,14 @@ function! LanguageClient_closeFloatingHover(...)
     return call('LanguageClient#closeFloatingHover', a:000)
 endfunction
 
+function! LanguageClient_handleCodeLensAction(...)
+    return call('LanguageClient#handleCodeLensAction', a:000)
+endfunction
+
+function! LanguageClient_explainErrorAtPoint(...)
+    return call('LanguageClient#explainErrorAtPoint', a:000)
+endfunction
+
 command! -nargs=* LanguageClientStart :call LanguageClient#startServer(<f-args>)
 command! LanguageClientStop :call LanguageClient#exit()
 
@@ -150,4 +158,20 @@ augroup languageClient
         autocmd CompleteDone *
                     \ call LanguageClient#textDocument_signatureHelp({}, 's:HandleOutputNothing')
     endif
+
+    nnoremap <Plug>(lcn-menu)               :call LanguageClient_contextMenu()<CR>
+    nnoremap <Plug>(lcn-hover)              :call LanguageClient_textDocument_hover()<CR>
+    nnoremap <Plug>(lcn-rename)             :call LanguageClient_textDocument_rename()<CR>
+    nnoremap <Plug>(lcn-definition)         :call LanguageClient_textDocument_definition()<CR>
+    nnoremap <Plug>(lcn-type-definition)    :call LanguageClient_textDocument_typeDefinition()<CR>
+    nnoremap <Plug>(lcn-references)         :call LanguageClient_textDocument_references()<CR>
+    nnoremap <Plug>(lcn-implementation)     :call LanguageClient_textDocument_implementation()<CR>
+    nnoremap <Plug>(lcn-code-action)        :call LanguageClient_textDocument_codeAction()<CR>
+    vnoremap <Plug>(lcn-code-action)        :call LanguageClient#textDocument_visualCodeAction()<CR>
+    nnoremap <Plug>(lcn-code-lens-action)   :call LanguageClient_handleCodeLensAction()<CR>
+    nnoremap <Plug>(lcn-symbols)            :call LanguageClient_textDocument_documentSymbol()<CR>
+    nnoremap <Plug>(lcn-highlight)          :call LanguageClient_textDocument_documentHighlight()<CR>
+    nnoremap <Plug>(lcn-explain-error)      :call LanguageClient_explainErrorAtPoint()<CR>
+    nnoremap <Plug>(lcn-format)             :call LanguageClient_textDocument_formatting()<CR>
+    nnoremap <Plug>(lcn-format-sync)        :call LanguageClient_textDocument_formatting_sync()<CR>
 augroup END


### PR DESCRIPTION
This PR adds Plug mappings for most functions, this provides slightly cleaner mappings and also easier to remember names and keeps the sanity of not setting default plugins in the user's mapping namespace.

My reasoning behind the names for the mappings was that the user doesn't really have to know or care about all the `textDocument` or `workspace` bit of the commands, so things like `lcn-rename` (instead of `LanguageClient_textDocument_rename`) are friendlier to the user.