### PR TITLE
Do not enclose plaintext in ``` on hover

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -807,9 +807,15 @@ impl ToDisplay for Hover {
                     if let MarkedString::LanguageString(ref ls) = ms {
                         let mut buf = Vec::new();
 
-                        buf.push(format!("```{}", ls.language));
+                        if ls.language != "plaintext" {
+                            buf.push(format!("```{}", ls.language));
+                        }
+
                         buf.extend(ls.value.lines().map(String::from));
-                        buf.push("```".to_string());
+
+                        if ls.language != "plaintext" {
+                            buf.push("```".to_string());
+                        }
 
                         buf
                     } else {


### PR DESCRIPTION
When working with larger multiple plaintext outputs, enclosing each output in ``` hinders readability.

![image](https://user-images.githubusercontent.com/6503361/112186831-cdc49300-8c01-11eb-8407-e2d3df45db7f.png)

versus

![image](https://user-images.githubusercontent.com/6503361/112188241-1df02500-8c03-11eb-88c1-b20c3dd1a63f.png)

As far as I am aware, the only "fake" language in this way is "plaintext", every other language should be continued packed in ```. If this is not the case, we can adjust the condition of course.