### PR TITLE
Use GetVar instead of get in HasCommand

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -786,10 +786,13 @@ function! s:SkipSendingMessage() abort
         return v:false
     endif
 
-    let l:commands = get(g:, 'LanguageClient_serverCommands', {})
-    let l:has_command = has_key(l:commands, &filetype)
-
+    let l:has_command = LanguageClient#HasCommand(&filetype)
     return !l:has_command || &buftype !=# '' || &filetype ==# '' || expand('%') ==# ''
+endfunction
+
+function! LanguageClient#HasCommand(filetype) abort
+  let l:commands = s:GetVar('LanguageClient_serverCommands', {})
+  return has_key(l:commands, a:filetype)
 endfunction
 
 function! LanguageClient#Call(method, params, callback, ...) abort

--- a/plugin/LanguageClient.vim
+++ b/plugin/LanguageClient.vim
@@ -154,7 +154,7 @@ command! -nargs=* LanguageClientStart :call LanguageClient#startServer(<f-args>)
 command! LanguageClientStop call LanguageClient#shutdown()
 
 function! s:OnBufEnter()
-  if !s:HasCommand()
+  if !LanguageClient#HasCommand(&filetype)
     return
   endif
 
@@ -163,17 +163,12 @@ function! s:OnBufEnter()
 endfunction
 
 function! s:OnFileType()
-  if !s:HasCommand()
+  if !LanguageClient#HasCommand(&filetype)
     return
   endif
 
   call LanguageClient#handleFileType()
   call s:ConfigureAutocmds()
-endfunction
-
-function! s:HasCommand()
-  let l:commands = get(g:, 'LanguageClient_serverCommands', {})
-  return has_key(l:commands, &filetype)
 endfunction
 
 function! s:ConfigureAutocmds()


### PR DESCRIPTION
This PR fixes the way we check for server commands. It was previously using `g:LanguageClient_serverCommands` and not considering that the command could be configured in `b:LanguageClient_serverCommands`. I changed the implementation to use `s:GetVar` instead of `get(g:, ..)` to take this into account.