### PR TITLE
Document symbol container name

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1156,11 +1156,21 @@ impl ListItem for lsp_types::DocumentSymbol {
     }
 }
 
+fn prepend(
+    text: impl AsRef<str>,
+    optional_head: Option<&String>,
+    divisor: impl AsRef<str>,
+) -> String {
+    return optional_head.filter(|x| x.trim() != "").map_or_else(
+        || text.as_ref().to_string(),
+        |v| format!("{}{}{}", v, divisor.as_ref(), text.as_ref()),
+    );
+}
+
 impl ListItem for SymbolInformation {
     fn quickfix_item(&self, _: &LanguageClient) -> Result<QuickfixEntry> {
         let start = self.location.range.start;
-        let container_name = self.container_name.clone().unwrap_or_default();
-        let text = [container_name, self.name.clone()].join("::");
+        let text = prepend(&self.name, self.container_name.as_ref(), "::");
         Ok(QuickfixEntry {
             filename: self.location.uri.filepath()?.to_string_lossy().into_owned(),
             lnum: start.line + 1,
@@ -1175,8 +1185,7 @@ impl ListItem for SymbolInformation {
         let filename = self.location.uri.filepath()?;
         let relpath = diff_paths(&filename, Path::new(cwd)).unwrap_or(filename);
         let start = self.location.range.start;
-        let container_name = self.container_name.clone().unwrap_or_default();
-        let text = [container_name, self.name.clone()].join("::");
+        let text = prepend(&self.name, self.container_name.as_ref(), "::");
         Ok(format!(
             "{}:{}:{}:\t{}\t\t{:?}",
             relpath.to_string_lossy(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1159,12 +1159,13 @@ impl ListItem for lsp_types::DocumentSymbol {
 impl ListItem for SymbolInformation {
     fn quickfix_item(&self, _: &LanguageClient) -> Result<QuickfixEntry> {
         let start = self.location.range.start;
-
+        let container_name = self.container_name.clone().unwrap_or_default();
+        let text = [self.name.clone(), container_name].join("::");
         Ok(QuickfixEntry {
             filename: self.location.uri.filepath()?.to_string_lossy().into_owned(),
             lnum: start.line + 1,
             col: Some(start.character + 1),
-            text: Some(self.name.clone()),
+            text: Some(text),
             nr: None,
             typ: None,
         })
@@ -1174,12 +1175,14 @@ impl ListItem for SymbolInformation {
         let filename = self.location.uri.filepath()?;
         let relpath = diff_paths(&filename, Path::new(cwd)).unwrap_or(filename);
         let start = self.location.range.start;
+        let container_name = self.container_name.clone().unwrap_or_default();
+        let text = [self.name.clone(), container_name].join("::");
         Ok(format!(
             "{}:{}:{}:\t{}\t\t{:?}",
             relpath.to_string_lossy(),
             start.line + 1,
             start.character + 1,
-            self.name,
+            text,
             self.kind
         ))
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1160,7 +1160,7 @@ impl ListItem for SymbolInformation {
     fn quickfix_item(&self, _: &LanguageClient) -> Result<QuickfixEntry> {
         let start = self.location.range.start;
         let container_name = self.container_name.clone().unwrap_or_default();
-        let text = [self.name.clone(), container_name].join("::");
+        let text = [container_name, self.name.clone()].join("::");
         Ok(QuickfixEntry {
             filename: self.location.uri.filepath()?.to_string_lossy().into_owned(),
             lnum: start.line + 1,
@@ -1176,7 +1176,7 @@ impl ListItem for SymbolInformation {
         let relpath = diff_paths(&filename, Path::new(cwd)).unwrap_or(filename);
         let start = self.location.range.start;
         let container_name = self.container_name.clone().unwrap_or_default();
-        let text = [self.name.clone(), container_name].join("::");
+        let text = [container_name, self.name.clone()].join("::");
         Ok(format!(
             "{}:{}:{}:\t{}\t\t{:?}",
             relpath.to_string_lossy(),


### PR DESCRIPTION
This is rather a proposal within demo than a pull request. It adds `containerName` into the text which is shown in a document symbols list. It improves user experience as one can see where a symbol from. In the screenshots you can see that a couple structures can have the same function just implementing one trait. The similar experience is writing Python. A couple of class can have `__init__` method so in symbols you can't see which class the selected constructor for.

I'm not sure about where to place `containerName` in a symbol list's item, so I'm open to suggestions. Currently I decided to add it as a prefix with `::` as a divisor. I didn't find a convinient way to make it as an option in settings.

Take a look at the screenshots.

![before](https://user-images.githubusercontent.com/2972483/133907291-1f39d360-e3eb-4502-8f7a-de929ad76fcf.png)
![after](https://user-images.githubusercontent.com/2972483/133907290-674a8d76-abdd-40fa-8a07-5aea112b3d4a.png)
