### PR TITLE
Remove unnecessary calls to didChange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,8 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "thiserror",
+ "tracing",
+ "tracing-log",
  "url",
 ]
 
@@ -730,6 +732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +989,50 @@ name = "tinyvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+
+[[package]]
+name = "tracing"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
 
 [[package]]
 name = "traitobject"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,5 @@ derivative = "2.1.1"
 anyhow = "1.0.32"
 thiserror = "1.0.20"
 lazy_static = "1.4.0"
+tracing = { version = "0.1", features = ["log", "log-always"] }
+tracing-log = "0.1.1"

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -783,7 +783,6 @@ function! LanguageClient#textDocument_hover(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
                 \ 'handle': s:IsFalse(l:Callback),
@@ -846,7 +845,6 @@ function! LanguageClient#textDocument_references(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
                 \ 'includeDeclaration': v:true,
@@ -860,7 +858,6 @@ endfunction
 function! LanguageClient#textDocument_rename(...) abort
     let l:params = {
                 \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
                 \ 'cword': expand('<cword>'),
@@ -875,7 +872,6 @@ function! LanguageClient#textDocument_documentSymbol(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
                 \ 'handle': s:IsFalse(l:Callback),
                 \ }
     call extend(l:params, get(a:000, 0, {}))
@@ -886,7 +882,6 @@ function! LanguageClient#workspace_symbol(...) abort
     let l:Callback = get(a:000, 2, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
                 \ 'query': get(a:000, 0, ''),
                 \ 'handle': s:IsFalse(l:Callback),
                 \ }
@@ -898,7 +893,6 @@ function! LanguageClient#textDocument_codeLens(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
                 \ 'handle': s:IsFalse(l:Callback),
