### PR TITLE
Use separate namespaces for document and diagnostic highlights

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -337,10 +337,11 @@ function! s:ApplySemanticHighlights(bufnr, ns_id, clears, highlights) abort
 endfunction
 
 " Batch version of nvim_buf_add_highlight
-function! s:AddHighlights(namespace_id, highlights) abort
+function! s:AddHighlights(namespace, highlights) abort
   if has('nvim')
+    let l:namespace_id = nvim_create_namespace(a:namespace)
     for hl in a:highlights
-        call nvim_buf_add_highlight(0, a:namespace_id, hl.group, hl.line, hl.character_start, hl.character_end)
+        call nvim_buf_add_highlight(0, l:namespace_id, hl.group, hl.line, hl.character_start, hl.character_end)
     endfor
   else
     let match_ids = []
@@ -349,32 +350,27 @@ function! s:AddHighlights(namespace_id, highlights) abort
       let match_ids = add(match_ids, match_id)
     endfor
 
-    call setbufvar(bufname(), 'document_highlight_match_ids', match_ids)
+    call setbufvar(bufname(), a:namespace . '_IDS', match_ids)
   endif
 endfunction
 
-function! s:SetHighlights(highlights) abort
-  call s:ClearHighlights()
-  if has('nvim')
-    let s:namespace_id = nvim_create_namespace('__LCN_DOCUMENT_HIGHLIGHTS__')
-    call s:AddHighlights(s:namespace_id, a:highlights)
-  else
-    call s:AddHighlights(0, a:highlights)
-  endif
+function! s:SetHighlights(highlights, namespace) abort
+  call s:ClearHighlights(a:namespace)
+  call s:AddHighlights(a:namespace, a:highlights)
 endfunction
 
-function! s:ClearHighlights() abort
+function! s:ClearHighlights(namespace) abort
   if has('nvim')
-    let s:namespace_id = nvim_create_namespace('__LCN_DOCUMENT_HIGHLIGHTS__')
-    call nvim_buf_clear_namespace(0, s:namespace_id, 0, -1)
+    let l:namespace_id = nvim_create_namespace(a:namespace)
+    call nvim_buf_clear_namespace(0, l:namespace_id, 0, -1)
   else
-    let match_ids = get(b:, 'document_highlight_match_ids', [])
+    let match_ids = get(b:, a:namespace . '_IDS', [])
     for mid in match_ids
       " call inside a try/catch to avoid error for manually cleared matches
       try | call matchdelete(mid) | catch
       endtry
     endfor
-    call setbufvar(bufname(), 'document_highlight_match_ids', [])
+    call setbufvar(bufname(), a:namespace . '_IDS', [])
   endif
 endfunction
 

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -510,7 +510,8 @@ impl LanguageClient {
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            self.vim()?.set_highlights(&highlights)?;
+            self.vim()?
+                .set_highlights(&highlights, "__LCN_DOCUMENT_HIGHLIGHT__")?;
         }
 
         Ok(result)
@@ -518,7 +519,7 @@ impl LanguageClient {
 
     #[tracing::instrument(level = "info", skip(self))]
     pub fn clear_document_highlight(&self, _params: &Value) -> Result<()> {
-        self.vim()?.clear_highlights()
+        self.vim()?.clear_highlights("__LCN_DOCUMENT_HIGHLIGHT__")
     }
 
     #[tracing::instrument(level = "info", skip(self))]
@@ -3117,7 +3118,8 @@ impl LanguageClient {
                 .collect())
         })?;
 
-        self.vim()?.set_highlights(&highlights)?;
+        self.vim()?
+            .set_highlights(&highlights, "__LCN_DIAGNOSTIC_HIGHLIGHT__")?;
         self.draw_virtual_texts(&params)?;
 
         Ok(())

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -239,18 +239,19 @@ impl Vim {
     }
 
     /// clears all highlights in the current buffer.
-    pub fn clear_highlights(&self) -> Result<()> {
-        self.rpcclient.notify("s:ClearHighlights", json!([]))
+    pub fn clear_highlights(&self, namespace: &str) -> Result<()> {
+        self.rpcclient
+            .notify("s:ClearHighlights", json!([namespace]))
     }
 
     /// replaces the highlights of the current document with the passed highlights.
-    pub fn set_highlights(&self, highlights: &[Highlight]) -> Result<()> {
+    pub fn set_highlights(&self, highlights: &[Highlight], namespace: &str) -> Result<()> {
         if highlights.is_empty() {
-            return Ok(());
+            return self.clear_highlights(namespace);
         }
 
         self.rpcclient
-            .notify("s:SetHighlights", json!([highlights]))
+            .notify("s:SetHighlights", json!([highlights, namespace]))
     }
 
     pub fn create_namespace(&self, name: &str) -> Result<i64> {


### PR DESCRIPTION
This PR fixes an issue with highlight namespacing that would result in not being able to differentiate diagnostic highlights over document highlights when clearing them.