### PR TITLE
Refactor cosebase for better testability

### DIFF
--- a/src/extensions/clangd.rs
+++ b/src/extensions/clangd.rs
@@ -1,4 +1,4 @@
-use crate::{language_client::LanguageClient, utils::ToUrl};
+use crate::{language_client::LanguageClient, rpcclient::RpcClient, utils::ToUrl};
 use anyhow::Result;
 use jsonrpc_core::Value;
 use lsp_types::{request::Request, TextDocumentIdentifier};

--- a/src/extensions/rust_analyzer.rs
+++ b/src/extensions/rust_analyzer.rs
@@ -1,5 +1,8 @@
 use crate::types;
-use crate::{language_client::LanguageClient, types::WorkspaceEditWithCursor, utils::ToUrl};
+use crate::{
+    language_client::LanguageClient, rpcclient::RpcClient, types::WorkspaceEditWithCursor,
+    utils::ToUrl,
+};
 use anyhow::{anyhow, Result};
 use jsonrpc_core::Value;
 use lsp_types::{request::Request, Command, Location, Range, TextDocumentIdentifier};

--- a/src/rpcclient/mock.rs
+++ b/src/rpcclient/mock.rs
@@ -1,0 +1,34 @@
+#[cfg(test)]
+use crate::rpcclient::RpcClient;
+#[cfg(test)]
+use crate::types::Id;
+#[cfg(test)]
+use anyhow::Result;
+#[cfg(test)]
+use serde::{de::DeserializeOwned, Serialize};
+
+#[cfg(test)]
+pub struct MockRpcClient {}
+
+#[cfg(test)]
+impl RpcClient for MockRpcClient {
+    fn process_id(&self) -> Option<u32> {
+        Some(0)
+    }
+
+    fn notify(&self, method: impl AsRef<str>, params: impl Serialize) -> Result<()> {
+        todo!()
+    }
+
+    fn output(&self, id: Id, result: Result<impl Serialize>) -> Result<()> {
+        todo!()
+    }
+
+    fn call<R: DeserializeOwned>(
+        &self,
+        method: impl AsRef<str>,
+        params: impl Serialize,
+    ) -> Result<R> {
+        todo!()
+    }
+}

--- a/src/rpcclient/mod.rs
+++ b/src/rpcclient/mod.rs
@@ -1,0 +1,68 @@
+pub mod io;
+pub mod mock;
+
+use crate::types::Id;
+use anyhow::Result;
+use io::IoRpcClient;
+#[cfg(test)]
+use mock::MockRpcClient;
+use serde::{de::DeserializeOwned, Serialize};
+
+pub enum Backend {
+    Io(IoRpcClient),
+    #[cfg(test)]
+    Mock(MockRpcClient),
+}
+
+pub trait RpcClient {
+    fn process_id(&self) -> Option<u32>;
+    fn notify(&self, method: impl AsRef<str>, params: impl Serialize) -> Result<()>;
+    fn output(&self, id: Id, result: Result<impl Serialize>) -> Result<()>;
+    fn call<R: DeserializeOwned>(
+        &self,
+        method: impl AsRef<str>,
+        params: impl Serialize,
+    ) -> Result<R>;
+}
+
+impl RpcClient for Client {
+    fn process_id(&self) -> Option<u32> {
+        match self.backend {
+            Backend::Io(ref c) => c.process_id(),
+            #[cfg(test)]
+            Backend::Mock(ref c) => c.process_id(),
+        }
+    }
+
+    fn notify(&self, method: impl AsRef<str>, params: impl Serialize) -> Result<()> {
+        match self.backend {
+            Backend::Io(ref c) => c.notify(method, params),
+            #[cfg(test)]
+            Backend::Mock(ref c) => c.notify(method, params),
+        }
+    }
+
+    fn output(&self, id: Id, result: Result<impl Serialize>) -> Result<()> {
+        match self.backend {
+            Backend::Io(ref c) => c.output(id, result),
+            #[cfg(test)]
+            Backend::Mock(ref c) => c.output(id, result),
+        }
+    }
+
+    fn call<R: DeserializeOwned>(
+        &self,
+        method: impl AsRef<str>,
+        params: impl Serialize,
+    ) -> Result<R> {
+        match self.backend {
+            Backend::Io(ref c) => c.call(method, params),
+            #[cfg(test)]
+            Backend::Mock(ref c) => c.call(method, params),
+        }
+    }
+}
+
+pub struct Client {
+    pub backend: Backend,
+}

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -1,5 +1,8 @@
 use crate::extensions::clangd;
-use crate::{language_client::LanguageClient, language_server_protocol::Direction, types::*};
+use crate::{
+    language_client::LanguageClient, language_server_protocol::Direction, rpcclient::RpcClient,
+    types::*,
+};
 use anyhow::{anyhow, Result};
 use log::*;
 use lsp_types::notification::{self, Notification};

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use crate::logger::Logger;
-use crate::rpcclient::RpcClient;
+use crate::rpcclient::Client;
 use crate::{
     language_client::LanguageClient,
     utils::{code_action_kind_as_str, ToUrl},
@@ -143,7 +143,7 @@ pub struct State {
     pub tx: crossbeam::channel::Sender<Call>,
 
     #[serde(skip_serializing)]
-    pub clients: HashMap<LanguageId, Arc<RpcClient>>,
+    pub clients: HashMap<LanguageId, Arc<Client>>,
     #[serde(skip_serializing)]
     pub restarts: HashMap<LanguageId, u8>,
 
@@ -210,11 +210,7 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(
-        tx: crossbeam::channel::Sender<Call>,
-        client: Arc<RpcClient>,
-        logger: Logger,
-    ) -> Self {
+    pub fn new(tx: crossbeam::channel::Sender<Call>, client: Arc<Client>, logger: Logger) -> Self {
         Self {
             tx,
             vim: Vim::new(Arc::clone(&client)),

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -1,5 +1,5 @@
 use crate::{
-    rpcclient::RpcClient,
+    rpcclient::{Client, RpcClient},
     sign::Sign,
     types::{Bufnr, QuickfixEntry, VimExp, VirtualText},
     utils::Canonicalize,
@@ -77,11 +77,11 @@ impl From<&str> for Mode {
 
 #[derive(Clone)]
 pub struct Vim {
-    pub rpcclient: Arc<RpcClient>,
+    pub rpcclient: Arc<Client>,
 }
 
 impl Vim {
-    pub fn new(rpcclient: Arc<RpcClient>) -> Self {
+    pub fn new(rpcclient: Arc<Client>) -> Self {
         Self { rpcclient }
     }
 


### PR DESCRIPTION
This PR refactors the codebase to use an `RpcClient` trait instead of relying on a concrete type to enable better testability. 