### PR TITLE
Attempt to fix autodetection of fzf

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1466,7 +1466,7 @@ function! LanguageClient_contextMenu() abort
 				\ get(g:, 'LanguageClient_fzfContextMenu', 1))
     if l:useSelectionUI
             \ && (type(get(g:, 'LanguageClient_selectionUI', v:null)) is s:TYPE.funcref
-                \ || (get(g:, 'LanguageClient_selectionUI', v:null) ==? 'FZF'
+                \ || (get(g:, 'LanguageClient_selectionUI', 'FZF') ==? 'FZF'
                     \ && get(g:, 'loaded_fzf')
                 \ )
             \ )


### PR DESCRIPTION
Prior to this commit, even if `fzf` was available on the PATH, it wasn't
used for the pleasant UI. Setting `g:LanguageClient_selectionUI` to
`FZF` definitely worked, but the documentation says this isn't
necessary.

Please note that I've not tested this extensively. Removing fzf from the PATH doesn't result in any problems, but I haven't checked if there are more places where this was/is broken.