### PR TITLE
support the workspace/configuration request

### DIFF
--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -86,6 +86,7 @@ impl LanguageClient {
             request::Rename::METHOD => self.text_document_rename(&params),
             request::DocumentSymbolRequest::METHOD => self.text_document_document_symbol(&params),
             request::ShowMessageRequest::METHOD => self.window_show_message_request(&params),
+            request::WorkspaceConfiguration::METHOD => self.workspace_configuration(&params),
             request::WorkspaceSymbol::METHOD => self.workspace_symbol(&params),
             request::CodeActionRequest::METHOD => self.text_document_code_action(&params),
             request::Completion::METHOD => self.text_document_completion(&params),


### PR DESCRIPTION
This is needed to send configuration to rust-analyzer and the TexLab language server.

Fixes #923.
