### PR TITLE
Use LCN defined highlights and introduce CodeLensDisplay config

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -14,6 +14,35 @@ let s:POPUP_WINDOW_AVAILABLE = exists('*popup_atcursor')
 " timers to control throttling
 let s:timers = {}
 
+if !hlexists('LanguageClientCodeLens')
+  hi link LanguageClientCodeLens Title
+endif
+
+if !hlexists('LanguageClientWarningSign')
+  hi link LanguageClientWarningSign todo
+endif
+
+if !hlexists('LanguageClientWarning')
+  hi link LanguageClientWarning SpellCap
+endif
+
+if !hlexists('LanguageClientInfoSign')
+  hi link LanguageClientInfoSign LanguageClientWarningSign
+endif
+
+if !hlexists('LanguageClientInfo')
+  hi link LanguageClientInfo LanguageClientWarning
+endif
+
+if !hlexists('LanguageClientErrorSign')
+  hi link LanguageClientErrorSign error
+endif
+
+if !hlexists('LanguageClientError')
+  hi link LanguageClientError SpellBad
+endif
+
+
 function! s:AddPrefix(message) abort
     return '[LC] ' . a:message
 endfunction

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -103,30 +103,30 @@ Default: >
     {
         1: {
             "name": "Error",
-            "texthl": "ALEError",
+            "texthl": "LanguageClientError",
             "signText": "✖",
-            "signTexthl": "ALEErrorSign",
+            "signTexthl": "LanguageClientErrorSign",
             "virtualTexthl": "Error",
         },
         2: {
             "name": "Warning",
-            "texthl": "ALEWarning",
+            "texthl": "LanguageClientWarning",
             "signText": "⚠",
-            "signTexthl": "ALEWarningSign",
+            "signTexthl": "LanguageClientWarningSign",
             "virtualTexthl": "Todo",
         },
         3: {
             "name": "Information",
-            "texthl": "ALEInfo",
+            "texthl": "LanguageClientInfo",
             "signText": "ℹ",
-            "signTexthl": "ALEInfoSign",
+            "signTexthl": "LanguageClientInfoSign",
             "virtualTexthl": "Todo",
         },
         4: {
             "name": "Hint",
-            "texthl": "ALEInfo",
+            "texthl": "LanguageClientInfo",
             "signText": "➤",
-            "signTexthl": "ALEInfoSign",
+            "signTexthl": "LanguageClientInfoSign",
             "virtualTexthl": "Todo",
         },
     }
@@ -629,11 +629,14 @@ The default value for this config, or the absence of this config, enables extens
 
 Default: v:null
 
-2.41 g:LanguageClient_codeLensHighlightGroup          *g:LanguageClient_codeLensHighlightGroup*
+2.41 g:LanguageClient_codeLensDisplay          *g:LanguageClient_codeLensDisplay*
 
-Highlight group to be used for code lens.
+Control how code lenses are displayed.
 
-Default: 'Comment'
+Default: >
+  {
+    "virtualTexthl": "LanguageClientCodeLens",
+  }
 
 2.42 g:LanguageClient_hoverMarginSize        *g:LanguageClient_hoverMarginSize*
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -155,7 +155,7 @@ pub struct State {
     pub diagnostics: HashMap<String, Vec<Diagnostic>>,
     // filename => codeLens.
     pub code_lens: HashMap<String, Vec<CodeLens>>,
-    pub code_lens_hl_group: String,
+    pub code_lens_display: CodeLensDisplay,
     #[serde(skip_serializing)]
     pub line_diagnostics: HashMap<(String, u64), String>,
     pub namespace_ids: HashMap<String, i64>,
@@ -291,7 +291,7 @@ impl State {
             server_stderr: None,
             preferred_markup_kind: None,
             enable_extensions: None,
-            code_lens_hl_group: "Comment".into(),
+            code_lens_display: CodeLensDisplay::default(),
             restart_on_crash: true,
             max_restart_retries: 5,
 
@@ -403,6 +403,20 @@ impl FromStr for DiagnosticsList {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct CodeLensDisplay {
+    pub virtual_texthl: String,
+}
+
+impl Default for CodeLensDisplay {
+    fn default() -> Self {
+        CodeLensDisplay {
+            virtual_texthl: "LanguageClientCodeLens".into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DiagnosticsDisplay {
     pub name: String,
     pub texthl: String,
@@ -418,9 +432,9 @@ impl DiagnosticsDisplay {
             1,
             Self {
                 name: "Error".to_owned(),
-                texthl: "ALEError".to_owned(),
+                texthl: "LanguageClientError".to_owned(),
                 sign_text: "✖".to_owned(),
-                sign_texthl: "ALEErrorSign".to_owned(),
+                sign_texthl: "LanguageClientErrorSign".to_owned(),
                 virtual_texthl: "Error".to_owned(),
             },
         );
@@ -428,9 +442,9 @@ impl DiagnosticsDisplay {
             2,
             Self {
                 name: "Warning".to_owned(),
-                texthl: "ALEWarning".to_owned(),
+                texthl: "LanguageClientWarning".to_owned(),
                 sign_text: "⚠".to_owned(),
-                sign_texthl: "ALEWarningSign".to_owned(),
+                sign_texthl: "LanguageClientWarningSign".to_owned(),
                 virtual_texthl: "Todo".to_owned(),
             },
         );
@@ -438,9 +452,9 @@ impl DiagnosticsDisplay {
             3,
             Self {
                 name: "Information".to_owned(),
-                texthl: "ALEInfo".to_owned(),
+                texthl: "LanguageClientInfo".to_owned(),
                 sign_text: "ℹ".to_owned(),
-                sign_texthl: "ALEInfoSign".to_owned(),
+                sign_texthl: "LanguageClientInfoSign".to_owned(),
                 virtual_texthl: "Todo".to_owned(),
             },
         );
@@ -448,9 +462,9 @@ impl DiagnosticsDisplay {
             4,
             Self {
                 name: "Hint".to_owned(),
-                texthl: "ALEInfo".to_owned(),
+                texthl: "LanguageClientInfo".to_owned(),
                 sign_text: "➤".to_owned(),
-                sign_texthl: "ALEInfoSign".to_owned(),
+                sign_texthl: "LanguageClientInfoSign".to_owned(),
                 virtual_texthl: "Todo".to_owned(),
             },
         );


### PR DESCRIPTION
This PR defines highlight groups for diagnostics display instead of relying on the ones defined by ALE being available. This fixes the default config for vim8 users that don't use ale, as using an undefined highlight group in vim results in an error (it doesn't in neovim).

It also creates a new struct `CodeLensDisplay` to be used to control how code lenses are displayed so that both code lenses and diagnostics are configured in a similar fashion. Right now, the `CodeLensDisplay` struct only takes the `virtual_texthl`, but eventually my plan is to add support for signs for code lenses, so that vim8 users can know that there is a code lens in that line, as right now they can't because of the lack of virtual texts in vim8.

Note that this introduces a minor breaking change, as the config for controlling code lens highlight group has been changed, but it is a non-critical break and the client will continue to work normally except that it will not display the expected highlight group, and also that config is rather new so probably not so many users are aware of it, so I think we should merge as is.