### PR TITLE
Show all diagnostics on point on explain error at point buffer

### DIFF
--- a/tests/data/sample-go/main.go
+++ b/tests/data/sample-go/main.go
@@ -20,3 +20,8 @@ func yo() {
 	log.Println(b)
 	log.Println(otherYo())
 }
+
+func yoWithDiagnostic() {
+	x := 0
+	x = x
+}


### PR DESCRIPTION
This PR modifies explainErrorAtPoint so that it shows all diagnostics under the cursor instead of only the first one.