### PR TITLE
Fix incorrect deserialization of completions on ncm2_on_complete

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -3510,7 +3510,8 @@ impl LanguageClient {
         let is_incomplete;
         let matches;
         if let Ok(ref value) = result {
-            let completion = CompletionResponse::deserialize(value)?;
+            let completion = <Option<CompletionResponse>>::deserialize(value)?;
+            let completion = completion.unwrap_or_else(|| CompletionResponse::Array(vec![]));
             is_incomplete = match completion {
                 CompletionResponse::List(ref list) => list.is_incomplete,
                 _ => false,


### PR DESCRIPTION
This PR fixes an issue with the deserialization of CompletionResponse in `ncm2_on_complete` which would cause an error on cases where no completion results were returned from the server.