### PR TITLE
Implement textDocument/semanticTokens/full

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -896,6 +896,22 @@ function! LanguageClient#Notify(method, params) abort
                 \ }))
 endfunction
 
+function! LanguageClient#textDocument_semanticTokensFull(...) abort
+    if s:ShouldUseFloatWindow() && s:MoveIntoHoverPreview('__LCNHover__')
+        return
+    endif
+    let l:Callback = get(a:000, 1, v:null)
+    let l:params = {
+                \ 'filename': LSP#filename(),
+                \ 'text': LSP#text(),
+                \ 'line': LSP#line(),
+                \ 'character': LSP#character(),
+                \ 'handle': s:IsFalse(l:Callback),
+                \ }
+    call extend(l:params, get(a:000, 0, {}))
+    return LanguageClient#Call('textDocument/semanticTokens/full', l:params, l:Callback)
+endfunction
+
 function! LanguageClient#textDocument_hover(...) abort
     if s:ShouldUseFloatWindow() && s:MoveIntoHoverPreview('__LCNHover__')
         return
@@ -1679,20 +1695,6 @@ function! s:print_semantic_scopes(response) abort
     endfor
 
     echo l:msg
-endfunction
-
-function! LanguageClient#showSemanticHighlightSymbols(...) abort
-    let l:params = get(a:000, 0, {})
-    let l:Callback = get(a:000, 1, v:null)
-
-    return LanguageClient#Call('languageClient/showSemanticHighlightSymbols', l:params, l:Callback)
-endfunction
-
-function! LanguageClient_showCursorSemanticHighlightSymbols(...) abort
-    let l:params = get(a:000, 0, {})
-    let l:Callback = get(a:000, 1, function('s:print_cursor_semantic_symbol'))
-
-    return LanguageClient#showSemanticHighlightSymbols(l:params, l:Callback)
 endfunction
 
 function! s:print_cursor_semantic_symbol(response) abort

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -515,104 +515,7 @@ Valid options: 1 | 0
 
 2.33 g:LanguageClient_semanticHighlightMaps   *g:LanguageClient_semanticHighlightMaps*
 
