### PR TITLE
Overall code improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,8 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "thiserror",
+ "tracing",
+ "tracing-log",
  "url",
 ]
 
@@ -730,6 +732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +989,50 @@ name = "tinyvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+
+[[package]]
+name = "tracing"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
 
 [[package]]
 name = "traitobject"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,5 @@ derivative = "2.1.1"
 anyhow = "1.0.32"
 thiserror = "1.0.20"
 lazy_static = "1.4.0"
+tracing = { version = "0.1", features = ["log", "log-always"] }
+tracing-log = "0.1.1"

--- a/src/rpcclient.rs
+++ b/src/rpcclient.rs
@@ -188,7 +188,7 @@ fn loop_read(
         if message.is_empty() {
             continue;
         }
-        info!("<= {:?} {}", language_id, message);
+        debug!("<= {:?} {}", language_id, message);
         // FIXME: Remove extra `meta` property from javascript-typescript-langserver and
         // `requestMethod` sent by Sorbet.
         let s = RE_REMOVE_EXTRA_FIELDS.replace(message, "");
@@ -235,7 +235,7 @@ fn loop_write(
 
     for msg in rx.iter() {
         let s = serde_json::to_string(&msg)?;
-        info!("=> {:?} {}", language_id, s);
+        debug!("=> {:?} {}", language_id, s);
         if language_id.is_none() {
             // Use different convention for two reasons,
             // 1. If using '\r\ncontent', nvim will receive output as `\r` + `content`, while vim


### PR DESCRIPTION
This PR is a bit of everything, but the overall goal is to make the code a little more readable and efficient 😄 
It essentially does three things:

- Adds the crates `tracing` and `tracing-log`: this enables us to replace all the manual logs we have in our methods with the `#[tracing::instrument]` macro, which will log the name of the function and the parameters it was called with. This makes the code much easier to read and uniform, and also makes the logs easier to read, as the function name and arguments are now logged on the same line and we get basically one line per function call.

- Removes unnecessary logs: now that we have the above we no longer need to log all the messages we receive and send to the server, as we're already logging the parameters with which we call the functions anyways, so this will make the logs a lot easier to read as well.

- Removes unnecessary clones: We had a lot of cases where we called `serde_json::from_value(value.clone())` when really we could be calling `T::deserialize(&value)`, which doesn't take ownership of `value` and achieves exactly the same.