### PR TITLE
Only send textDocument/didSave if server advertises support for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install other dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends neovim curl git python3-pip python3-pytest mypy flake8 nodejs-dev node-gyp libssl1.0 npm make
+        sudo apt-get install --yes --no-install-recommends neovim curl git python3-pip python3-pytest mypy flake8 libnode-dev node-gyp libssl1.0 npm make
         sudo apt-get clean
         sudo rm -rf /var/lib/apt/lists/*
         python3 -m pip install neovim vim-vint


### PR DESCRIPTION
This PR changes the implementation of `textDocument/didSave` as to only send the notification if the server has advertised support for it.

For the sake of fixing the currently broken servers faster and for making this PR easier to review I only included the check for the didSave notification, but we should probably do the same with all the others.

Fixes #834 