### PR TITLE
Fix incorrect logic around placing signs

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -177,15 +177,33 @@ function! s:set_virtual_texts(buf_id, ns_id, line_start, line_end, virtual_texts
     endfor
 endfunction
 
-function! s:set_signs(file, signs_to_add, signs_to_delete) abort
-    " TODO: Optimize to update sign instead of add + remove sign.
-    for l:sign in a:signs_to_add
-        let l:line = l:sign['line'] + 1
-        execute ':sign place ' . l:sign['id'] . ' line=' . l:line . ' name=' . l:sign['name'] . ' file=' . a:file
-    endfor
-    for l:sign in a:signs_to_delete
-        execute ':sign unplace ' . l:sign['id']
-    endfor
+function! s:place_sign(id, name, file, line) abort
+  if !exists('*sign_place')
+    execute 'sign place id=' . a:id . ' name=' . a:name . ' file=' . a:file . ' line=' . a:line
+  endif
+
+  call sign_place(0, 'LanguageClientNeovim', a:name, a:file, { 'lnum': a:line })
+endfunction
+
+" clears all signs on the buffer with the given name
+function! s:clear_buffer_signs(file) abort
+  if !exists('*sign_unplace')
+    execute 'sign unplace * group=LanguageClientNeovim buffer=' . a:file
+  else
+    call sign_unplace('LanguageClientNeovim', { 'buffer': a:file })
+  endif
+endfunction
+
+" replaces the signs on a file with the ones passed as an argument
+function! s:set_signs(file, signs) abort
+  call s:clear_buffer_signs(a:file)
+
+  for l:sign in a:signs
+    let l:line = l:sign['line'] + 1
+    let l:name = l:sign['name']
+    let l:id = l:sign['id']
+    call s:place_sign(l:id, l:name, a:file, l:line)
+  endfor
 endfunction
 
 " Execute serious of ex commands.

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -191,7 +191,7 @@ impl LanguageClient {
             NOTIFICATION_HANDLE_TEXT_CHANGED => self.handle_text_changed(&params)?,
             NOTIFICATION_HANDLE_BUF_WRITE_POST => self.handle_buf_write_post(&params)?,
             NOTIFICATION_HANDLE_BUF_DELETE => self.handle_buf_delete(&params)?,
-            NOTIFICATION_HANDLE_CURSOR_MOVED => self.handle_cursor_moved(&params)?,
+            NOTIFICATION_HANDLE_CURSOR_MOVED => self.handle_cursor_moved(&params, false)?,
             NOTIFICATION_HANDLE_COMPLETE_DONE => self.handle_complete_done(&params)?,
             NOTIFICATION_FZF_SINK_LOCATION => self.fzf_sink_location(&params)?,
             NOTIFICATION_FZF_SINK_COMMAND => self.fzf_sink_command(&params)?,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,12 +1,11 @@
-use crate::logger::Logger;
 use crate::rpcclient::RpcClient;
-use crate::sign::Sign;
 use crate::{
     language_client::LanguageClient,
     utils::{code_action_kind_as_str, ToUrl},
     vim::Vim,
     watcher::FSWatch,
 };
+use crate::{logger::Logger, viewport::Viewport};
 use anyhow::{anyhow, Result};
 use jsonrpc_core::Params;
 use log::*;
@@ -22,7 +21,7 @@ use pathdiff::diff_paths;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     io::{BufRead, BufReader, BufWriter, Write},
     net::TcpStream,
     path::{Path, PathBuf},
@@ -151,6 +150,7 @@ pub struct State {
     pub registrations: Vec<Registration>,
     pub roots: HashMap<String, String>,
     pub text_documents: HashMap<String, TextDocumentItem>,
+    pub viewports: HashMap<String, Viewport>,
     pub text_documents_metadata: HashMap<String, TextDocumentItemMetadata>,
     pub semantic_scopes: HashMap<String, Vec<Vec<String>>>,
     pub semantic_scope_to_hl_group_table: HashMap<String, Vec<Option<String>>>,
@@ -163,8 +163,6 @@ pub struct State {
     pub code_lens_hl_group: String,
     #[serde(skip_serializing)]
     pub line_diagnostics: HashMap<(String, u64), String>,
-    /// Active signs.
-    pub signs: HashMap<String, BTreeMap<u64, Sign>>,
     pub namespace_ids: HashMap<String, i64>,
     pub highlight_source: Option<u64>,
     pub highlights: HashMap<String, Vec<Highlight>>,
@@ -248,6 +246,7 @@ impl State {
             registrations: vec![],
             roots: HashMap::new(),
             text_documents: HashMap::new(),
+            viewports: HashMap::new(),
             text_documents_metadata: HashMap::new(),
             semantic_scopes: HashMap::new(),
             semantic_scope_to_hl_group_table: HashMap::new(),
@@ -255,7 +254,6 @@ impl State {
             code_lens: HashMap::new(),
             diagnostics: HashMap::new(),
             line_diagnostics: HashMap::new(),
-            signs: HashMap::new(),
             namespace_ids: HashMap::new(),
             highlight_source: None,
             highlights: HashMap::new(),

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -241,15 +241,7 @@ impl Vim {
         )
     }
 
-    pub fn set_signs(
-        &self,
-        filename: &str,
-        signs_to_add: &[Sign],
-        signs_to_delete: &[Sign],
-    ) -> Result<i8> {
-        self.rpcclient.call(
-            "s:set_signs",
-            json!([filename, signs_to_add, signs_to_delete]),
-        )
+    pub fn set_signs(&self, filename: &str, signs: &[Sign]) -> Result<i8> {
+        self.rpcclient.call("s:set_signs", json!([filename, signs]))
     }
 }


### PR DESCRIPTION
This PR attempts to fix a bug around the logic on how we place the signs. The issue is described in #1125.

The fix I'm proposing simplifies a lot of the complexity around signs but could also be more expensive in some cases, as instead of calculating the signs diff and sending the signs to add and signs to delete, I propose just replacing the signs on the buffer with the new ones that fit in the current viewport. This is a pretty naive approach but I think we should favour correctness over performance.

I did, however, do what I mentioned in the issue: keep track of the viewport for each file and only update the signs when it has changed (except for cases like file changes when we really really want to update it, for which I added a `force_redraw` flag to the `handle_cursor_moved` function). I applied the same viewport logic to the section of `handle_cursor_moved` where we redraw virtual texts and highlights, so all this should also save us a lot of other updates to the buffer.

![Kapture 2020-10-31 at 20 44 00](https://user-images.githubusercontent.com/4250565/97789639-09f74880-1bba-11eb-9417-c878c02f4630.gif)

Fixes #1125 and #964
