### PR TITLE
Introduce LanguageClient_hoverMarginSize

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -392,14 +392,14 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
         call s:CloseFloatingHover()
 
         let pos = getpos('.')
-
+        let l:hoverMarginSize = s:GetVar('LanguageClient_hoverMarginSize', 1)
         " Calculate width and height and give margin to lines
         let width = 0
         for index in range(len(lines))
             let line = lines[index]
             if line !=# ''
                 " Give a left margin
-                let line = ' ' . line
+                let line = repeat(' ', l:hoverMarginSize) . line
             endif
             let lw = strdisplaywidth(line)
             if lw > width
@@ -409,8 +409,9 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
         endfor
 
         " Give margin
-        let width += 1
-        let lines = [''] + lines + ['']
+        let width += l:hoverMarginSize
+        let l:topBottom = repeat([''], l:hoverMarginSize)
+        let lines = l:topBottom + lines + l:topBottom
         let height = len(lines)
 
         " Calculate anchor

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -635,6 +635,28 @@ Highlight group to be used for code lens.
 
 Default: 'Comment'
 
+2.42 g:LanguageClient_hoverMarginSize        *g:LanguageClient_hoverMarginSize*
+
+When using floating windows to open hover previews (for more information see
+|g:LanguageClient_useFloatingHover|), this setting controls whether and how
+big of a margin to draw around the contents of the hover.
+
+Having some margin looks nice, so the default is 1.
+
+Floating windows don't have a true way to set padding/margin on them, so the
+strategy used is to add one line above and below the language server's raw
+hover response, and one space character before the start of every non-empty
+line in the hover response.
+
+Having a space in front of the hover content can cause some syntax
+highlighters to mess up (because e.g., they have a regex expecting a syntax
+construct to be anchored to the start of a line). To turn off adding this
+margin, set this setting to 0. Example:
+>
+  let g:LanguageClient_hoverMarginSize = 0
+<
+Default: 1
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 


### PR DESCRIPTION
The markdown plugin I use has a bunch of regex matching groups that look
for certain characters at the start of a line (like `###`), and the
syntax highlighting breaks when they're not on the start of the line.

We add a single space to the start of every line in a hover comment.
I'd like to make that configurable, so that I can get better markdown
syntax highlighting.

I've chosen to let the user set how big they want the margin to be as an
integer. I'd also be fine with an option that just removes the margin,
but this code is actually shorter to write.