-String to list/map map. Defines the mapping of semantic highlighting "scopes" to
-highlight groups. This depends on the LSP server supporting the proposed
-semantic highlighting protocol, see:
-
-https://github.com/microsoft/language-server-protocol/issues/18
-https://github.com/microsoft/vscode-languageserver-node/issues/368
-
-
-Like |g:LanguageClient_serverCommands| this is a map where the keys are
-filetypes. However each submap has |regexp| keys and highlight group names
-as values (see |highlight-groups|).
->
-    let g:LanguageClient_semanticHighlightMaps = {
-        \ 'java': {
-        \   '^entity.name.function.java': 'Function',
-        \   '^entity.name.type.class.java': 'Type',
-        \   '^[^:]*entity.name.function.java': 'Function',
-        \   '^[^:]entity.name.type.class.java': 'Type'
-        \ }
-        \ }
-
-The |regexp| in the keys will be used to match semantic scopes. Then any symbols
-that have a semantic scope that matches the key will be highlighted with the
-associated highlight group value. Currently there is no defined order if a
-semantic scope can match multiple keys, so it is recommended to make the keys
-more specific to only match the desired scope(s).
-
-There are a fixed set of semantic scopes defined by the LSP server on startup.
-These can be viewed by calling |LanguageClient_showSemanticScopes| which will
-show all the semantic scopes and their currently mapped highlight group for
-the currently open buffer's filetype.
->
-     call LanguageClient_showSemanticScopes()
-
-     == Output from eclipse.jdt.ls ==
-
-     Highlight Group:
-      None
-     Semantic Scope:
-      invalid.deprecated.java
-       meta.class.java
-        source.java
-
-     Highlight Group:
-      None
-     Semantic Scope:
-      variable.other.autoboxing.java
-       meta.method.body.java
-        meta.method.java
-         meta.class.body.java
-          meta.class.java
-           source.java
-
-     ...
-
-Each semantic scope is a list of strings. They are printed with increasing
-indent to make it easier to read. For example the first scope is:
->
-     ['invalid.deprecated.java', 'meta.class.java', 'source.java']
-
-It is currently isn't mapped to any highlight group as indicated by the None.
-
-Often its more useful to find what semantic scope corresponds to a piece of
-text. This can be done by calling |LanguageClient_showCursorSemanticHighlightSymbols|
-while hovering over the text of interest.
->
-     call LanguageClient_showCursorSemanticHighlightSymbols()
-
-When matching the semantic scopes to keys in |LanguageClient_semanticHighlightMaps|,
-the scopes are concatentated using |LanguageClient_semanticScopeSeparator|
-which is set to the string |':'| by default. For the previous example the
-semantic scope would have this string form using the default separator:
->
-     invalid.deprecated.java:meta.class.java:source.java
-
-Here are a couple of example |regexp| keys that can/cannot match this scope:
->
-     'meta.class.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
-     '^meta.class.java' !~ 'invalid.deprecated.java:meta.class.java:source.java'
-     '^invalid.deprecated.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
-     'source.java$' =~ 'invalid.deprecated.java:meta.class.java:source.java'
-     'meta.class.java:source.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
-     'invalid.deprecated.java:.*:source.java' =~ 'invalid.deprecated.java:meta.class.java:source.java'
-
-Example configuration for eclipse.jdt.ls:
->
-     let g:LanguageClient_semanticHighlightMaps = {}
-     let g:LanguageClient_semanticHighlightMaps['java'] = {
-       \ '^storage.modifier.static.java:entity.name.function.java': 'JavaStaticMemberFunction',
-       \ '^meta.definition.variable.java:meta.class.body.java:meta.class.java': 'JavaMemberVariable',
-       \ '^entity.name.function.java': 'Function',
-       \ '^[^:]*entity.name.function.java': 'Function',
-       \ '^[^:]*entity.name.type.class.java': 'Type',
-       \ }
-
-     highlight! JavaStaticMemberFunction ctermfg=Green cterm=none guifg=Green gui=none
-     highlight! JavaMemberVariable ctermfg=White cterm=italic guifg=White gui=italic
-
+Deprecated, see g:LanguageClient_semanticTokenMappings.
 
 2.34 g:LanguageClient_applyCompletionAdditionalTextEdits *g:LanguageClient_applyCompletionAdditionalTextEdits*
 
@@ -758,6 +661,57 @@ Show completion item documentation in a floating window right next to pmenu.
 
 Default: 1
 Valid options: 1 | 0
