### PR TITLE
Add support for rust-analyzer chaining hints

### DIFF
--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -2,3 +2,43 @@ pub mod clangd;
 pub mod gopls;
 pub mod java;
 pub mod rust_analyzer;
+
+use crate::language_client::LanguageClient;
+use anyhow::Result;
+
+impl LanguageClient {
+    pub fn text_document_inlay_hints(&self, language_id: &str, filename: &str) -> Result<()> {
+        if !self.extensions_enabled(language_id)? {
+            return Ok(());
+        }
+
+        let server_name = self.get_state(|state| match state.capabilities.get(language_id) {
+            Some(c) => c
+                .server_info
+                .as_ref()
+                .map(|info| info.name.clone())
+                .unwrap_or_default(),
+            None => String::new(),
+        })?;
+
+        let hints = match server_name.as_str() {
+            rust_analyzer::SERVER_NAME => self.rust_analyzer_inlay_hints(filename)?,
+            _ => return Ok(()),
+        };
+
+        self.update_state(|state| {
+            state.inlay_hints.insert(filename.to_string(), hints);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    pub fn extensions_enabled(&self, filetype: &str) -> Result<bool> {
+        let result = self.get_config(|c| match &c.enable_extensions {
+            Some(extensions) => extensions.get(filetype).cloned().unwrap_or(true),
+            None => true,
+        })?;
+        Ok(result)
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,6 +10,7 @@ use crate::{viewport::Viewport, vim::Highlight};
 use anyhow::{anyhow, Result};
 use jsonrpc_core::Params;
 use log::*;
+use lsp_types::Range;
 use lsp_types::{
     CodeAction, CodeLens, Command, CompletionItem, CompletionTextEdit, Diagnostic,
     DiagnosticSeverity, DocumentHighlightKind, FileChangeType, FileEvent, Hover, HoverContents,
@@ -128,6 +129,12 @@ pub enum UseVirtualText {
     No,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct InlayHint {
+    pub range: Range,
+    pub label: String,
+}
+
 #[derive(Serialize)]
 pub struct State {
     // Program state.
@@ -156,6 +163,8 @@ pub struct State {
     pub diagnostics: HashMap<String, Vec<Diagnostic>>,
     // filename => codeLens.
     pub code_lens: HashMap<String, Vec<CodeLens>>,
+    // filename => inlayHint.
+    pub inlay_hints: HashMap<String, Vec<InlayHint>>,
     #[serde(skip_serializing)]
     pub line_diagnostics: HashMap<(String, u64), String>,
     pub namespace_ids: HashMap<String, i64>,
@@ -175,6 +184,7 @@ pub struct State {
     pub stashed_code_action_actions: Vec<CodeAction>,
 
     pub logger: Logger,
+    pub initialization_options: HashMap<String, Value>,
 }
 
 impl State {
@@ -197,6 +207,7 @@ impl State {
             semantic_scopes: HashMap::new(),
             semantic_scope_to_hl_group_table: HashMap::new(),
             semantic_highlights: HashMap::new(),
+            inlay_hints: HashMap::new(),
             code_lens: HashMap::new(),
             diagnostics: HashMap::new(),
             line_diagnostics: HashMap::new(),
@@ -211,6 +222,7 @@ impl State {
             last_cursor_line: 0,
             last_line_diagnostic: " ".into(),
             stashed_code_action_actions: vec![],
+            initialization_options: HashMap::new(),
             logger,
         }
     }


### PR DESCRIPTION
This PR adds support for rust-analyzer chaining hints. rust-analyzer exposes this as a client->server request, so in order for this feature to be able to be turned on/off and have it behave similarly to other clients I had to retain the initialization options within the state of the client and check for the flag before issuing the request.

By default this feature is disabled, as it is a little invasive, but you can enable it by having a workspace settings (`.vim/settings.json`) that looks something like this:

```json
{
    "initializationOptions": {
        "inlayHints": {
            "enable": true
        }
    }
}
```

Note that you can also disable each type of hint individually, which the server then filters, but this `enable` flag is only valid/controlled client-side. The value of this is that it saves us a request to the server and it allows us to disable this as a default.

Also, the hints will only be visible if you are using virtual texts for code lens (`LanguageClient_useVirtualText = 'CodeLens'` or `LanguageClient_useVirtualText = 'All'`). And in the case that you are using virtual texts for both diagnostics and code lens, the diagnostics will take precedence over the hints/code lens.

This is how it looks like:

<img width="798" alt="image" src="https://user-images.githubusercontent.com/4250565/96925209-b98e3580-14ab-11eb-9700-4ec409f81ef7.png">

