### PR TITLE
Fix markdown syntax on hover

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -524,6 +524,8 @@ function! s:OpenHoverPreview(bufname, lines, filetype) abort
         endif
 
         call setline(1, lines)
+        " trigger refresh on plasticboy/vim-markdown
+        normal! i
         setlocal nomodified nomodifiable
 
         wincmd p


### PR DESCRIPTION
This PR fixes an issue with syntax highlighting with plasticboy/vim-markdown. The issue was we were not triggering any autocmds that would translate in the plugin refreshing the syntax. Adding a `normal i` was enough for this as the plugin refreshes on `InsertLeave`.