+
+2.46 g:LanguageClient_semanticHighlightingEnabled *g:LanguageClient_semanticHighlightingEnabled*
+
+If enabled, the client will call the LSP semantic tokens method after opening,
+modifying or saving a buffer to try and apply semantic highlighting to the
+buffer.
+
+Default: 0
+Valid options: 1 | 0
+
+2.47 g:LanguageClient_semanticTokenMappings *g:LanguageClient_semanticTokenMappings*
+
+Maps LSP token types to vim highlight groups. Each item in this array is a
+dictionary with the fields name, modifiers and highlightGroup, where name is
+the name of the LSP token type, modifiers is a list of modifiers that need to
+be present in that token for this mapping to match and highlightGroup is the
+vim highlight group that should be applied to the token.
+
+Example:
+
+>
+let g:LanguageClient_semanticTokenMappings = [
+  { 'name': 'comment', 'modifiers': [], 'highlightGroup': 'Comment' },
+  { 'name': 'comment', 'modifiers': ['documentation'], 'highlightGroup': 'Question' },
+];
+<
+
+Note the mappings included in this config will be merged with the default ones.
+
+The first mapping in that example maps the tokens of type `comment` to the
+highlight group `Comment`, and the second matches the tokens of type `comment`
+that have the `documentation` modifier to the `Question` highlight group, this
+way documentation comments and regular comments are (potentially) displayed
+with a different colour.
+
+Default: [
+  { 'name': 'comment',        'modifiers': [], 'highlightGroup': 'Comment' },
+  { 'name': 'function',       'modifiers': [], 'highlightGroup': 'Function' },
+  { 'name': 'struct',         'modifiers': [], 'highlightGroup': 'Structure' },
+  { 'name': 'enum',           'modifiers': [], 'highlightGroup': 'Structure' },
+  { 'name': 'class',          'modifiers': [], 'highlightGroup': 'Structure' },
+  { 'name': 'interface',      'modifiers': [], 'highlightGroup': 'Structure' },
+  { 'name': 'type',           'modifiers': [], 'highlightGroup': 'Type' },
+  { 'name': 'typeParameter',  'modifiers': [], 'highlightGroup': 'Typedef' },
+  { 'name': 'string',         'modifiers': [], 'highlightGroup': 'String' },
+  { 'name': 'number',         'modifiers': [], 'highlightGroup': 'Number' },
+  { 'name': 'operator',       'modifiers': [], 'highlightGroup': 'Operator' },
+]
+
+For a full list of the possible token types (name) see the LSP documentation:
+https://microsoft.github.io/language-server-protocol/specifications/specification-current/
 
 ==============================================================================
 3. Commands                                           *LanguageClientCommands*

--- a/doc/LanguageClient.txt
+++ b/doc/LanguageClient.txt
@@ -688,27 +688,13 @@ let g:LanguageClient_semanticTokenMappings = [
 ];
 <
 
-Note the mappings included in this config will be merged with the default ones.
-
 The first mapping in that example maps the tokens of type `comment` to the
 highlight group `Comment`, and the second matches the tokens of type `comment`
 that have the `documentation` modifier to the `Question` highlight group, this
 way documentation comments and regular comments are (potentially) displayed
 with a different colour.
 
-Default: [
-  { 'name': 'comment',        'modifiers': [], 'highlightGroup': 'Comment' },
-  { 'name': 'function',       'modifiers': [], 'highlightGroup': 'Function' },
-  { 'name': 'struct',         'modifiers': [], 'highlightGroup': 'Structure' },
-  { 'name': 'enum',           'modifiers': [], 'highlightGroup': 'Structure' },
-  { 'name': 'class',          'modifiers': [], 'highlightGroup': 'Structure' },
-  { 'name': 'interface',      'modifiers': [], 'highlightGroup': 'Structure' },
-  { 'name': 'type',           'modifiers': [], 'highlightGroup': 'Type' },
-  { 'name': 'typeParameter',  'modifiers': [], 'highlightGroup': 'Typedef' },
-  { 'name': 'string',         'modifiers': [], 'highlightGroup': 'String' },
-  { 'name': 'number',         'modifiers': [], 'highlightGroup': 'Number' },
-  { 'name': 'operator',       'modifiers': [], 'highlightGroup': 'Operator' },
-]
+Default: []
 
 For a full list of the possible token types (name) see the LSP documentation:
 https://microsoft.github.io/language-server-protocol/specifications/specification-current/

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -97,6 +97,7 @@ pub struct Config {
     ///     { "name": "type", "modifiers": [], "highlightGroup": "Type" }
     /// ]
     pub semantic_token_mappings: Vec<SemanticTokenMapping>,
+    pub semantic_highlighting_enabled: bool,
 }
 
 impl Default for Config {
@@ -134,6 +135,7 @@ impl Default for Config {
             restart_on_crash: true,
             max_restart_retries: 5,
             semantic_token_mappings: vec![],
+            semantic_highlighting_enabled: false,
         }
     }
 }
