### PR TITLE
Add code lens sign

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,4 +1,4 @@
-use lsp_types::{Diagnostic, DiagnosticSeverity};
+use lsp_types::{CodeLens, Diagnostic, DiagnosticSeverity};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -15,6 +15,16 @@ impl From<&Diagnostic> for Sign {
         let severity = diagnostic.severity.unwrap_or(DiagnosticSeverity::Hint);
         let name = format!("LanguageClient{:?}", severity);
         let id = 75_000 + line as u64 * DiagnosticSeverity::Hint as u64 + severity as u64;
+
+        Sign { id, line, name }
+    }
+}
+
+impl From<&CodeLens> for Sign {
+    fn from(code_lens: &CodeLens) -> Self {
+        let line = code_lens.range.start.line;
+        let name = "LanguageClientCodeLens".to_owned();
+        let id = 95_000 + line as u64;
 
         Sign { id, line, name }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -356,12 +356,16 @@ impl FromStr for DiagnosticsList {
 #[serde(rename_all = "camelCase")]
 pub struct CodeLensDisplay {
     pub virtual_texthl: String,
+    pub sign_text: String,
+    pub sign_texthl: String,
 }
 
 impl Default for CodeLensDisplay {
     fn default() -> Self {
         CodeLensDisplay {
             virtual_texthl: "LanguageClientCodeLens".into(),
+            sign_text: "🔍".to_owned(),
+            sign_texthl: "Todo".to_owned(),
         }
     }
 }


### PR DESCRIPTION
This PR adds a code lens sign so that code lenses are visible without the need for virtual texts.