### PR TITLE
Add function to execute code action by kind

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -1049,6 +1049,20 @@ function! LanguageClient#textDocument_codeAction(...) abort
   call s:do_codeAction('n', a:000)
 endfunction
 
+function! LanguageClient#executeCodeAction(kind, ...) abort
+  let l:Callback = get(a:000, 1, v:null)
+  let l:params = {
+              \ 'filename': LSP#filename(),
+              \ 'line': LSP#line(),
+              \ 'character': LSP#character(),
+              \ 'handle': s:IsFalse(l:Callback),
+              \ 'range': LSP#range('n'),
+              \ 'kind': a:kind,
+              \ }
+  call extend(l:params, get(a:000, 0, {}))
+  return LanguageClient#Call('languageClient/executeCodeAction', l:params, l:Callback)
+endfunction
+
 function! LanguageClient#textDocument_completion(...) abort
     " Note: do not add 'text' as it might be huge.
     let l:params = {

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -1025,6 +1025,21 @@ Signature: LanguageClient#textDocument_switchSourceHeader(...)
 
 Calls clangd's `textDocument/switchSourceHeader` extension request.
 
+*LanguageClient#executeCodeAction*
+Signature: LanguageClient#executeCodeAction(kind, ...)
+
+Tries to execute the code action with the give kind under the cursor position.
+The action will only be executed if there is exactly one code action with that
+kind under the cursor.
+
+This function can be used to create commands for common LSP actions, such as
+`source.organizeImports`.  To do so you can create a command like this:
+
+  command! OrganizeImports call LanguageClient#executeCodeAction('source.organizeImports')
+
+Note that this only works for code actions, not commands, and only in normal
+mode.
+
 ==============================================================================
 5. Mappings                                           *LanguageClientMappings*
 

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -120,6 +120,7 @@ impl LanguageClient {
             REQUEST_CODE_LENS_ACTION => self.handle_code_lens_action(&params),
             REQUEST_SEMANTIC_SCOPES => self.semantic_scopes(&params),
             REQUEST_SHOW_SEMANTIC_HL_SYMBOLS => self.semantic_highlight_symbols(&params),
+            REQUEST_EXECUTE_CODE_ACTION => self.execute_code_action(&params),
 
             clangd::request::SwitchSourceHeader::METHOD => {
                 self.text_document_switch_source_header(&params)

--- a/src/types.rs
+++ b/src/types.rs
@@ -64,6 +64,7 @@ pub const REQUEST_CODE_LENS_ACTION: &str = "LanguageClient/handleCodeLensAction"
 pub const REQUEST_SEMANTIC_SCOPES: &str = "languageClient/semanticScopes";
 pub const REQUEST_SHOW_SEMANTIC_HL_SYMBOLS: &str = "languageClient/showSemanticHighlightSymbols";
 pub const REQUEST_CLASS_FILE_CONTENTS: &str = "java/classFileContents";
+pub const REQUEST_EXECUTE_CODE_ACTION: &str = "languageClient/executeCodeAction";
 
 pub const NOTIFICATION_HANDLE_BUF_NEW_FILE: &str = "languageClient/handleBufNewFile";
 pub const NOTIFICATION_HANDLE_BUF_ENTER: &str = "languageClient/handleBufEnter";


### PR DESCRIPTION
This PR adds a function to execute code actions by kind. The function can be mapped to commands for a better user experience (I may consider adding commands for the common actions later on).
For example, a command could look like this:
```command! OrganizeImports call LanguageClient#executeCodeAction('source.organizeImports')```

And called with `:OrganizeImports`.

Mapping a key binding or calling the function itself I suppose is self-explanatory from the above example.

Note that this PR only works for code actions, not commands, as they can't be filtered by kind alone, and commands can already be executed via `LanguageClient#workspace_executeCommand`

Closes #1158 