### PR TITLE
Silence Vim:Interrupt errors

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -672,6 +672,15 @@ function! s:HandleMessage(job, lines, event) abort
                                     \ 'result': l:result,
                                     \ }))
                     endif
+                catch 'Vim:Interrupt'
+                    call LanguageClient#Write(json_encode({
+                                \ 'jsonrpc': '2.0',
+                                \ 'id': l:id,
+                                \ 'error': {
+                                \   'code': -32800,
+                                \   'message': string(v:exception)
+                                \   }
+                                \ }))
                 catch
                     let l:exception = v:exception
                     if l:id isnot v:null

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,6 +44,8 @@ pub enum Direction {
 pub enum LanguageServerError {
     #[error("Content Modified")]
     ContentModified,
+    #[error("Request Cancelled")]
+    RequestCancelled,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Silence Vim:Interrupt errors as they don't really add anything and they are (mostly?) triggered by the user anyways.