### PR TITLE
Add support for server specific handlers

### DIFF
--- a/.vim/settings.json
+++ b/.vim/settings.json
@@ -4,5 +4,16 @@
         "all_targets": false,
         "build_on_save": true,
         "wait_to_build": 0
+    },
+    "rust-analyzer": {
+      "diagnostics": {
+        "disabled": ["macro-error"]
+      },
+      "procMacro": {
+        "enable": true
+      },
+      "cargo": {
+        "loadOutDirsFromCheck": true
+      }
     }
 }

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -78,11 +78,11 @@ To use the language server with Vim's formatting operator |gq|, set 'formatexpr'
 Dictionary to specify the servers to be used for each filetype. The keys are
 strings representing the filetypes and the values are either
   1 - a list of strings that form a command
-  2 - a dictionary with keys name, command and initializationOptions, where:
-    - name: is the name of the server, which should match the root node of the
+  2 - a dictionary with the following keys:
+    - name: the name of the server, which should match the root node of the
       configuration options specified in the settings.json file for this server
-    - command: is the same list of strings in option 1
-    - initializationOptions: is an optional dictionary with options to be passed
+    - command: the same list of strings in option 1
+    - initializationOptions: an optional dictionary with options to be passed
       to the server. The values to be set here are highly dependent on each
       server so you should see the documentation for each server to find out
       what to configure in here (if anything).  The options set in
@@ -93,6 +93,13 @@ strings representing the filetypes and the values are either
       then the server settings configured in this section and lastly the
       contents of the files in the `LanguageClient_settingsPath` variable in
       the order in which they were listed.
+    - handlers: an optional dictionary of custom handlers to register for this
+      server. The keys for this dictionary should be (LSP) method names, and
+      the values should be vim functions to be executed upon receiving an event
+      with that method. The function will be called with a single param which
+      is the JSON-RPC message itself. Note that any events will only be handled
+      once, so if you register a handler for an event, the function you specify
+      will dictate all that happens with that event.
 
 For example: >
 
@@ -108,14 +115,21 @@ For example: >
         \       'test': v:true,
         \     },
         \   },
+        \   'handlers': {
+        \    'window/logMessage': 'LogMessage'
+        \   }
         \ },
         \}
 
 In the configuration for the rust filetype above, 'run', 'stable', and 'rls'
-are arguments to the 'rustup' command line tool. And in the configuration for
-the go filetype the server is configured to run the command `gopls` with no
-additional arguments, and with the initialization options set in the
-`initializationOptions` key.
+are arguments to the 'rustup' command line tool.
+
+In the configuration for the go filetype the server is configured to run the
+command `gopls` with no additional arguments, and with the initialization
+options set in the `initializationOptions` key. Also, the go server is
+configured to run the vim function LogMessage upon receiving an event with
+method `window/logMessage`.  Remember that both initializationOptions and
+handlers are optional, so you can omit specifying those if you wish.
 
 You can also use a tcp connection to the server, for example: >
     let g:LanguageClient_serverCommands = {

--- a/src/config/server_command.rs
+++ b/src/config/server_command.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::utils::expand_json_path;
 use jsonrpc_core::Value;
 use serde::{Deserialize, Serialize};
@@ -8,6 +10,7 @@ pub struct ServerDetails {
     pub command: Vec<String>,
     pub name: String,
     pub initialization_options: Option<Value>,
+    pub handlers: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -45,6 +48,13 @@ impl ServerCommand {
                 let options = cmd.initialization_options.clone();
                 expand_json_path(options.unwrap_or_default())
             }
+        }
+    }
+
+    pub fn handlers(&self) -> HashMap<String, String> {
+        match self {
+            ServerCommand::Simple(_) => HashMap::new(),
+            ServerCommand::Detailed(cmd) => cmd.handlers.clone().unwrap_or_default(),
         }
     }
 

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -858,6 +858,17 @@ impl LanguageClient {
         }
         let command = command.unwrap();
 
+        let handlers = command.handlers();
+        if !handlers.is_empty() {
+            self.update_state(|s| {
+                s.custom_handlers
+                    .entry(language_id.clone())
+                    .or_insert_with(HashMap::new)
+                    .extend(handlers);
+                Ok(())
+            })?;
+        }
+
         let settings = self.get_workspace_settings(&root).unwrap_or_default();
         // warn the user that they are using a deprecated workspace settings
         // file format and direct them to the documentation about the new one
@@ -3982,6 +3993,7 @@ mod test {
             initialization_options: Some(json!({
                 "inlayHints.enable": true,
             })),
+            handlers: None,
         });
 
         let options = merged_initialization_options(&command, &settings)
@@ -4014,6 +4026,7 @@ mod test {
             name: "gopls".into(),
             command: vec!["gopls".into()],
             initialization_options: None,
+            handlers: None,
         });
 
         let options = merged_initialization_options(&command, &settings)
@@ -4040,6 +4053,7 @@ mod test {
             initialization_options: Some(json!({
                 "usePlaceholders": true,
             })),
+            handlers: None,
         });
 
         let options = merged_initialization_options(&command, &settings)

--- a/src/types.rs
+++ b/src/types.rs
@@ -175,6 +175,12 @@ pub struct State {
     // TODO: make file specific.
     pub highlight_match_ids: Vec<u32>,
     pub user_handlers: HashMap<String, String>,
+    /// server_handlers stores a hashmap keyed by filetype with values being another hashmap, keyed
+    /// by method and values being a vim function to call when an LSP event with that method is
+    /// received.
+    /// The difference between user_handlers and server_handlers is that this one is filetype
+    /// specific, and user_handlers is global, the handlers are ran for all language servers.
+    pub custom_handlers: HashMap<String, HashMap<String, String>>,
     #[serde(skip_serializing)]
     pub watchers: HashMap<String, FSWatch>,
     #[serde(skip_serializing)]
@@ -233,6 +239,7 @@ impl State {
             highlights_placed: HashMap::new(),
             highlight_match_ids: Vec::new(),
             user_handlers: HashMap::new(),
+            custom_handlers: HashMap::new(),
             watchers: HashMap::new(),
             watcher_rxs: HashMap::new(),
             last_cursor_line: 0,


### PR DESCRIPTION
This PR adds support for server specific handlers that are specified via config. Other than enabling the user to run certain handlers for a specific server. Becase of this being via config, we can register the handlers before initialization, which ensures all events of that type are handled correctly.

An example configuration to use this would look like this:

```
let g:LanguageClient_serverCommands = {}
let g:LanguageClient_serverCommands.go =  {
			\ 'name': 'gopls',
			\ 'command': ['gopls'],
                        \ 'handlers': {
                        \  'window/logMessage': 'LogProgress'
                        \ }
			\}

```

Note that this is only possible with the newly introduced way of specifying a server command.

Closes #1176 