### PR TITLE
Refactor textDocument/definition to use it's own method

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -932,11 +932,17 @@ function! LanguageClient#textDocument_switchSourceHeader(...) abort
 endfunction
 
 function! LanguageClient#textDocument_definition(...) abort
+    let l:Callback = get(a:000, 1, v:null)
     let l:params = {
-                \ 'method': 'textDocument/definition',
+                \ 'filename': LSP#filename(),
+                \ 'text': LSP#text(),
+                \ 'line': LSP#line(),
+                \ 'character': LSP#character(),
+                \ 'handle': s:IsFalse(l:Callback),
+                \ 'gotoCmd': v:null,
                 \ }
     call extend(l:params, get(a:000, 0, {}))
-    return call('LanguageClient#findLocations', [l:params] + a:000[1:])
+    return LanguageClient#Call('textDocument/definition', l:params, l:Callback)
 endfunction
 
 function! LanguageClient#textDocument_typeDefinition(...) abort

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -1659,9 +1659,18 @@ impl LanguageClient {
     }
 
     #[tracing::instrument(level = "info", skip(self))]
+    pub fn text_document_definition(&self, params: &Value) -> Result<Value> {
+        let params = json!({
+            "method": lsp_types::request::GotoDefinition::METHOD,
+        })
+        .combine(params);
+        let result = self.find_locations(&params)?;
+        Ok(result)
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
     pub fn text_document_references(&self, params: &Value) -> Result<Value> {
         let include_declaration: bool = try_get("includeDeclaration", params)?.unwrap_or(true);
-        // TODO: cleanup.
         let params = json!({
             "method": lsp_types::request::References::METHOD,
             "context": ReferenceContext {

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -90,6 +90,7 @@ impl LanguageClient {
             request::CodeActionRequest::METHOD => self.text_document_code_action(&params),
             request::Completion::METHOD => self.text_document_completion(&params),
             request::SignatureHelpRequest::METHOD => self.text_document_signature_help(&params),
+            request::GotoDefinition::METHOD => self.text_document_definition(&params),
             request::References::METHOD => self.text_document_references(&params),
             request::Formatting::METHOD => self.text_document_formatting(&params),
             request::RangeFormatting::METHOD => self.text_document_range_formatting(&params),


### PR DESCRIPTION
Minor addition to include a specific method for `textDocument/definition` for clarity purposes only.