### PR TITLE
Add support for rust-analyzer type & parameter hints

### DIFF
--- a/src/config/server_command.rs
+++ b/src/config/server_command.rs
@@ -81,14 +81,14 @@ mod test {
 
     #[test]
     fn test_name_from_command_handles_binary_name() {
-        let name = ServerCommand::name_from_command(&vec!["gopls".into()]);
+        let name = ServerCommand::name_from_command(&["gopls".into()]);
         assert_eq!(name.as_str(), "gopls");
     }
 
     #[test]
     #[cfg(not(target_os = "windows"))]
     fn test_name_from_command_handles_binary_path() {
-        let name = ServerCommand::name_from_command(&vec!["/path/to/gopls".into()]);
+        let name = ServerCommand::name_from_command(&["/path/to/gopls".into()]);
         assert_eq!(name.as_str(), "gopls");
     }
 }


### PR DESCRIPTION
Temporary workaround for https://github.com/autozimu/LanguageClient-neovim/issues/934, until `neovim` anticonceal https://github.com/neovim/neovim/pull/9496 is finished.
ChainingHints - `Iterator<u32>`
TypeHints - `: u32`
ParameterHints - `𝑓(a, b, c)`

Demo:

![image](https://user-images.githubusercontent.com/29541480/117653226-cdc22780-b19c-11eb-83c7-2904183c8268.png)