### PR TITLE
Add two options to set preview window for hover

### DIFF
--- a/autoload/LanguageClient.vim
+++ b/autoload/LanguageClient.vim
@@ -559,8 +559,19 @@ function! s:OpenHoverPreview(bufname, lines, filetype, ...) abort
         " trigger refresh on plasticboy/vim-markdown
         call win_execute(pop_win_id, 'doautocmd InsertLeave')
     elseif display_approach ==# 'preview'
-        execute 'silent! noswapfile pedit!' a:bufname
+        let loc = s:GetVar('LanguageClient_PreviewWindowLoc', '')
+        let size = s:GetVar('LanguageClient_PreviewHeight', &previewheight)
+        let win_modifiers_from_loc = #{left: ["","vertical"], right: ["botright","vertical"], top:["",""], bottom: ["botright",""]}
+        if has_key(win_modifiers_from_loc, loc)
+            let win_modifiers = win_modifiers_from_loc[loc]
+            let [win_b, win_v] = win_modifiers
+        else
+            let win_b = ""
+            let win_v = ""
+        endif
+        execute 'silent! noswapfile' win_b win_v 'pedit!' a:bufname
         wincmd P
+        execute 'silent!' win_v "resize" size
     else
         call s:Echoerr('Unknown display approach: ' . display_approach)
     endif


### PR DESCRIPTION
add following options to set preview window for hover:
- g:LanguageClient_PreviewWindowLoc: the location of PreviewWindow, available is one of: “left”,"right","top","bottom". If setted to invalid value, put it in "top" like the default behavior of vim preview window.
- g:LanguageClient_PreviewHeight: the size of PreviewWindow, inspired from vim option "previewheight"