### PR TITLE
denite: fix IntEnum str representation for python3.11

### DIFF
--- a/rplugin/python3/denite/lsp/protocol.py
+++ b/rplugin/python3/denite/lsp/protocol.py
@@ -50,6 +50,6 @@ for e in SymbolKind:
     if e == SymbolKind.Unknown:
         s = ""
     else:
-        s = re.sub("([a-z])([A-Z])", r"\g<1> \g<2>", str(e).split(".", 1)[1])
+        s = re.sub("([a-z])([A-Z])", r"\g<1> \g<2>", e.name)
 
     SymbolKind._pprint_map[int(e)] = s


### PR DESCRIPTION
Python 3.11 has a breaking change that `IntEnum.__str__()` returns the int value instead of its name. This will make the following indexing fail on Python 3.11.

Ref: https://docs.python.org/3.11/library/enum.html#enum.IntEnum