### PR TITLE
Handle empty hover contents

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1270,6 +1270,12 @@ impl LanguageClient {
 
         let hover = Option::<Hover>::deserialize(&result)?;
         if let Some(hover) = hover {
+            if hover.to_display().is_empty() {
+                self.vim()?
+                    .echowarn("No hover information found for symbol")?;
+                return Ok(Value::Null);
+            }
+
             let hover_preview = self.get(|state| state.hover_preview)?;
             let use_preview = match hover_preview {
                 HoverPreviewOption::Always => true,


### PR DESCRIPTION
This PR prevents the preview from showing if the contents of the hover info are empty.

Fixes #873 