### PR TITLE
Add parameter to silence explainErrorAtPoint

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -560,9 +560,9 @@ function! s:OpenHoverPreview(bufname, lines, filetype, ...) abort
     endif
 endfunction
 
-function! s:MoveIntoHoverPreview() abort
+function! s:MoveIntoHoverPreview(bufname) abort
     for bufnr in range(1, bufnr('$'))
-        if bufname(bufnr) ==# '__LanguageClient__'
+        if bufname(bufnr) ==# a:bufname
             let winnr = bufwinnr(bufnr)
             if winnr != -1
                 execute winnr . 'wincmd w'
@@ -865,7 +865,7 @@ function! LanguageClient#Notify(method, params) abort
 endfunction
 
 function! LanguageClient#textDocument_hover(...) abort
-    if s:ShouldUseFloatWindow() && s:MoveIntoHoverPreview()
+    if s:ShouldUseFloatWindow() && s:MoveIntoHoverPreview('__LCNHover__')
         return
     endif
     let l:Callback = get(a:000, 1, v:null)
@@ -1353,7 +1353,9 @@ function! LanguageClient_NCM2OnComplete(context) abort
 endfunction
 
 function! LanguageClient#explainErrorAtPoint(...) abort
-    if s:ShouldUseFloatWindow() && s:MoveIntoHoverPreview()
+    let extra = get(a:000, 0, {})
+    let silent_mode = get(extra, 'silent', v:false)
+    if s:ShouldUseFloatWindow() && !silent_mode && s:MoveIntoHoverPreview('__LCNExplainError__')
         return
     endif
 
@@ -1365,7 +1367,7 @@ function! LanguageClient#explainErrorAtPoint(...) abort
                 \ 'character': LSP#character(),
                 \ 'handle': s:IsFalse(l:Callback),
                 \ }
-    call extend(l:params, get(a:000, 0, {}))
+    call extend(l:params, extra)
     return LanguageClient#Call('languageClient/explainErrorAtPoint', l:params, l:Callback)
 endfunction
 

--- a/tests/LanguageClient_test.py
+++ b/tests/LanguageClient_test.py
@@ -39,7 +39,7 @@ def assertRetry(predicate, retry_max=100):
 
 
 def getLanguageClientBuffers(nvim):
-    return [b for b in nvim.buffers if b.name.endswith("__LanguageClient__")]
+    return [b for b in nvim.buffers if b.name.endswith("__LCNHover__")]
 
 
 @pytest.fixture(scope="module")
@@ -324,7 +324,7 @@ def test_textDocument_hover_float_window_move_cursor_into_window(nvim):
 
     # Moves cursor into floating window
     nvim.funcs.LanguageClient_textDocument_hover()
-    assert nvim.current.buffer.name.endswith("__LanguageClient__")
+    assert nvim.current.buffer.name.endswith("__LCNHover__")
 
     # Close the window
     nvim.command('close')


### PR DESCRIPTION
This PR adds an optional parameter to be sent to explainErrorAtPoint so that the `no diagnostics found` error can be silenced. The function can be called as it was called normally, but it also now can be called like this:

`:call LanguageClient#explainErrorAtPoint({'silent': v:true})`

This is useful for users that want to set up this call on `CursorHold` without having an error displayed every time they stop on a position with no diagnostic in it. The relevant autocmd config for that would then look like this:

`autocmd CursorHold * call LanguageClient#explainErrorAtPoint({'silent': v:true})`

Note that I had to move things around a little so that the cursor would not move inside the window after a second `CursorHold` with the hover open. And also to prevent moving into the window by calling `LanguageClient#textDocument_hover()`. There is an interaction between those two that is not really ideal, but I think it makes sense in any case, and that is that if you call hover on a position where you have an error (meaning, the window for explainErrorAtPoint is being display), the documentation window will basically show and immediately hide, because the CursorHold fires the explainErrorAtPoint again. I think we can probably do something about this, but I suppose the wanted behaviour is a little user-specific, so I'm leaving it as is because it's at least somewhat useful like this (you at least get a peek at the documentation).

Closes #884 