### PR TITLE
Add implementation for clangd's textDocument/switchSourceHeader

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -808,6 +808,15 @@ function! LanguageClient#findLocations(...) abort
     return LanguageClient#Call('languageClient/findLocations', l:params, l:Callback)
 endfunction
 
+function! LanguageClient#textDocument_switchSourceHeader(...) abort
+    let l:Callback = get(a:000, 1, v:null)
+    let l:params = {
+                \ 'filename': LSP#filename(),
+                \ }
+    call extend(l:params, get(a:000, 0, {}))
+    return LanguageClient#Call('textDocument/switchSourceHeader', l:params, l:Callback)
+endfunction
+
 function! LanguageClient#textDocument_definition(...) abort
     let l:params = {
                 \ 'method': 'textDocument/definition',

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -974,6 +974,10 @@ Signature: LanguageClient#diagnosticsPrevious()
 
 Moves the cursor to the previous diagnostic in the buffer, relative to the current cursor position.
 
+*LanguageClient#textDocument_switchSourceHeader*
+Signature: LanguageClient#textDocument_switchSourceHeader(...)
+
+Calls clangd's `textDocument/switchSourceHeader` extension request.
 
 ==============================================================================
 5. Mappings                                           *LanguageClientMappings*

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -146,6 +146,10 @@ function! LanguageClient_explainErrorAtPoint(...)
     return call('LanguageClient#explainErrorAtPoint', a:000)
 endfunction
 
+function! LanguageClient_textDocument_switchSourceHeader(...)
+    return call('LanguageClient#textDocument_switchSourceHeader', a:000)
+endfunction
+
 command! -nargs=* LanguageClientStart :call LanguageClient#startServer(<f-args>)
 command! LanguageClientStop :call LanguageClient#exit()
 

--- a/src/extensions/clangd.rs
+++ b/src/extensions/clangd.rs
@@ -1,0 +1,27 @@
+use crate::{language_client::LanguageClient, utils::ToUrl};
+use anyhow::Result;
+use jsonrpc_core::Value;
+use lsp_types::TextDocumentIdentifier;
+
+pub mod request {
+    pub const SWITCH_SOURCE_HEADER: &str = "textDocument/switchSourceHeader";
+}
+
+impl LanguageClient {
+    pub fn text_document_switch_source_header(&self, params: &Value) -> Result<Value> {
+        let filename = self.vim()?.get_filename(params)?;
+        let language_id = self.vim()?.get_language_id(&filename, &Value::Null)?;
+        let params = TextDocumentIdentifier {
+            uri: filename.to_url()?,
+        };
+
+        let response: String = self
+            .get_client(&Some(language_id))?
+            .call(request::SWITCH_SOURCE_HEADER, params)?;
+
+        let path = std::path::Path::new(&response);
+        self.vim()?.edit(&None, path)?;
+
+        Ok(Value::Null)
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,3 +1,4 @@
+pub mod clangd;
 pub mod gopls;
 pub mod java;
 pub mod rust_analyzer;

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -1,3 +1,4 @@
+use crate::extensions::clangd;
 use crate::{language_client::LanguageClient, language_server_protocol::Direction, types::*};
 use anyhow::{anyhow, Result};
 use log::*;
@@ -117,6 +118,10 @@ impl LanguageClient {
             REQUEST_CODE_LENS_ACTION => self.handle_code_lens_action(&params),
             REQUEST_SEMANTIC_SCOPES => self.semantic_scopes(&params),
             REQUEST_SHOW_SEMANTIC_HL_SYMBOLS => self.semantic_highlight_symbols(&params),
+
+            clangd::request::SWITCH_SOURCE_HEADER => {
+                self.text_document_switch_source_header(&params)
+            }
 
             _ => {
                 let language_id_target = if language_id.is_some() {


### PR DESCRIPTION
This PR adds support for clangd's `textDocument/switchSourceHeader` extension request. I only added the implementation and functions but no default mappings.

The name of the function could be problematic if eventually another server added an extension request with the same name, but I suppose that's unlikely to happen and we can always fix later (with a breaking change).

I didn't add a mapping for this, as it's very specific to that language server only, but users looking to add a mapping can always follow some of the other examples in the docs.

Closes #1021