@@ -172,6 +174,7 @@ struct DeserializableConfig {
     restart_on_crash: u8,
     max_restart_retries: u8,
     semantic_token_mappings: Vec<SemanticTokenMapping>,
+    semantic_highlighting_enabled: u8,
 }
 
 impl Config {
@@ -209,21 +212,36 @@ impl Config {
             "max_restart_retries": get(g:, 'LanguageClient_maxRestartRetries', 5),
             "server_stderr": get(g:, 'LanguageClient_serverStderr', v:null),
             "semantic_token_mappings": get(g:, 'LanguageClient_semanticTokenMappings', []),
+            "semantic_highlighting_enabled": get(g:, 'LanguageClient_semanticHighlightingEnabled', 0),
         }"#;
 
         let res: DeserializableConfig = vim.eval(req.replace("\n", ""))?;
-
         let mut default_mappings = vec![
-            SemanticTokenMapping::new("type", &[], "Type"),
-            SemanticTokenMapping::new("class", &[], "Structure"),
-            SemanticTokenMapping::new("enum", &[], "Structure"),
-            SemanticTokenMapping::new("interface", &[], "Structure"),
-            SemanticTokenMapping::new("typeParameter", &[], "Typedef"),
+            SemanticTokenMapping::new("type", &["declaration"], "Type"),
+            SemanticTokenMapping::new("class", &["declaration"], "Structure"),
+            SemanticTokenMapping::new("enum", &["declaration"], "Structure"),
+            SemanticTokenMapping::new("interface", &["declaration"], "Structure"),
+            SemanticTokenMapping::new("struct", &["declaration"], "Structure"),
+            // SemanticTokenMapping::new("typeParameter", &[], "Typedef"),
+            // SemanticTokenMapping::new("parameter", &[], "Identifier"),
+            // SemanticTokenMapping::new("variable", &[], "Identifier"),
+            // SemanticTokenMapping::new("property", &[], "Typedef"),
+            // SemanticTokenMapping::new("enumMember", &[], "Typedef"),
+            // SemanticTokenMapping::new("event", &[], "Typedef"),
             SemanticTokenMapping::new("function", &[], "Function"),
+            SemanticTokenMapping::new("method", &[], "Function"),
+            SemanticTokenMapping::new("macro", &[], "Function"),
+            SemanticTokenMapping::new("function", &["deprecated"], "Comment"),
+            SemanticTokenMapping::new("method", &["deprecated"], "Comment"),
+            SemanticTokenMapping::new("macro", &["deprecated"], "Comment"),
+            SemanticTokenMapping::new("keyword", &[], "Keyword"),
+            // SemanticTokenMapping::new("modifier", &[], "Function"),
+            SemanticTokenMapping::new("comment", &[], "Comment"),
+            SemanticTokenMapping::new("comment", &["documentation"], "Special"),
             SemanticTokenMapping::new("string", &[], "String"),
             SemanticTokenMapping::new("number", &[], "Number"),
+            SemanticTokenMapping::new("regexp", &[], "String"),
             SemanticTokenMapping::new("operator", &[], "Operator"),
-            SemanticTokenMapping::new("comment", &[], "Comment"),
         ];
         // itertools returns the first item that matches the predicate in unique_by, so custom
         // mappings go first to favor the user configured mappings over the default ones.
@@ -293,6 +311,7 @@ impl Config {
             restart_on_crash: res.restart_on_crash == 1,
             max_restart_retries: res.max_restart_retries,
             semantic_token_mappings,
+            semantic_highlighting_enabled: res.semantic_highlighting_enabled == 1,
         })
     }
 }

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -182,11 +182,15 @@ impl LanguageClient {
             notification::DidChangeConfiguration::METHOD => {
                 self.workspace_did_change_configuration(&params)?
             }
-            notification::DidOpenTextDocument::METHOD => self.text_document_did_open(&params)?,
-            notification::DidChangeTextDocument::METHOD => {
-                self.text_document_did_change(&params)?
+            notification::DidOpenTextDocument::METHOD => {
+                self.text_document_did_open(&params)?;
             }
-            notification::DidSaveTextDocument::METHOD => self.text_document_did_save(&params)?,
+            notification::DidChangeTextDocument::METHOD => {
+                self.text_document_did_change(&params)?;
+            }
+            notification::DidSaveTextDocument::METHOD => {
+                self.text_document_did_save(&params)?;
+            }
             notification::DidCloseTextDocument::METHOD => self.text_document_did_close(&params)?,
             notification::PublishDiagnostics::METHOD => {
                 self.text_document_publish_diagnostics(&params)?
@@ -196,11 +200,20 @@ impl LanguageClient {
             notification::ShowMessage::METHOD => self.window_show_message(&params)?,
             notification::Exit::METHOD => self.exit(&params)?,
             // Extensions.
-            NOTIFICATION_HANDLE_FILE_TYPE => self.handle_file_type(&params)?,
+            NOTIFICATION_HANDLE_FILE_TYPE => {
+                self.handle_file_type(&params)?;
+                self.text_document_semantic_tokens_full(&params)?;
+            }
             NOTIFICATION_HANDLE_BUF_NEW_FILE => self.handle_buf_new_file(&params)?,
-            NOTIFICATION_HANDLE_BUF_ENTER => self.handle_buf_enter(&params)?,
+            NOTIFICATION_HANDLE_BUF_ENTER => {
+                self.handle_buf_enter(&params)?;
+                self.text_document_semantic_tokens_full(&params)?;
+            }
             NOTIFICATION_HANDLE_TEXT_CHANGED => self.handle_text_changed(&params)?,
-            NOTIFICATION_HANDLE_BUF_WRITE_POST => self.handle_buf_write_post(&params)?,
+            NOTIFICATION_HANDLE_BUF_WRITE_POST => {
+                self.handle_buf_write_post(&params)?;
+                self.text_document_semantic_tokens_full(&params)?;
+            }
             NOTIFICATION_HANDLE_BUF_DELETE => self.handle_buf_delete(&params)?,
             NOTIFICATION_HANDLE_CURSOR_MOVED => self.handle_cursor_moved(&params, false)?,
             NOTIFICATION_HANDLE_COMPLETE_DONE => self.handle_complete_done(&params)?,

--- a/src/rpchandler.rs
+++ b/src/rpchandler.rs
@@ -96,6 +96,9 @@ impl LanguageClient {
             request::ResolveCompletionItem::METHOD => self.completion_item_resolve(&params),
             request::ExecuteCommand::METHOD => self.workspace_execute_command(&params),
             request::ApplyWorkspaceEdit::METHOD => self.workspace_apply_edit(&params),
+            request::SemanticTokensFullRequest::METHOD => {
+                self.text_document_semantic_tokens_full(&params)
+            }
             request::Shutdown::METHOD => self.shutdown(&params),
             request::DocumentHighlightRequest::METHOD => {
                 self.text_document_document_highlight(&params)
@@ -116,8 +119,6 @@ impl LanguageClient {
             REQUEST_CLASS_FILE_CONTENTS => self.java_class_file_contents(&params),
             REQUEST_DEBUG_INFO => self.debug_info(&params),
             REQUEST_CODE_LENS_ACTION => self.handle_code_lens_action(&params),
-            REQUEST_SEMANTIC_SCOPES => self.semantic_scopes(&params),
-            REQUEST_SHOW_SEMANTIC_HL_SYMBOLS => self.semantic_highlight_symbols(&params),
             REQUEST_EXECUTE_CODE_ACTION => self.execute_code_action(&params),
 
             clangd::request::SwitchSourceHeader::METHOD => {
@@ -189,9 +190,6 @@ impl LanguageClient {
             notification::DidCloseTextDocument::METHOD => self.text_document_did_close(&params)?,
             notification::PublishDiagnostics::METHOD => {
                 self.text_document_publish_diagnostics(&params)?
-            }
-            notification::SemanticHighlighting::METHOD => {
-                self.text_document_semantic_highlight(&params)?
             }
             notification::Progress::METHOD => self.progress(&params)?,
             notification::LogMessage::METHOD => self.window_log_message(&params)?,

--- a/src/types.rs
+++ b/src/types.rs
@@ -683,14 +683,14 @@ impl ToRpcError for anyhow::Error {
 }
 
 pub trait ToParams {
-    fn to_params(self) -> Result<Params>;
+    fn to_params(&self) -> Result<Params>;
 }
 
 impl<T> ToParams for T
 where
     T: Serialize,
 {
-    fn to_params(self) -> Result<Params> {
+    fn to_params(&self) -> Result<Params> {
         let json_value = serde_json::to_value(self)?;
 
         let params = match json_value {
@@ -1010,11 +1010,11 @@ impl Default for TextDocumentItemMetadata {
 }
 
 pub trait ToLSP<T> {
-    fn to_lsp(self) -> Result<T>;
+    fn to_lsp(&self) -> Result<T>;
 }
 
 impl ToLSP<Vec<FileEvent>> for notify::DebouncedEvent {
-    fn to_lsp(self) -> Result<Vec<FileEvent>> {
+    fn to_lsp(&self) -> Result<Vec<FileEvent>> {
         match self {
             notify::DebouncedEvent::Create(p) => Ok(vec![FileEvent {
                 uri: p.to_url()?,

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,6 @@ use crate::{viewport::Viewport, vim::Highlight};
 use anyhow::{anyhow, Result};
 use jsonrpc_core::Params;
 use log::*;
-use lsp_types::Range;
 use lsp_types::{
     CodeAction, CodeLens, Command, CompletionItem, CompletionTextEdit, Diagnostic,
     DiagnosticSeverity, DocumentHighlightKind, FileChangeType, FileEvent, Hover, HoverContents,
@@ -18,6 +17,7 @@ use lsp_types::{
     MessageType, NumberOrString, Registration, SemanticHighlightingInformation, SymbolInformation,
     TextDocumentItem, TextDocumentPositionParams, Url, WorkspaceEdit,
 };
+use lsp_types::{Range, SemanticTokensLegend};
 use maplit::hashmap;
 use pathdiff::diff_paths;
 use serde::{Deserialize, Serialize};
@@ -62,8 +62,6 @@ pub const REQUEST_EXPLAIN_ERROR_AT_POINT: &str = "languageClient/explainErrorAtP
 pub const REQUEST_FIND_LOCATIONS: &str = "languageClient/findLocations";
 pub const REQUEST_DEBUG_INFO: &str = "languageClient/debugInfo";
 pub const REQUEST_CODE_LENS_ACTION: &str = "LanguageClient/handleCodeLensAction";
-pub const REQUEST_SEMANTIC_SCOPES: &str = "languageClient/semanticScopes";
-pub const REQUEST_SHOW_SEMANTIC_HL_SYMBOLS: &str = "languageClient/showSemanticHighlightSymbols";
 pub const REQUEST_CLASS_FILE_CONTENTS: &str = "java/classFileContents";
 pub const REQUEST_EXECUTE_CODE_ACTION: &str = "languageClient/executeCodeAction";
 
@@ -156,8 +154,15 @@ pub struct State {
     pub text_documents: HashMap<String, TextDocumentItem>,
     pub viewports: HashMap<String, Viewport>,
     pub text_documents_metadata: HashMap<String, TextDocumentItemMetadata>,
-    pub semantic_scopes: HashMap<String, Vec<Vec<String>>>,
-    pub semantic_scope_to_hl_group_table: HashMap<String, Vec<Option<String>>>,
+    /// semantic_token_legends is a map of language id to semantic tokens legend. The semantic
+    /// tokengs legend is returned by the server upon initialization.
+    ///
+    /// For example:
+    ///
+    /// {
+    ///     "rust": { "token_types": ["type", "struct", "variable"] }
+    /// }
+    pub semantic_token_legends: HashMap<String, SemanticTokensLegend>,
     // filename => semantic highlight state
     pub semantic_highlights: HashMap<String, TextDocumentSemanticHighlightState>,
     // filename => diagnostics.
@@ -226,8 +231,7 @@ impl State {
             text_documents: HashMap::new(),
             viewports: HashMap::new(),
             text_documents_metadata: HashMap::new(),
-            semantic_scopes: HashMap::new(),
-            semantic_scope_to_hl_group_table: HashMap::new(),
+            semantic_token_legends: HashMap::new(),
             semantic_highlights: HashMap::new(),
             inlay_hints: HashMap::new(),
             code_lens: HashMap::new(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -452,33 +452,6 @@ pub fn decode_parameter_label(
     }
 }
 
-/// Given a string, convert it into a string for vimscript
-/// The string gets surrounded by single quotes.
-///
-/// Existing single quotes will get escaped by inserting
-/// another single quote in place.
-///
-/// E.g.
-/// abcdefg -> 'abcdefg'
-/// abdcef'g -> 'abcdef''g'
-pub fn convert_to_vim_str(s: &str) -> String {
-    let mut vs = String::with_capacity(s.len());
-
-    vs.push('\'');
-
-    for i in s.chars() {
-        if i == '\'' {
-            vs.push(i);
-        }
-
-        vs.push(i);
-    }
-
-    vs.push('\'');
-
-    vs
-}
-
 /// Converts the kind of a `CodeAction` to a `&str`.
 pub fn code_action_kind_as_str(action: &CodeAction) -> &str {
     match action.kind.as_ref().map(|k| k.as_str()) {
@@ -765,14 +738,5 @@ mod test {
                 "state.line".to_owned() => (json!(1), json!(3)),
             }
         );
-    }
-
-    #[test]
-    fn test_convert_to_vim_str() {
-        assert_eq!(convert_to_vim_str("abcdefg"), "'abcdefg'");
-        assert_eq!(convert_to_vim_str("'abcdefg"), "'''abcdefg'");
-        assert_eq!(convert_to_vim_str("'x'x'x'x'"), "'''x''x''x''x'''");
-        assert_eq!(convert_to_vim_str("xyz'''ffff"), "'xyz''''''ffff'");
-        assert_eq!(convert_to_vim_str("'''"), "''''''''");
     }
 }

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -29,7 +29,7 @@ pub struct HighlightSource {
     pub source: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Highlight {
     pub line: u32,
     pub character_start: u32,


### PR DESCRIPTION
This PR implements the `textDocument/semanticTokens/full` LSP method and removes the old "deprecated" (didn't ever really land as an accepted feature of LSP) implementation.

This also sets a default generic mapping of LSP token types to VIM highlight groups that will be merged with the user-provided language-id-specific semantic tokens mappings config which is used to decide which highlight group to assign to each token.

This is still a draft and there a few things left for this to be considered "working":

- [x] Token modifiers
- [ ] ~Map all token types to a vim highlight group~
- [x] Call the function to get the semantic tokens on file save/change/open/etc
- [x] Decide on whether we want to map to vim highlight groups or create our own LCN specific highlight groups that we can link to VIM's generic ones.
- [x] Update user documentation to reflect the removal of textDocument/semanticHighlight and the addition of this one. Also might be a good idea to add a link to the LSP documentation listing all the different token types if we end up supporting all of them.
- [ ] ~Support for `textDocument/semanticTokens/range` (this I believe we could leave out of the first release of this feature)~
- [ ] ~Support for `textDocument/semanticTokens/full/delta` (this could also be optional for the first release)~


Closes #1193