### PR TITLE
Fix markdown syntax on hover for Vim8

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -551,6 +551,8 @@ function! s:OpenHoverPreview(bufname, lines, filetype, ...) abort
           let pop_win_id = popup_atcursor(a:lines, { 'padding': l:padding })
         endif
         call setbufvar(winbufnr(pop_win_id), '&filetype', a:filetype)
+        " trigger refresh on plasticboy/vim-markdown
+        call win_execute(pop_win_id, 'doautocmd InsertLeave')
     elseif display_approach ==# 'preview'
         execute 'silent! noswapfile pedit!' a:bufname
         wincmd P


### PR DESCRIPTION
This PR is similar to #1139, it triggers the `InsertLeave` autocmd to let vim-markdown highlight hover text.
But #1139 only works for neovim's floating windows, this PR is adds the same for vim8's popup windows.