### PR TITLE
Support sorbet: URIs

### DIFF
--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -113,6 +113,7 @@ impl LanguageClient {
             REQUEST_EXPLAIN_ERROR_AT_POINT => self.explain_error_at_point(&params),
             REQUEST_OMNI_COMPLETE => self.omnicomplete(&params),
             REQUEST_CLASS_FILE_CONTENTS => self.java_class_file_contents(&params),
+            REQUEST_SORBET_READ_FILE => self.sorbet_read_file(&params),
             REQUEST_DEBUG_INFO => self.debug_info(&params),
             REQUEST_CODE_LENS_ACTION => self.handle_code_lens_action(&params),
             REQUEST_SEMANTIC_SCOPES => self.semantic_scopes(&params),

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,6 +63,7 @@ pub const REQUEST_CODE_LENS_ACTION: &str = "LanguageClient/handleCodeLensAction"
 pub const REQUEST_SEMANTIC_SCOPES: &str = "languageClient/semanticScopes";
 pub const REQUEST_SHOW_SEMANTIC_HL_SYMBOLS: &str = "languageClient/showSemanticHighlightSymbols";
 pub const REQUEST_CLASS_FILE_CONTENTS: &str = "java/classFileContents";
+pub const REQUEST_SORBET_READ_FILE: &str = "sorbet/readFile";
 
 pub const NOTIFICATION_HANDLE_BUF_NEW_FILE: &str = "languageClient/handleBufNewFile";
 pub const NOTIFICATION_HANDLE_BUF_ENTER: &str = "languageClient/handleBufEnter";


### PR DESCRIPTION
Mostly trying to guage how much interest there is in this feature.
I see something similar already exists for `jdt://` URIs, and I used
that to model this implementation.

[Sorbet](https://sorbet.org), a type checker for Ruby, returns `sorbet:`
URIs when it knows about a file but that file does not exist on the
client's disk. That happens in two situations:

- The file is a part of the standard library type annotations (RBI
  files), which come baked into the Sorbet binary as a string.

- The client has passed Sorbet's --lsp-directories-missing-from-client
  flag, which declares folders that only exist where the server is
  running (say, a remote development machine), not where the editor is
  running (a laptop talking to that machine over SSH).

In both cases, Sorbet supports a `sorbet/readFile` file operation that
takes in a single `sorbet:...` URI and returns the text content of the
file (among other things--it actually returns a `TextDocumentItem` from
the LSP spec).

If Sorbet receieves this option in `initializationOptions` at startup:

```json
{
  "supportsSorbetURIs": true
}
```

It will send `sorbet:` URIs when appropriate. The expectation is that
the client will use those URIs to send `sorbet/readFile` requests and
handle them appropriately.

I'd love your thoughts on whether you think this is the sort of change
that would be worth committing to LanguageClient-neovim. I'm happy to
write tests for this change, but I didn't want to spend that effort
until I got feedback on the idea and the implementation.

I have tested this on my laptop for a few days while using Sorbet and it
has not had any problems.

Implementation of sorbet/readFile in Sorbet (~10 lines long):
https://github.com/sorbet/sorbet/blob/master/main/lsp/requests/sorbet_read_file.cc