### PR TITLE
Add support for automatic server restart on crash

### DIFF
--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -657,6 +657,20 @@ margin, set this setting to 0. Example:
 <
 Default: 1
 
+2.43 g:LanguageClient_restartOnCrash          *g:LanguageClient_restartOnCrash*
+
+If enabled, the client will attempt to restart the server on the event that it
+unexpectedly crashes.
+
+Default: 1
+
+2.44 g:LanguageClient_maxRestartRetries          *g:LanguageClient_maxRestartRetries*
+
+Max number of times to attempt to recover from a server crash. Each language
+handles its own count independently.
+
+Default: 5
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 
@@ -1093,6 +1107,11 @@ This event is triggered when diagnostics changed.
 *LanguageClientTextDocumentDidOpenPost*
 
 Triggered after textDocument/didOpen notification is sent to language server.
+
+6.5 LanguageServerCrashed
+*LanguageServerCrashed*
+
+This event is triggered when a language server unexpectedly quits.
 
 ==============================================================================
 7. License                                             *LanguageClientLicense*

--- a/src/types.rs
+++ b/src/types.rs
@@ -142,6 +142,7 @@ pub struct State {
 
     #[serde(skip_serializing)]
     pub clients: HashMap<LanguageId, Arc<RpcClient>>,
+    pub restarts: HashMap<LanguageId, u8>,
 
     #[serde(skip_serializing)]
     pub vim: Vim,
@@ -215,6 +216,8 @@ pub struct State {
     pub server_stderr: Option<String>,
     pub logger: Logger,
     pub preferred_markup_kind: Option<Vec<MarkupKind>>,
+    pub restart_on_crash: bool,
+    pub max_restart_retries: u8,
 }
 
 impl State {
@@ -228,6 +231,7 @@ impl State {
             BufWriter::new(std::io::stdout()),
             None,
             tx.clone(),
+            |_: &LanguageId| {},
         )?);
 
         Ok(Self {
@@ -236,6 +240,7 @@ impl State {
             clients: hashmap! {
                 None => client.clone(),
             },
+            restarts: HashMap::new(),
 
             vim: Vim::new(client),
 
@@ -296,6 +301,8 @@ impl State {
             preferred_markup_kind: None,
             enable_extensions: None,
             code_lens_hl_group: "Comment".into(),
+            restart_on_crash: true,
+            max_restart_retries: 5,
 
             logger,
         })


### PR DESCRIPTION
This PR adds support for automatic server restart retries on crash.

The way this is implemented it allows the user to specify whether or not to try to restart the server on crash via the option `LanguageClient_restartOnCrash` (which defaults to 1). Additionally, the user can specify a max number of retries via `LanguageClient_maxRestartRetries` (which applies for each languageId separately, and defaults to 5).

The restarts follow a very naive exponential backoff, I could have added a new dependency on a library that implements a better backoff logic, but I think this simple approach should be enough.

Also, when a server crashes, the client will emit a new event `LanguageServerCrashed`.

Note that the attempted restart gets the current file name for the server initialisation, so if for example, your Go server crashes, but you are currently editing a JS file, things might go wrong.

Closes #1110, #320 and #774.