### PR TITLE
Add `shutdown` implementation

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1360,6 +1360,18 @@ function! LanguageClient#workspace_executeCommand(command, ...) abort
     return LanguageClient#Call('workspace/executeCommand', l:params, l:Callback)
 endfunction
 
+function! s:shutdownCallback(...) abort
+    call LanguageClient#exit()
+    echom '[LC] Server shutdown complete'
+endfunction
+
+function! LanguageClient#shutdown() abort
+    return LanguageClient#Call('shutdown', {
+                \ 'languageId': &filetype,
+                \ },
+                \ function('s:shutdownCallback'))
+endfunction
+
 function! LanguageClient#exit() abort
     return LanguageClient#Notify('exit', {
                 \ 'languageId': &filetype,

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -151,7 +151,7 @@ function! LanguageClient_textDocument_switchSourceHeader(...)
 endfunction
 
 command! -nargs=* LanguageClientStart :call LanguageClient#startServer(<f-args>)
-command! LanguageClientStop :call LanguageClient#exit()
+command! LanguageClientStop call LanguageClient#shutdown()
 
 augroup languageClient
     autocmd!

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -97,6 +97,7 @@ impl LanguageClient {
             request::ResolveCompletionItem::METHOD => self.completion_item_resolve(&params),
             request::ExecuteCommand::METHOD => self.workspace_execute_command(&params),
             request::ApplyWorkspaceEdit::METHOD => self.workspace_apply_edit(&params),
+            request::Shutdown::METHOD => self.shutdown(&params),
             request::DocumentHighlightRequest::METHOD => {
                 self.text_document_document_highlight(&params)
             }


### PR DESCRIPTION
This PR adds support for the `shutdown` request and fixes two issues. The first issue is that we were using `exit` instead of `shutdown` to indicate a server shutdown. The second issue is that shutting down (or exiting) the server would now cause the client to try and restart the server (because of the newly added auto-restart logic), so this checks whether the server was running before running the restart logic to fix that.

I've also modified the `LanguageClientStop` command to issue a `shutdown` instead of `exit` now, and call `exit` as a callback to `shutdown`.