@@ -1023,7 +1017,6 @@ function! LanguageClient#textDocument_documentHighlight(...) abort
     let l:Callback = get(a:000, 1, v:null)
     let l:params = {
                 \ 'filename': LSP#filename(),
-                \ 'text': LSP#text(),
                 \ 'line': LSP#line(),
                 \ 'character': LSP#character(),
                 \ 'handle': s:IsFalse(l:Callback),

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -657,6 +657,20 @@ margin, set this setting to 0. Example:
 <
 Default: 1
 
+2.43 g:LanguageClient_restartOnCrash          *g:LanguageClient_restartOnCrash*
+
+If enabled, the client will attempt to restart the server on the event that it
+unexpectedly crashes.
+
+Default: 1
+
+2.44 g:LanguageClient_maxRestartRetries          *g:LanguageClient_maxRestartRetries*
+
+Max number of times to attempt to recover from a server crash. Each language
+handles its own count independently.
+
+Default: 5
+
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*
 
@@ -1093,6 +1107,11 @@ This event is triggered when diagnostics changed.
 *LanguageClientTextDocumentDidOpenPost*
 
 Triggered after textDocument/didOpen notification is sent to language server.
+
+6.5 LanguageServerCrashed
+*LanguageServerCrashed*
+
+This event is triggered when a language server unexpectedly quits.
 
 ==============================================================================
 7. License                                             *LanguageClientLicense*

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -462,7 +462,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_document_highlight(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(&Value::Null)?;
         let language_id = self.vim()?.get_language_id(&filename, &Value::Null)?;
         let position = self.vim()?.get_position(&Value::Null)?;
@@ -1307,7 +1306,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_hover(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
@@ -1347,7 +1345,6 @@ impl LanguageClient {
     /// Generic find locations, e.g, definitions, references.
     #[tracing::instrument(level = "info", skip(self))]
     pub fn find_locations(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let method: String =
             try_get("method", params)?.ok_or_else(|| anyhow!("method not found in request!"))?;
         let filename = self.vim()?.get_filename(params)?;
@@ -1411,7 +1408,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_rename(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
@@ -1458,7 +1454,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_document_symbol(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
 
@@ -1521,7 +1516,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_code_action(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
         let range = Range::deserialize(&params["range"])?;
@@ -1646,7 +1640,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_signature_help(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
         let position = self.vim()?.get_position(params)?;
@@ -1725,7 +1718,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_formatting(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
 
@@ -1763,7 +1755,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_range_formatting(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
         let start_line = try_get("range_start_line", params)?
@@ -1815,7 +1806,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn completion_item_resolve(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
         let completion_item: CompletionItem = try_get("completionItem", params)?
@@ -1934,7 +1924,6 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn workspace_symbol(&self, params: &Value) -> Result<Value> {
-        self.text_document_did_change(params)?;
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
 
@@ -2155,7 +2144,7 @@ impl LanguageClient {
     pub fn text_document_did_open(&self, params: &Value) -> Result<()> {
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;
-        let text = self.vim()?.get_text(&filename)?;
+        let text = self.vim()?.get_text(&filename, params)?;
         let set_omnifunc: bool = self
             .vim()?
             .eval("s:GetVar('LanguageClient_setOmnifunc', v:true)")?;
@@ -2205,7 +2194,7 @@ impl LanguageClient {
             return self.text_document_did_open(params);
         }
 
-        let text = self.vim()?.get_text(&filename)?.join("\n");
+        let text = self.vim()?.get_text(&filename, params)?.join("\n");
         let text_state = self.get(|state| {
             state
                 .text_documents
@@ -3888,7 +3877,6 @@ impl LanguageClient {
             .notify("setbufvar", json!([filename, VIM_IS_SERVER_RUNNING, 1]))?;
 
         self.text_document_did_open(&params)?;
-        self.text_document_did_change(&params)?;
 
         self.vim()?
             .rpcclient

--- a/src/rpcclient.rs
+++ b/src/rpcclient.rs
@@ -188,7 +188,7 @@ fn loop_read(
         if message.is_empty() {
             continue;
         }
-        info!("<= {:?} {}", language_id, message);
+        debug!("<= {:?} {}", language_id, message);
         // FIXME: Remove extra `meta` property from javascript-typescript-langserver and
         // `requestMethod` sent by Sorbet.
         let s = RE_REMOVE_EXTRA_FIELDS.replace(message, "");
@@ -235,7 +235,7 @@ fn loop_write(
 
     for msg in rx.iter() {
         let s = serde_json::to_string(&msg)?;
-        info!("=> {:?} {}", language_id, s);
+        debug!("=> {:?} {}", language_id, s);
         if language_id.is_none() {
             // Use different convention for two reasons,
             // 1. If using '\r\ncontent', nvim will receive output as `\r` + `content`, while vim

--- a/src/types.rs
+++ b/src/types.rs
@@ -142,6 +142,7 @@ pub struct State {
 
     #[serde(skip_serializing)]
     pub clients: HashMap<LanguageId, Arc<RpcClient>>,
+    pub restarts: HashMap<LanguageId, u8>,
 
     #[serde(skip_serializing)]
     pub vim: Vim,
@@ -215,6 +216,8 @@ pub struct State {
     pub server_stderr: Option<String>,
     pub logger: Logger,
     pub preferred_markup_kind: Option<Vec<MarkupKind>>,
+    pub restart_on_crash: bool,
+    pub max_restart_retries: u8,
 }
 
 impl State {
@@ -228,6 +231,7 @@ impl State {
             BufWriter::new(std::io::stdout()),
             None,
             tx.clone(),
+            |_: &LanguageId| {},
         )?);
 
         Ok(Self {
@@ -236,6 +240,7 @@ impl State {
             clients: hashmap! {
                 None => client.clone(),
             },
+            restarts: HashMap::new(),
 
             vim: Vim::new(client),
 
@@ -296,6 +301,8 @@ impl State {
             preferred_markup_kind: None,
             enable_extensions: None,
             code_lens_hl_group: "Comment".into(),
+            restart_on_crash: true,
+            max_restart_retries: 5,
 
             logger,
         })

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -154,8 +154,9 @@ impl Vim {
         Ok(insert_spaces == 1)
     }
 
-    pub fn get_text(&self, bufname: &str) -> Result<Vec<String>> {
-        self.rpcclient.call("LSP#text", json!([bufname]))
+    pub fn get_text(&self, bufname: &str, params: &Value) -> Result<Vec<String>> {
+        try_get("text", params)?
+            .map_or_else(|| self.rpcclient.call("LSP#text", json!([bufname])), Ok)
     }
 
     pub fn get_handle(&self, params: &Value) -> Result<bool> {


### PR DESCRIPTION
I'm not quite sure if this is correct, but all those calls to `text_document_did_change` seemed unnecessary to me. While removing those I also noticed that our `handle_text_change` function doesn't really do anything, it used to have a call to `text_document_did_change` but at some point that got deleted, and it seems to me like we want to have that there, especially if we're removing the other calls.

This also lets us remove the `text` parameter from the functions that don't really need it, reducing the size of the message considerably.