### PR TITLE
Add enable_extensions config and set up gopls extensions

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -569,8 +569,9 @@ Example setting 3. Set the preferred markup kind to `markdown`
 
   ```
   let g:LanguageClient_preferredMarkupKind: ['markdown']
+  ```
 
-This setting may have no effect of the server decides not to honour it.
+This setting may have no effect if the server decides not to honour it.
 
 Default: v:null
 Valid options: Array<String>
@@ -602,6 +603,31 @@ Full path to languageclient binary.
 
 Default: 'bin/languageclient' relative to plugin root.
 Valid options: String
+
+2.39 g:LanguageClient_enableExtensions          *g:LanguageClient_enableExtensions*
+
+LanguageClient-neovim provides extensions for some language servers, such as gopls or rust-analyzer.
+These extensions can be turned on or off, and they are configurable per language (not per language
+server).
+
+An example of the extensions provided is running Rust or Go tests in a vim terminal. This takes
+advantage of the commands provided by rust-analyzer or gopls (respectively) and executes those
+commands in a vim terminal.
+
+Example config:
+  ```
+  let g:LanguageClient_enableExtensions = {
+    \ 'go': v:false,
+    \ 'rust': v:true,
+    \ }
+  ```
+In this example we explicitly disable extensions for the filetype `go`, and enable them for `rust`.
+Filetypes not included in this config will also have their extensions disabled, unless you
+explicitly enable them like we did for `rust`.
+
+The default value for this config, or the absence of this config, enables extensions for all filetypes.
+
+Default: v:null
 
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*

