### PR TITLE
Zombie burying ritual

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -3746,8 +3746,6 @@ impl LanguageClient {
                     Err(e) => error!("Process wait failed: {}", e),
                 }
             }
-            client.child_process = None;
-            state.clients.insert(language_id.clone(), Arc::new(client));
             Ok(())
         })
             .map_err(|err| anyhow!(
@@ -3787,7 +3785,6 @@ impl LanguageClient {
                 restarts = 0;
             };
 
-            state.clients.remove(language_id);
             state.restarts.insert(language_id.clone(), restarts);
             Ok(())
         })?;

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2091,7 +2091,7 @@ impl LanguageClient {
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn text_document_publish_diagnostics(&self, params: &Value) -> Result<()> {
         let params = PublishDiagnosticsParams::deserialize(params)?;
         if !self.get_config(|c| c.diagnostics_enable)? {
@@ -3873,7 +3873,7 @@ impl LanguageClient {
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn workspace_did_change_watched_files(&self, params: &Value) -> Result<()> {
         let filename = self.vim()?.get_filename(params)?;
         let language_id = self.vim()?.get_language_id(&filename, params)?;

--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -792,7 +792,6 @@ impl LanguageClient {
         self.handle_cursor_moved(&Value::Null, true)?;
 
         self.update_state(|state| {
-            state.clients.remove(&Some(language_id.into()));
             state.last_cursor_line = 0;
             state.text_documents.retain(|f, _| !f.starts_with(&root));
             state.roots.remove(language_id);

--- a/src/rpcclient.rs
+++ b/src/rpcclient.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use std::{
     collections::HashMap,
     io::BufRead,
+    process::Child,
     sync::atomic::{AtomicU64, Ordering},
     thread,
     time::Duration,
@@ -32,7 +33,8 @@ pub struct RpcClient {
     writer_tx: Sender<RawMessage>,
     #[serde(skip_serializing)]
     reader_tx: Sender<(Id, Sender<jsonrpc_core::Output>)>,
-    pub process_id: Option<u32>,
+    #[serde(skip_serializing)] // FIXME
+    pub child_process: Option<Child>,
 }
 
 impl RpcClient {
@@ -41,7 +43,7 @@ impl RpcClient {
         language_id: LanguageId,
         reader: impl BufRead + Send + 'static,
         writer: impl Write + Send + 'static,
-        process_id: Option<u32>,
+        child_process: Option<Child>,
         sink: Sender<Call>,
         on_crash: impl Fn(&LanguageId) + Clone + Send + 'static,
     ) -> Result<Self> {
@@ -86,7 +88,7 @@ impl RpcClient {
         Ok(Self {
             language_id,
             id: AtomicU64::default(),
-            process_id,
+            child_process,
             reader_tx,
             writer_tx,
         })


### PR DESCRIPTION
I've noticed LanguageClient-neovim accumulates zombies on LSP-server restarts... :ghost: 

Classically, whenever that happens — it means the parent process doesn't respect its duty to at least read out the exit-code of children processes that die.

Here's a fix by means of keeping track of the spawned `Child` process instead of its `u32` PID. IIRC, it wasn't possible to construct a `Child` from bare PID for that `child.try_wait()` call. See code.
