### PR TITLE
Do not call LanguageClient#handleBufWritePost on :wq

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -709,6 +709,11 @@ endfunction
 function! LanguageClient#Write(message) abort
     let l:message = a:message . "\n"
     if has('nvim')
+        " abort write if nvim is exiting
+        if get(v:, 'exiting', v:null) isnot v:null
+          return
+        endif
+
         " jobsend respond 1 for success.
         return !jobsend(s:job, l:message)
     elseif has('channel')


### PR DESCRIPTION
This PR fixes an issue with us calling `LanguageClient#handleBufWritePost` on `:wq`, causing the client to log an error to the console after leaving vim due to it not being able to complete that call.

Fixes #1127 