--- a/src/extensions/gopls.rs
+++ b/src/extensions/gopls.rs
@@ -1,0 +1,89 @@
+use crate::language_client::LanguageClient;
+use anyhow::Result;
+use lsp_types::Command;
+use serde::Deserialize;
+use serde_json::Value;
+
+pub mod command {
+    pub const TEST: &str = "test";
+    pub const GENERATE: &str = "generate";
+}
+
+impl LanguageClient {
+    pub fn handle_gopls_command(&self, cmd: &Command) -> Result<bool> {
+        match cmd.command.as_str() {
+            command::TEST => {
+                if let Some(args) = &cmd.arguments {
+                    if let Some(file) = args.get(0) {
+                        let file = String::deserialize(file)?;
+                        let path = parse_package_path(file.as_str()).unwrap_or("./...".into());
+                        let run = <Option<Vec<String>>>::deserialize(
+                            args.get(1).unwrap_or(&Value::Null),
+                        )?;
+
+                        let bench = <Option<Vec<String>>>::deserialize(
+                            args.get(2).unwrap_or(&Value::Null),
+                        )?;
+
+                        let run = run.unwrap_or_default();
+                        let bench = bench.unwrap_or_default();
+
+                        if run.len() > 0 {
+                            let cmd = format!("term go test -run '{}' {}", run.join("|"), path);
+                            self.vim()?.command(cmd)?;
+                        } else if bench.len() > 0 {
+                            let cmd = format!("term go test -bench '{}' {}", bench.join("|"), path);
+                            self.vim()?.command(cmd)?;
+                        } else {
+                            self.vim()?.echoerr("No tests to run")?;
+                        }
+                    }
+                }
+            }
+            command::GENERATE => {
+                if let Some(arguments) = &cmd.arguments {
+                    if let Some(package) = arguments.get(0) {
+                        let package = String::deserialize(package)?;
+                        let recursive =
+                            bool::deserialize(arguments.get(1).unwrap_or(&Value::Bool(false)))?;
+                        let cmd = match (package, recursive) {
+                            (package, false) => format!("term go generate -x {}", package),
+                            (_, true) => "term go generate -x ./...".into(),
+                        };
+                        self.vim()?.command(cmd)?;
+                    }
+                }
+            }
+
+            _ => return Ok(false),
+        }
+
+        Ok(true)
+    }
+}
+
+fn parse_package_path(path: &str) -> Option<String> {
+    let path = if path.starts_with("file://") {
+        path.strip_prefix("file://")?
+    } else {
+        path
+    };
+    let path = std::path::PathBuf::from(path);
+    Some(path.parent()?.to_str()?.to_owned())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_package_path() {
+        let folder = parse_package_path("file:///home/dev/someone/project/file.go");
+        assert!(folder.is_some());
+        assert_eq!("/home/dev/someone/project", folder.unwrap());
+
+        let folder = parse_package_path("/home/dev/someone/project/file.go");
+        assert!(folder.is_some());
+        assert_eq!("/home/dev/someone/project", folder.unwrap());
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,2 +1,3 @@
+pub mod gopls;
 pub mod java;
 pub mod rust_analyzer;

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,8 +13,8 @@ use log::*;
 use lsp_types::{
     CodeAction, CodeLens, Command, CompletionItem, CompletionTextEdit, Diagnostic,
     DiagnosticSeverity, DocumentHighlightKind, FileChangeType, FileEvent, Hover, HoverContents,
-    InsertTextFormat, Location, MarkedString, MarkupContent, MarkupKind, MessageType,
-    NumberOrString, Registration, SemanticHighlightingInformation, SymbolInformation,
+    InitializeResult, InsertTextFormat, Location, MarkedString, MarkupContent, MarkupKind,
+    MessageType, NumberOrString, Registration, SemanticHighlightingInformation, SymbolInformation,
     TextDocumentItem, TextDocumentPositionParams, TraceOption, Url, WorkspaceEdit,
 };
 use maplit::hashmap;
@@ -146,7 +146,7 @@ pub struct State {
     #[serde(skip_serializing)]
     pub vim: Vim,
 
-    pub capabilities: HashMap<String, Value>,
+    pub capabilities: HashMap<String, InitializeResult>,
     pub registrations: Vec<Registration>,
     pub roots: HashMap<String, String>,
     pub text_documents: HashMap<String, TextDocumentItem>,
@@ -209,6 +209,7 @@ pub struct State {
     pub use_virtual_text: UseVirtualText,
     pub hide_virtual_texts_on_insert: bool,
     pub echo_project_root: bool,
+    pub enable_extensions: Option<HashMap<String, bool>>,
 
     pub server_stderr: Option<String>,
     pub logger: Logger,
@@ -292,6 +293,7 @@ impl State {
             echo_project_root: true,
             server_stderr: None,
             preferred_markup_kind: None,
+            enable_extensions: None,
 
             logger,
         })


### PR DESCRIPTION
This PR adds a new config value (`g:LanguageClient_enableExtensions`), which provides a way to turn the provided language extensions off.

For example, to turn off Rust language extensions and enable Go extensions:
```vim
  let g:LanguageClient_enableExtensions = {
    \ 'go': v:true,
    \ 'rust': v:false,
    \ }
```

In that example we've enabled Go's extensions and disabled Rust's. Also, as we haven't specified any other filetypes, extensions for all the other filetypes will be disabled. If you wanted to also enable them for, say java, you'd have to include that in the config map as well.

This PR also adds extensions for Go, specifically for Go with `gopls` as a server. It provides extensions for `test` and `generate` code lenses, providing a way to run them in a vim terminal (like we do with the Rust tests). Here's a screencast of that functionality.

![Peek 2020-06-29 08-29](https://user-images.githubusercontent.com/4250565/85988275-b9db6000-b9e6-11ea-88f9-a6ec8628dfd2.gif)

I think at some point it will be worth considering moving to an plugin extensions scheme, were we provide additional plugins to plug this sort of language-server-specific functionality into the client via a defined interface. We could even have a wrapper plugin around all those plugins for the users that want to add a single line to their vimrc to get all the goodies. This requires a bit of work though, as some functionality is not properly exposed via vim functions, for example `rust-analyzer.showReferences` would requires us to re-write the whole UI selection thing in vim or to include a vim function to call into it. But even considering that extra work, and considering that this will probably be a breaking change, I think it would be the best scenario, as we would be able to remove that code from the client's codebase and open up the ecosystem to developers that want to support a very specific command from a very specific language server without us having to get in the way and maintain a zillion extensions baked into the binary. 

I was thinking, something in the lines of this:

https://github.com/martskins/lcn-extension-gopls
https://github.com/martskins/lcn-extension-rust-analyzer

And have `try_handle_commmand_by_client` call into the `lcn#extension#{language_server}#handle_command` function and handle it vim side (or call into the client again if necessary).

I know that this is way out of topic for this PR, but if sounds like a better alternative I'm up for closing this one and focusing on getting those two up to speed and adding the `java` one and the wrapper for all three so we get the same functionality.

What do you think @autozimu ?