### PR TITLE
Do not send requests/notifications for buffers without a configured server command

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -789,10 +789,24 @@ function! s:SkipSendingMessage() abort
     return &buftype !=# '' || &filetype ==# '' || expand('%') ==# ''
 endfunction
 
+function! s:ServerCommandForFiletype(filetype) abort
+  let s:commands = get(g:, 'LanguageClient_serverCommands', {})
+  if !has_key(s:commands, a:filetype)
+    return v:null
+  endif
+
+  return s:commands[a:filetype]
+endfunction
+
 function! LanguageClient#Call(method, params, callback, ...) abort
     if s:SkipSendingMessage()
         " call s:Debug('Skip sending message')
         return
+    endif
+
+    if s:ServerCommandForFiletype(&filetype) is v:null
+      echo '[LC] Server not configured for ' . &filetype . ', skipping request'
+      return
     endif
 
     let l:id = s:id
@@ -823,6 +837,10 @@ function! LanguageClient#Notify(method, params) abort
     if s:SkipSendingMessage()
         " call s:Debug('Skip sending message')
         return
+    endif
+
+    if s:ServerCommandForFiletype(&filetype) is v:null
+      return
     endif
 
     let l:params = a:params

--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -786,27 +786,16 @@ function! s:SkipSendingMessage() abort
         return v:false
     endif
 
-    return &buftype !=# '' || &filetype ==# '' || expand('%') ==# ''
-endfunction
+    let l:commands = get(g:, 'LanguageClient_serverCommands', {})
+    let l:has_command = has_key(l:commands, &filetype)
 
-function! s:ServerCommandForFiletype(filetype) abort
-  let s:commands = get(g:, 'LanguageClient_serverCommands', {})
-  if !has_key(s:commands, a:filetype)
-    return v:null
-  endif
-
-  return s:commands[a:filetype]
+    return !l:has_command || &buftype !=# '' || &filetype ==# '' || expand('%') ==# ''
 endfunction
 
 function! LanguageClient#Call(method, params, callback, ...) abort
     if s:SkipSendingMessage()
-        " call s:Debug('Skip sending message')
+        echo '[LC] Server not configured for filetype ' . &filetype
         return
-    endif
-
-    if s:ServerCommandForFiletype(&filetype) is v:null
-      echo '[LC] Server not configured for ' . &filetype . ', skipping request'
-      return
     endif
 
     let l:id = s:id
@@ -837,10 +826,6 @@ function! LanguageClient#Notify(method, params) abort
     if s:SkipSendingMessage()
         " call s:Debug('Skip sending message')
         return
-    endif
-
-    if s:ServerCommandForFiletype(&filetype) is v:null
-      return
     endif
 
     let l:params = a:params


### PR DESCRIPTION
This PR stops LCN from trying to communicate with a server for languages or from handling the events we track (such as `CursorMoved` for languages that don't have a configured server command.

I was a little dubious about setting `autocmd`s inside a function like that, but it seems to work.

Fixes #984 