### PR TITLE
Fix start_server implementation

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1056,7 +1056,7 @@ function! LanguageClient#textDocument_rangeFormatting_sync(...) abort
     return l:result isnot v:null
 endfunction
 
-function! LanguageClient#textDocument_didOpen() abort
+function! LanguageClient#textDocument_didOpen(...) abort
     return LanguageClient#Notify('textDocument/didOpen', {
                 \ 'filename': LSP#filename(),
                 \ 'text': LSP#text(),
@@ -1113,7 +1113,7 @@ function! LanguageClient#startServer(...) abort
                 \ 'cmdargs': [],
                 \ }
     call extend(l:params, a:0 > 0 ? {'cmdargs': a:000} : {})
-    return LanguageClient#Call('languageClient/startServer', l:params, v:null)
+    return LanguageClient#Call('languageClient/startServer', l:params, funcref('LanguageClient#textDocument_didOpen'))
 endfunction
 
 function! LanguageClient#registerServerCommands(cmds, ...) abort

--- a/src/types.rs
+++ b/src/types.rs
@@ -135,6 +135,7 @@ pub struct State {
 
     #[serde(skip_serializing)]
     pub clients: HashMap<LanguageId, Arc<RpcClient>>,
+    #[serde(skip_serializing)]
     pub restarts: HashMap<LanguageId, u8>,
 
     #[serde(skip_serializing)]


### PR DESCRIPTION
This PR removes the calls to `did_open` and `did_change` inside our `start_server` implementation as errors from those could be misleading in indicating that the server had failed. Also, the call to `did_change` I think isn't really necessary since we're already sending the text inside `did_open`.